### PR TITLE
[init] #9 무중단 배포 (블루/그린) 배포

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,11 +12,12 @@ pipeline {
         JAR_NAME = "HILINGUAL-SERVER-1.0-SNAPSHOT.jar"
     }
 
-   stage('Git Clone') {
-       steps {
-           checkout scm
-       }
-   }
+    stages {
+        stage('Git Clone') {
+            steps {
+                checkout scm
+            }
+        }
 
         stage('Build JAR') {
             steps {
@@ -40,8 +41,8 @@ pipeline {
 
                         ssh -o StrictHostKeyChecking=no $DEPLOY_SERVER "
                             cd $PROJECT_PATH &&
-                            docker compose down || true &&
-                            docker compose up --build -d
+                            chmod +x deploy.sh &&
+                            ./deploy.sh
                         "
                     '''
                 }

--- a/deploy.sh
+++ b/deploy.sh
@@ -27,7 +27,14 @@ for cnt in {1..10}; do
 done
 
 if [ $cnt -eq 10 ]; then
-    echo "[ERROR] 서버 실행 실패. 롤백하세요."
+    echo "[ERROR] 서버 실행 실패. 롤백을 시작합니다..."
+
+    docker compose stop spring-${AFTER_COLOR}
+    docker compose up -d spring-${BEFORE_COLOR}
+    echo "deployment_target=${BEFORE_COLOR}" > ./nginx/.env
+    docker compose up -d --force-recreate nginx
+
+    echo "[INFO] 롤백 완료. 이전 서버(${BEFORE_COLOR})로 복구됨."
     exit 1
 fi
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+EXIST_BLUE=$(docker ps | grep "hilingual-blue" | grep Up)
+
+if [ -z "$EXIST_BLUE" ]; then
+    docker compose up -d spring-blue
+    BEFORE_COLOR="green"
+    AFTER_COLOR="blue"
+    AFTER_PORT=8080
+else
+    docker compose up -d spring-green
+    BEFORE_COLOR="blue"
+    AFTER_COLOR="green"
+    AFTER_PORT=8081
+fi
+
+echo "[INFO] ${AFTER_COLOR} 서버 기동 완료, 헬스체크 중..."
+for cnt in {1..10}; do
+    UP=$(curl -s http://localhost:${AFTER_PORT}/actuator/health | grep UP)
+    if [ -z "$UP" ]; then
+        echo "[INFO] 응답 없음 (${cnt}/10), 재시도..."
+        sleep 5
+    else
+        echo "[INFO] 서버 응답 확인됨."
+        break
+    fi
+done
+
+if [ $cnt -eq 10 ]; then
+    echo "[ERROR] 서버 실행 실패. 롤백하세요."
+    exit 1
+fi
+
+echo "[INFO] Nginx 대상 변경: ${AFTER_COLOR}"
+echo "deployment_target=${AFTER_COLOR}" > ./nginx/.env
+
+echo "[INFO] Nginx 컨테이너 재시작 중..."
+docker compose up -d --force-recreate nginx
+
+echo "[INFO] 이전 서버 종료: $BEFORE_COLOR"
+docker compose stop spring-${BEFORE_COLOR}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,28 @@
 version: '3.8'
 
 services:
-  app:
+  spring-blue:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: hilingual-app
+    container_name: hilingual-blue
     ports:
       - "8080:8080"
     environment:
+      - SPRING_PROFILES_ACTIVE=blue
+      - DB_URL=${DB_URL}
+      - DB_ID=${DB_ID}
+      - DB_PW=${DB_PW}
+
+  spring-green:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: hilingual-green
+    ports:
+      - "8081:8080"
+    environment:
+      - SPRING_PROFILES_ACTIVE=green
       - DB_URL=${DB_URL}
       - DB_ID=${DB_ID}
       - DB_PW=${DB_PW}
@@ -20,5 +34,3 @@ services:
       - "80:80"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
-    depends_on:
-      - app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,3 +34,6 @@ services:
       - "80:80"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/.env:/etc/nginx/.env
+    environment:
+      - deployment_target

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,19 +1,35 @@
 events {}
 
 http {
-  upstream spring_app {
-    server app:8080;
+  upstream blue {
+      server localhost:8080;
+  }
+
+  upstream green {
+      server localhost:8081;
+  }
+
+  map $deployment_target $target_upstream {
+      default blue;
+      "blue" blue;
+      "green" green;
   }
 
   server {
     listen 80;
 
     location / {
-      proxy_pass http://spring_app;
+      proxy_pass http://$target_upstream;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /healthz {
+      proxy_pass http://$target_upstream/actuator/health;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
     }
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,7 @@ spring:
     username: ${DB_ID}
     password: ${DB_PW}
     driver-class-name: com.mysql.cj.jdbc.Driver
+
   jpa:
     hibernate:
       ddl-auto: update
@@ -12,3 +13,30 @@ spring:
         show_sql: true
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      show-details: always
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: blue
+server:
+  port: 8080
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: green
+server:
+  port: 8081


### PR DESCRIPTION
## Related issue 🛠
- closed #9 

## Work Description ✏️
무중단배포를 롤링배포방식으로 하려고 했는데, 그저께 발표하고나서 더 찾아보다가, 여러 이유로 그냥 블루/그린 배포로 변경하게 되었습니다

- 기존 단일 컨테이너 배포 → 블루/그린 두 개의 Spring 서버 컨테이너로 변경  
- Nginx 설정 변경: `deployment_target` 환경변수에 따라 블루 또는 그린으로 트래픽 라우팅
- `deploy.sh` 스크립트 구현  
  - 현재 실행 중인 컨테이너 확인 후 다른 컨테이너 기동  
  - `/actuator/health` 엔드포인트를 통해 헬스체크 수행  
  - 헬스체크 성공 시 `nginx/.env` 파일을 갱신하고 nginx를 재시작하여 트래픽 전환  
  - 실패 시 롤백(기존 서버 유지) 처리
- Jenkins 파이프라인은 기존처럼 `.jar` 빌드 후 서버에 배포되며, 서버 측에서 `deploy.sh` 실행

## To Reviewers 📢
- .env는 scp로 바로 EC2 내부 디렉토리에 넣어놨습니다!
