### PR TITLE
[feat] #11 공통 응답 형식 및 예외 핸들링 setting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 
     // lombok
     compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
     // Spring Actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/src/main/java/org/hilingual/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/hilingual/advice/GlobalExceptionHandler.java
@@ -1,0 +1,58 @@
+package org.hilingual.advice;
+
+import org.hilingual.common.dto.BaseResponseDto;
+import org.hilingual.common.exception.code.ErrorCode;
+import org.hilingual.common.exception.code.GlobalErrorCode;
+import org.hilingual.domain.diary.api.exception.DiaryBaseException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(DiaryBaseException.class)
+    public ResponseEntity<BaseResponseDto<Void>> handleAuthBaseException(DiaryBaseException e) {
+        return ResponseEntity
+                .status(e.getStatus())
+                .body(BaseResponseDto.fail(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<BaseResponseDto<Map<String, String>>> handleValidationException(MethodArgumentNotValidException e) {
+        Map<String, String> errors = new HashMap<>();
+        e.getBindingResult().getFieldErrors().forEach(err ->
+                errors.put(err.getField(), err.getDefaultMessage())
+        );
+
+        return ResponseEntity
+                .status(GlobalErrorCode.INVALID_INPUT_VALUE.getHttpStatus())
+                .body(BaseResponseDto.fail(GlobalErrorCode.INVALID_INPUT_VALUE));
+    }
+
+    // 존재하지 않는 요청에 대한 예외
+    @ExceptionHandler(value = {NoHandlerFoundException.class, HttpRequestMethodNotSupportedException.class})
+    public ResponseEntity<BaseResponseDto<Void>> handleNoPageFoundException(Exception e) {
+        ErrorCode errorCode = e instanceof HttpRequestMethodNotSupportedException
+                ? GlobalErrorCode.METHOD_NOT_ALLOWED
+                : GlobalErrorCode.NOT_FOUND_END_POINT;
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(BaseResponseDto.fail(errorCode));
+    }
+
+    // 기본 예외
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<BaseResponseDto<Void>> handleException(Exception e) {
+        return ResponseEntity
+                .status(GlobalErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(BaseResponseDto.fail(GlobalErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/src/main/java/org/hilingual/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/hilingual/advice/GlobalExceptionHandler.java
@@ -18,7 +18,7 @@ import java.util.Map;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(DiaryBaseException.class)
-    public ResponseEntity<BaseResponseDto<Void>> handleAuthBaseException(DiaryBaseException e) {
+    public ResponseEntity<BaseResponseDto<Void>> handleDiaryBaseException(DiaryBaseException e) {
         return ResponseEntity
                 .status(e.getStatus())
                 .body(BaseResponseDto.fail(e.getErrorCode()));

--- a/src/main/java/org/hilingual/advice/ResponseDtoAdvice.java
+++ b/src/main/java/org/hilingual/advice/ResponseDtoAdvice.java
@@ -1,0 +1,50 @@
+package org.hilingual.advice;
+
+import lombok.NonNull;
+import org.hilingual.common.exception.code.ErrorCode;
+import org.hilingual.common.dto.BaseResponseDto;
+import org.hilingual.common.exception.code.GlobalSuccessCode;
+import org.hilingual.common.exception.code.SuccessCode;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice(
+        basePackages = "org.hilingual"
+)
+public class ResponseDtoAdvice implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return !(returnType.getParameterType() == BaseResponseDto.class)
+                && MappingJackson2HttpMessageConverter.class.isAssignableFrom(converterType);
+    }
+
+    @Override
+    public Object beforeBodyWrite(
+            Object body,
+            @NonNull MethodParameter returnType,
+            @NonNull MediaType selectedContentType,
+            @NonNull Class selectedConverterType,
+            @NonNull ServerHttpRequest request,
+            @NonNull ServerHttpResponse response
+    ) {
+        if (body instanceof BaseResponseDto) {
+            return body;
+        }
+
+        if (body instanceof ErrorCode errorCode) {
+            return BaseResponseDto.fail(errorCode);
+        }
+
+        if (body instanceof SuccessCode successCode) {
+            return BaseResponseDto.success(successCode);
+        }
+        return BaseResponseDto.success(GlobalSuccessCode.OK, body);
+    }
+}

--- a/src/main/java/org/hilingual/common/dto/BaseResponseDto.java
+++ b/src/main/java/org/hilingual/common/dto/BaseResponseDto.java
@@ -1,0 +1,22 @@
+package org.hilingual.common.dto;
+
+import org.hilingual.common.exception.code.ErrorCode;
+import org.hilingual.common.exception.code.SuccessCode;
+
+public record BaseResponseDto<T>(
+        int code,
+        T data,
+        String message
+) {
+    public static <T> BaseResponseDto<T> success(SuccessCode code, T data) {
+        return new BaseResponseDto<>(code.getCode(), data, code.getMessage());
+    }
+
+    public static <T> BaseResponseDto<T> success(SuccessCode code) {
+        return new BaseResponseDto<>(code.getCode(), null, code.getMessage());
+    }
+
+    public static <T> BaseResponseDto<T> fail(ErrorCode code) {
+        return new BaseResponseDto<>(code.getCode(), null, code.getMessage());
+    }
+}

--- a/src/main/java/org/hilingual/common/exception/base/HilingualBaseException.java
+++ b/src/main/java/org/hilingual/common/exception/base/HilingualBaseException.java
@@ -1,4 +1,4 @@
-package org.hilingual.common.exception;
+package org.hilingual.common.exception.base;
 
 public class HilingualBaseException extends RuntimeException {
 

--- a/src/main/java/org/hilingual/common/exception/code/ApiCode.java
+++ b/src/main/java/org/hilingual/common/exception/code/ApiCode.java
@@ -1,4 +1,4 @@
-package org.hilingual.common.code;
+package org.hilingual.common.exception.code;
 
 import org.springframework.http.HttpStatus;
 

--- a/src/main/java/org/hilingual/common/exception/code/ErrorCode.java
+++ b/src/main/java/org/hilingual/common/exception/code/ErrorCode.java
@@ -1,4 +1,4 @@
-package org.hilingual.common.code;
+package org.hilingual.common.exception.code;
 
 public interface ErrorCode extends ApiCode {
 }

--- a/src/main/java/org/hilingual/common/exception/code/GlobalErrorCode.java
+++ b/src/main/java/org/hilingual/common/exception/code/GlobalErrorCode.java
@@ -1,4 +1,4 @@
-package org.hilingual.common.code;
+package org.hilingual.common.exception.code;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -6,10 +6,13 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum GlobalErrorCode implements ErrorCode {
     // 400
-    INVALID_ARGUMENTS(HttpStatus.BAD_REQUEST, 40000, "인자의 형식이 올바르지 않습니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, 40000, "잘못된 요청 값입니다."),
 
     // 401
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 40100, "인증되지 않은 사용자입니다."),
+
+    // 404
+    NOT_FOUND_END_POINT(HttpStatus.NOT_FOUND, 40400, "요청한 API 엔드포인트가 존재하지 않습니다."),
 
     // 405
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, 40500, "지원하지 않는 HTTP 메서드입니다."),

--- a/src/main/java/org/hilingual/common/exception/code/GlobalSuccessCode.java
+++ b/src/main/java/org/hilingual/common/exception/code/GlobalSuccessCode.java
@@ -1,0 +1,31 @@
+package org.hilingual.common.exception.code;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum GlobalSuccessCode implements SuccessCode{
+    OK(HttpStatus.OK, 20000, "성공했습니다."),
+    OK_CUSTOM(HttpStatus.OK, 20100, "이건 default 아니지렁"),
+
+    ;
+
+    public final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus(){
+        return httpStatus;
+    }
+
+    @Override
+    public int getCode(){
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/org/hilingual/common/exception/code/SuccessCode.java
+++ b/src/main/java/org/hilingual/common/exception/code/SuccessCode.java
@@ -1,4 +1,4 @@
-package org.hilingual.common.code;
+package org.hilingual.common.exception.code;
 
 public interface SuccessCode extends ApiCode {
 }

--- a/src/main/java/org/hilingual/domain/diary/api/exception/DiaryApiErrorCode.java
+++ b/src/main/java/org/hilingual/domain/diary/api/exception/DiaryApiErrorCode.java
@@ -1,7 +1,7 @@
 package org.hilingual.domain.diary.api.exception;
 
 import lombok.RequiredArgsConstructor;
-import org.hilingual.common.code.ErrorCode;
+import org.hilingual.common.exception.code.ErrorCode;
 import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor

--- a/src/main/java/org/hilingual/domain/diary/api/exception/DiaryApiException.java
+++ b/src/main/java/org/hilingual/domain/diary/api/exception/DiaryApiException.java
@@ -1,6 +1,6 @@
 package org.hilingual.domain.diary.api.exception;
 
-import org.hilingual.common.code.ErrorCode;
+import org.hilingual.common.exception.code.ErrorCode;
 
 public abstract class DiaryApiException extends DiaryBaseException{
 

--- a/src/main/java/org/hilingual/domain/diary/api/exception/DiaryBaseException.java
+++ b/src/main/java/org/hilingual/domain/diary/api/exception/DiaryBaseException.java
@@ -3,8 +3,8 @@ package org.hilingual.domain.diary.api.exception;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.hilingual.common.code.ErrorCode;
-import org.hilingual.common.exception.HilingualBaseException;
+import org.hilingual.common.exception.code.ErrorCode;
+import org.hilingual.common.exception.base.HilingualBaseException;
 import org.springframework.http.HttpStatus;
 
 @Getter

--- a/src/main/java/org/hilingual/domain/diary/core/exception/DiaryCoreErrorCode.java
+++ b/src/main/java/org/hilingual/domain/diary/core/exception/DiaryCoreErrorCode.java
@@ -1,7 +1,7 @@
 package org.hilingual.domain.diary.core.exception;
 
 import lombok.RequiredArgsConstructor;
-import org.hilingual.common.code.ErrorCode;
+import org.hilingual.common.exception.code.ErrorCode;
 import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor

--- a/src/main/java/org/hilingual/domain/diary/core/exception/DiaryCoreException.java
+++ b/src/main/java/org/hilingual/domain/diary/core/exception/DiaryCoreException.java
@@ -1,6 +1,6 @@
 package org.hilingual.domain.diary.core.exception;
 
-import org.hilingual.common.code.ErrorCode;
+import org.hilingual.common.exception.code.ErrorCode;
 import org.hilingual.domain.diary.api.exception.DiaryBaseException;
 
 public abstract class DiaryCoreException extends DiaryBaseException {

--- a/src/main/java/org/hilingual/domain/diaryfeedback/DiaryFeedback.java
+++ b/src/main/java/org/hilingual/domain/diaryfeedback/DiaryFeedback.java
@@ -34,4 +34,7 @@ public class DiaryFeedback extends BaseTimeEntity {
 
     @Column(name = COLUMN_EXPLANATION, nullable = false)
     private String explanation;
+
+    @Column(name = COLUMN_VERSION, nullable = false)
+    private Integer version = 1;
 }

--- a/src/main/java/org/hilingual/domain/diaryfeedback/DiaryFeedbackTableConstants.java
+++ b/src/main/java/org/hilingual/domain/diaryfeedback/DiaryFeedbackTableConstants.java
@@ -7,4 +7,5 @@ public class DiaryFeedbackTableConstants {
     public static final String COLUMN_ORIGIN_PHRASE = "origin_phrase";
     public static final String COLUMN_REWRITE_PHRASE = "rewrite_phrase";
     public static final String COLUMN_EXPLANATION = "explanation";
+    public static final String COLUMN_VERSION = "version";
 }

--- a/src/main/java/org/hilingual/test/SuccessTestResponse.java
+++ b/src/main/java/org/hilingual/test/SuccessTestResponse.java
@@ -1,0 +1,12 @@
+package org.hilingual.test;
+
+import lombok.Builder;
+
+@Builder
+public record SuccessTestResponse(
+        long diaryId,
+        String title,
+        String writer,
+        String content
+) {
+}

--- a/src/main/java/org/hilingual/test/TestController.java
+++ b/src/main/java/org/hilingual/test/TestController.java
@@ -1,0 +1,53 @@
+package org.hilingual.test;
+
+import org.hilingual.common.dto.BaseResponseDto;
+import org.hilingual.common.exception.code.GlobalErrorCode;
+import org.hilingual.common.exception.code.GlobalSuccessCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RequestMapping("/api/v1/test")
+@RestController
+public class TestController {
+
+    @GetMapping("/success-with-data")
+    public ResponseEntity<BaseResponseDto<Map<String, Object>>> successWithData() {
+        Map<String, Object> data = Map.of("diaryId", 123);
+        return ResponseEntity
+                .ok(BaseResponseDto.success(GlobalSuccessCode.OK, data));
+    }
+
+    @GetMapping("/success-no-data")
+    public ResponseEntity<BaseResponseDto<Void>> successNoData() {
+        return ResponseEntity
+                .ok(BaseResponseDto.success(GlobalSuccessCode.OK));
+    }
+
+    @GetMapping("/ok-default")
+    public ResponseEntity<BaseResponseDto<SuccessTestResponse>> successDefault() {
+        SuccessTestResponse response = SuccessTestResponse.builder()
+                .diaryId(123L)
+                .title("오늘의 일기")
+                .writer("하륑구")
+                .content("정말 신나는 하루였다!")
+                .build();
+        return ResponseEntity.ok(BaseResponseDto.success(GlobalSuccessCode.OK_CUSTOM, response));
+    }
+
+    @GetMapping("/fail")
+    public ResponseEntity<BaseResponseDto<Void>> failResponse() {
+        return ResponseEntity
+                .status(GlobalErrorCode.INVALID_INPUT_VALUE.getHttpStatus())
+                .body(BaseResponseDto.fail(GlobalErrorCode.INVALID_INPUT_VALUE));
+    }
+
+    @GetMapping("/exception")
+    public ResponseEntity<BaseResponseDto<Void>> exception() {
+        throw new RuntimeException("강제로 발생시킨 예외");
+    }
+
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #11 

## Work Description ✏️
## 🔵 공통 응답 형식

클라 선생님들과 논의한 응답 형식 예시들은 다음과 같습니다.

- 모든 응답에서 code, data, message 필드는 항상 포함
- data가 없는 경우에는 null로 내려주되, **nullable**로 명시
- data 내에 List 타입 필드가 있을 경우, **빈 리스트**는 빈 리스트로 반환(null X)

### ✅ 성공응답 예시

- data 가 있는 경우

```json
{
  "code": 20000
  "data": {
    "diaryId": 123
  },
  "message": "AI 피드백이 성공적으로 저장되었습니다."
}
```

- data 가 없는 경우

```json
{
  "code": 20000
  "data": null
  "message": "AI 피드백이 성공적으로 저장되었습니다."
}
```

### ✅ 실패 응답 예시

```json
{
	"code": 400,
	"data": null,
	"message": "유효하지 않은 헤더입니다."
}
```

## 🔵 구현

### `BaseResponseDto.java`

- 모든 API 응답의 틀을 잡아주는 Response Wrapper 클래스입니다.
- code, data, message 필드를 항상 동일한 구조로 내려줍니다.

```java
public record BaseResponseDto<T>(
        int code,
        T data,
        String message
) {
    public static <T> BaseResponseDto<T> success(SuccessCode code, T data) {
        return new BaseResponseDto<>(code.getCode(), data, code.getMessage());
    }

    public static <T> BaseResponseDto<T> success(SuccessCode code) {
        return new BaseResponseDto<>(code.getCode(), null, code.getMessage());
    }

    public static <T> BaseResponseDto<T> fail(ErrorCode code) {
        return new BaseResponseDto<>(code.getCode(), null, code.getMessage());
    }
}
```

### `ResponseDtoAdvice.java`

- 모든 컨트롤러 응답을 자동으로 BaseResponseDto로 감싸줍니다.
- 응답 포맷을 자동으로 통일함으로써, 실수로 응답 포맷을 어기더라도 안전

```java
@RestControllerAdvice(
        basePackages = "org.hilingual"
)
public class ResponseDtoAdvice implements ResponseBodyAdvice<Object> {

    @Override
    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
        return !(returnType.getParameterType() == BaseResponseDto.class)
                && MappingJackson2HttpMessageConverter.class.isAssignableFrom(converterType);
    }

    @Override
    public Object beforeBodyWrite(
            Object body,
            @NonNull MethodParameter returnType,
            @NonNull MediaType selectedContentType,
            @NonNull Class selectedConverterType,
            @NonNull ServerHttpRequest request,
            @NonNull ServerHttpResponse response
    ) {
        // 이미 감싸진 경우 -> 그대로 반환
        if (body instanceof BaseResponseDto) {
            return body;
        }

        // 실패 응답
        if (body instanceof ErrorCode errorCode) {
            return BaseResponseDto.fail(errorCode);
        }

        // 성공 응답
        if (body instanceof SuccessCode successCode) {
            return BaseResponseDto.success(successCode);
        }

        // 성공 응답 default로 OK 상태코드 (data가 있는 경우)
        // TestController 보시면, 다른 상태코드 지정하면 그걸로 들어가는거 확인 가능하십니당
        return BaseResponseDto.success(GlobalSuccessCode.OK, body);
    }
}
```
---

## 🔵 예외 핸들링 처리

### ✅ 패키지 구조 수정

서비스 내에서 전역으로 사용되는 ErrorCode/SuccessCode들은 common-exception-code 내에 위치시켰습니다.

각 도메인별로 필요한  ErrorCode/SuccessCode 들은  아래 경로에 있는 인터페이스를 상속받아 구현하시면 됩니다.

![image](https://github.com/user-attachments/assets/89bd7286-5af4-4735-857c-e97aa422c00d)

### ✅ GlobalExceptionHandler

- 발생할 수 있는 기본 예외들은 미리 정의해두었습니다.
- DiaryBaseException 처리 구조 예시를 넣어두었으니, 각 도메인의 BaseException을 구현하실 때 참고 부탁드립니다!


## Screenshot 📸
| 설명 | 사진 |
|:-------------------------------:|:--------------------------------------------------------------------:|
| 성공 (data 있는 경우) | ![image](https://github.com/user-attachments/assets/9bf34fe6-4661-4408-b248-c21bc9f59979) |
| 성공 (data 없는 경우) | ![image](https://github.com/user-attachments/assets/fac9cff1-1a3e-4741-9685-25b1395bf5e6) |
| Default 성공 (data 있는 경우, default로 OK 성공코드) | ![image](https://github.com/user-attachments/assets/60c20a42-53ad-47f2-83a3-96558d4a54b2) |
| 실패 응답 | ![image](https://github.com/user-attachments/assets/3ab28269-b38e-44ec-992e-914c56773e2a) |
| 예외 테스트 (GlobalExceptionHandler 동작 확인용) | ![image](https://github.com/user-attachments/assets/8ad17107-3652-4536-bd46-3bce5eacfb55) |

## Uncompleted Tasks 😅
```
       ErrorCode errorCode = e instanceof HttpRequestMethodNotSupportedException
                ? GlobalErrorCode.METHOD_NOT_ALLOWED
                : GlobalErrorCode.NOT_FOUND_END_POINT;
```
GlobalExceptionHandler에서 NOT_FOUND_END_POINT이건가..? 여튼 뭐 작동 하나 제대로 안되는 것 같아요.. 나중에 수정하겠습니다..ㅠㅠ (할사람?ㅎㅎ)

## To Reviewers 📢
이제 이거 머지하면 본격 개발 하면 된다핑!!
