### PR TITLE
[feat] #16 닉네임 검사 API 구현

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.32/17d46b3e205515e1e8efd3ee4d57ce8018914163/lombok-1.18.32.jar" />
+        </processorPath>
+        <module name="HILINGUAL-SERVER.main" />
+      </profile>
+    </annotationProcessing>
     <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/src/main/java/org/hilingual/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/hilingual/advice/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.hilingual.domain.diary.api.exception.DiaryBaseException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
@@ -46,6 +47,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(BaseResponseDto.fail(errorCode));
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<BaseResponseDto<Void>> handleMissingParam(MissingServletRequestParameterException e) {
+        return ResponseEntity
+                .status(GlobalErrorCode.NOT_FOUND_END_POINT.getHttpStatus())
+                .body(BaseResponseDto.fail(GlobalErrorCode.NOT_FOUND_END_POINT));
     }
 
     // 기본 예외

--- a/src/main/java/org/hilingual/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/hilingual/advice/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.hilingual.common.dto.BaseResponseDto;
 import org.hilingual.common.exception.code.ErrorCode;
 import org.hilingual.common.exception.code.GlobalErrorCode;
 import org.hilingual.domain.diary.api.exception.DiaryBaseException;
+import org.hilingual.external.s3.exception.S3BaseException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;

--- a/src/main/java/org/hilingual/domain/diary/core/domain/Diary.java
+++ b/src/main/java/org/hilingual/domain/diary/core/domain/Diary.java
@@ -8,9 +8,8 @@ import lombok.NoArgsConstructor;
 import org.hilingual.common.domain.BaseTimeEntity;
 import org.hilingual.domain.diaryfeedback.DiaryFeedback;
 import org.hilingual.domain.recommend.Recommend;
-import org.hilingual.domain.user.User;
+import org.hilingual.domain.user.core.domain.User;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.hilingual.domain.diary.core.domain.DiaryTableConstants.*;

--- a/src/main/java/org/hilingual/domain/token/Token.java
+++ b/src/main/java/org/hilingual/domain/token/Token.java
@@ -1,7 +1,7 @@
 package org.hilingual.domain.token;
 
 import jakarta.persistence.*;
-import org.hilingual.domain.user.User;
+import org.hilingual.domain.user.core.domain.User;
 
 @Entity
 public class Token {

--- a/src/main/java/org/hilingual/domain/user/api/controller/UserController.java
+++ b/src/main/java/org/hilingual/domain/user/api/controller/UserController.java
@@ -1,0 +1,22 @@
+package org.hilingual.domain.user.api.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.hilingual.common.dto.BaseResponseDto;
+import org.hilingual.domain.user.api.dto.res.NicknameAvailableResponse;
+import org.hilingual.domain.user.api.service.UserService;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/v1/users/profile")
+    public BaseResponseDto<NicknameAvailableResponse> getUserProfile(
+            @RequestParam(value = "nickname") String nickname
+    ) {
+        return userService.getNicknameAvailable(nickname);
+    }
+}

--- a/src/main/java/org/hilingual/domain/user/api/dto/res/NicknameAvailableResponse.java
+++ b/src/main/java/org/hilingual/domain/user/api/dto/res/NicknameAvailableResponse.java
@@ -1,0 +1,9 @@
+package org.hilingual.domain.user.api.dto.res;
+
+public record NicknameAvailableResponse(
+        Boolean isAvailable
+) {
+    public static NicknameAvailableResponse from(Boolean availability) {
+        return new NicknameAvailableResponse(availability);
+    }
+}

--- a/src/main/java/org/hilingual/domain/user/api/exception/UserApiErrorCode.java
+++ b/src/main/java/org/hilingual/domain/user/api/exception/UserApiErrorCode.java
@@ -1,0 +1,29 @@
+package org.hilingual.domain.user.api.exception;
+
+import lombok.RequiredArgsConstructor;
+import org.hilingual.common.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum UserApiErrorCode implements ErrorCode {
+    ;
+
+    public final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus(){
+        return httpStatus;
+    }
+
+    @Override
+    public int getCode(){
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/org/hilingual/domain/user/api/exception/UserApiException.java
+++ b/src/main/java/org/hilingual/domain/user/api/exception/UserApiException.java
@@ -1,0 +1,11 @@
+package org.hilingual.domain.user.api.exception;
+
+import org.hilingual.common.exception.code.ErrorCode;
+import org.hilingual.domain.diary.api.exception.DiaryBaseException;
+
+public abstract class UserApiException extends UserBaseException {
+
+    protected UserApiException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/hilingual/domain/user/api/exception/UserBaseException.java
+++ b/src/main/java/org/hilingual/domain/user/api/exception/UserBaseException.java
@@ -1,0 +1,15 @@
+package org.hilingual.domain.user.api.exception;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.hilingual.common.exception.base.HilingualBaseException;
+import org.hilingual.common.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class UserBaseException extends HilingualBaseException {
+    private final ErrorCode errorCode;
+    public abstract HttpStatus getStatus();
+}

--- a/src/main/java/org/hilingual/domain/user/api/exception/UserSuccessCode.java
+++ b/src/main/java/org/hilingual/domain/user/api/exception/UserSuccessCode.java
@@ -1,0 +1,32 @@
+package org.hilingual.domain.user.api.exception;
+
+import lombok.RequiredArgsConstructor;
+import org.hilingual.common.exception.code.SuccessCode;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum UserSuccessCode implements SuccessCode {
+    NICKNAME_AVAILABLE(HttpStatus.OK, 20000, "사용 가능한 닉네임입니다."),
+    NICKNAME_DUPLICATED(HttpStatus.OK, 20001, "중복된 닉네임입니다."),
+    NICKNAME_SPECIAL_SYMBOLS(HttpStatus.OK, 20002, "특수문자, 이모지가 포함된 닉네임입니다."),
+    NICKNAME_COUNT(HttpStatus.OK, 20003, "2자 미만이거나 10자 초과된 닉네임입니다.");
+
+    public final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public int getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/org/hilingual/domain/user/api/service/UserService.java
+++ b/src/main/java/org/hilingual/domain/user/api/service/UserService.java
@@ -1,0 +1,53 @@
+package org.hilingual.domain.user.api.service;
+
+import lombok.RequiredArgsConstructor;
+import org.hilingual.common.dto.BaseResponseDto;
+import org.hilingual.domain.user.api.dto.res.NicknameAvailableResponse;
+import org.hilingual.domain.user.api.exception.UserSuccessCode;
+import org.hilingual.domain.user.core.facade.UserRetriever;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRetriever userRetriever;
+
+    public BaseResponseDto<NicknameAvailableResponse> getNicknameAvailable(String nickname) {
+        // 글자 수 검사
+        if (nickname.length() < 2 || nickname.length() > 10) {
+            return BaseResponseDto.success(
+                    UserSuccessCode.NICKNAME_COUNT,
+                    new NicknameAvailableResponse(false)
+            );
+        }
+
+        // 특수문자/이모지 검사
+        if (!isPlainKoreanOrEnglish(nickname)) {
+            return BaseResponseDto.success(
+                    UserSuccessCode.NICKNAME_SPECIAL_SYMBOLS,
+                    new NicknameAvailableResponse(false)
+            );
+        }
+
+        // 중복 검사
+        if (userRetriever.isNicknameExists(nickname)) {
+            return BaseResponseDto.success(
+                    UserSuccessCode.NICKNAME_DUPLICATED,
+                    new NicknameAvailableResponse(false)
+            );
+        }
+
+        // 사용 가능
+        return BaseResponseDto.success(
+                UserSuccessCode.NICKNAME_AVAILABLE,
+                new NicknameAvailableResponse(true)
+        );
+    }
+
+    private boolean isPlainKoreanOrEnglish(String nickname) {
+        return nickname.matches("^[가-힣a-zA-Z0-9]*$");
+    }
+}

--- a/src/main/java/org/hilingual/domain/user/api/service/UserService.java
+++ b/src/main/java/org/hilingual/domain/user/api/service/UserService.java
@@ -2,6 +2,7 @@ package org.hilingual.domain.user.api.service;
 
 import lombok.RequiredArgsConstructor;
 import org.hilingual.common.dto.BaseResponseDto;
+import org.hilingual.common.exception.code.SuccessCode;
 import org.hilingual.domain.user.api.dto.res.NicknameAvailableResponse;
 import org.hilingual.domain.user.api.exception.UserSuccessCode;
 import org.hilingual.domain.user.core.facade.UserRetriever;
@@ -16,38 +17,17 @@ public class UserService {
     private final UserRetriever userRetriever;
 
     public BaseResponseDto<NicknameAvailableResponse> getNicknameAvailable(String nickname) {
-        // 글자 수 검사
-        if (nickname.length() < 2 || nickname.length() > 10) {
-            return BaseResponseDto.success(
-                    UserSuccessCode.NICKNAME_COUNT,
-                    new NicknameAvailableResponse(false)
-            );
-        }
-
-        // 특수문자/이모지 검사
-        if (!isPlainKoreanOrEnglish(nickname)) {
-            return BaseResponseDto.success(
-                    UserSuccessCode.NICKNAME_SPECIAL_SYMBOLS,
-                    new NicknameAvailableResponse(false)
-            );
-        }
-
-        // 중복 검사
-        if (userRetriever.isNicknameExists(nickname)) {
-            return BaseResponseDto.success(
-                    UserSuccessCode.NICKNAME_DUPLICATED,
-                    new NicknameAvailableResponse(false)
-            );
-        }
-
-        // 사용 가능
-        return BaseResponseDto.success(
-                UserSuccessCode.NICKNAME_AVAILABLE,
-                new NicknameAvailableResponse(true)
-        );
+        if (nickname.length() < 2 || nickname.length() > 10) return unavailableNickname(UserSuccessCode.NICKNAME_COUNT);
+        if (!nickname.matches("^[ㄱ-ㅎ가-힣a-zA-Z0-9]+$")) return unavailableNickname(UserSuccessCode.NICKNAME_SPECIAL_SYMBOLS);
+        if (userRetriever.isNicknameExists(nickname)) return unavailableNickname(UserSuccessCode.NICKNAME_DUPLICATED);
+        return availableNickname();
     }
 
-    private boolean isPlainKoreanOrEnglish(String nickname) {
-        return nickname.matches("^[가-힣a-zA-Z0-9]*$");
+    private BaseResponseDto<NicknameAvailableResponse> availableNickname() {
+        return BaseResponseDto.success(UserSuccessCode.NICKNAME_AVAILABLE, new NicknameAvailableResponse(true));
+    }
+
+    private BaseResponseDto<NicknameAvailableResponse> unavailableNickname(SuccessCode code) {
+        return BaseResponseDto.success(code, new NicknameAvailableResponse(false));
     }
 }

--- a/src/main/java/org/hilingual/domain/user/api/service/UserService.java
+++ b/src/main/java/org/hilingual/domain/user/api/service/UserService.java
@@ -16,8 +16,8 @@ public class UserService {
     private final UserRetriever userRetriever;
 
     public BaseResponseDto<NicknameAvailableResponse> getNicknameAvailable(String nickname) {
-        if (nickname.length() < 2 || nickname.length() > 10) return unavailableNickname(UserSuccessCode.NICKNAME_COUNT);
         if (!nickname.matches("^[ㄱ-ㅎ가-힣a-zA-Z0-9]+$")) return unavailableNickname(UserSuccessCode.NICKNAME_SPECIAL_SYMBOLS);
+        if (nickname.length() < 2 || nickname.length() > 10) return unavailableNickname(UserSuccessCode.NICKNAME_COUNT);
         if (userRetriever.isNicknameExists(nickname)) return unavailableNickname(UserSuccessCode.NICKNAME_DUPLICATED);
         return availableNickname();
     }

--- a/src/main/java/org/hilingual/domain/user/api/service/UserService.java
+++ b/src/main/java/org/hilingual/domain/user/api/service/UserService.java
@@ -2,7 +2,6 @@ package org.hilingual.domain.user.api.service;
 
 import lombok.RequiredArgsConstructor;
 import org.hilingual.common.dto.BaseResponseDto;
-import org.hilingual.common.exception.code.SuccessCode;
 import org.hilingual.domain.user.api.dto.res.NicknameAvailableResponse;
 import org.hilingual.domain.user.api.exception.UserSuccessCode;
 import org.hilingual.domain.user.core.facade.UserRetriever;
@@ -27,7 +26,7 @@ public class UserService {
         return BaseResponseDto.success(UserSuccessCode.NICKNAME_AVAILABLE, new NicknameAvailableResponse(true));
     }
 
-    private BaseResponseDto<NicknameAvailableResponse> unavailableNickname(SuccessCode code) {
+    private BaseResponseDto<NicknameAvailableResponse> unavailableNickname(UserSuccessCode code) {
         return BaseResponseDto.success(code, new NicknameAvailableResponse(false));
     }
 }

--- a/src/main/java/org/hilingual/domain/user/core/domain/User.java
+++ b/src/main/java/org/hilingual/domain/user/core/domain/User.java
@@ -1,4 +1,4 @@
-package org.hilingual.domain.user;
+package org.hilingual.domain.user.core.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -15,7 +15,7 @@ import org.hilingual.domain.voca.Voca;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.hilingual.domain.user.UserTableConstants.*;
+import static org.hilingual.domain.user.core.domain.UserTableConstants.*;
 
 @Entity
 @Table(

--- a/src/main/java/org/hilingual/domain/user/core/domain/UserTableConstants.java
+++ b/src/main/java/org/hilingual/domain/user/core/domain/UserTableConstants.java
@@ -1,4 +1,4 @@
-package org.hilingual.domain.user;
+package org.hilingual.domain.user.core.domain;
 
 public class UserTableConstants {
     public static final String TABLE_USER = "users";

--- a/src/main/java/org/hilingual/domain/user/core/exception/UserCoreErrorCode.java
+++ b/src/main/java/org/hilingual/domain/user/core/exception/UserCoreErrorCode.java
@@ -1,0 +1,29 @@
+package org.hilingual.domain.user.core.exception;
+
+import lombok.RequiredArgsConstructor;
+import org.hilingual.common.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum UserCoreErrorCode implements ErrorCode {
+    ;
+
+    public final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus(){
+        return httpStatus;
+    }
+
+    @Override
+    public int getCode(){
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/org/hilingual/domain/user/core/exception/UserCoreException.java
+++ b/src/main/java/org/hilingual/domain/user/core/exception/UserCoreException.java
@@ -1,0 +1,10 @@
+package org.hilingual.domain.user.core.exception;
+
+import org.hilingual.common.exception.code.ErrorCode;
+import org.hilingual.domain.user.api.exception.UserBaseException;
+
+public abstract class UserCoreException extends UserBaseException {
+    protected UserCoreException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/hilingual/domain/user/core/facade/UserRetriever.java
+++ b/src/main/java/org/hilingual/domain/user/core/facade/UserRetriever.java
@@ -1,0 +1,15 @@
+package org.hilingual.domain.user.core.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.hilingual.domain.usesrprofile.core.repository.UserProfileRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserRetriever {
+    private final UserProfileRepository userProfileRepository;
+
+    public boolean isNicknameExists(String nickname) {
+        return userProfileRepository.existsByNickname(nickname);
+    }
+}

--- a/src/main/java/org/hilingual/domain/user/core/repository/UserRepository.java
+++ b/src/main/java/org/hilingual/domain/user/core/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package org.hilingual.domain.user.core.repository;
+
+import org.hilingual.domain.user.core.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/org/hilingual/domain/usercalendar/UserCalendar.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/UserCalendar.java
@@ -6,7 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hilingual.common.domain.BaseTimeEntity;
-import org.hilingual.domain.user.User;
+import org.hilingual.domain.user.core.domain.User;
 
 import java.time.LocalDate;
 

--- a/src/main/java/org/hilingual/domain/usesrprofile/UserProfile.java
+++ b/src/main/java/org/hilingual/domain/usesrprofile/UserProfile.java
@@ -6,7 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hilingual.common.domain.BaseTimeEntity;
-import org.hilingual.domain.user.User;
+import org.hilingual.domain.user.core.domain.User;
 
 import static org.hilingual.domain.usesrprofile.UserProfileTableConstants.*;
 

--- a/src/main/java/org/hilingual/domain/usesrprofile/core/repository/UserProfileRepository.java
+++ b/src/main/java/org/hilingual/domain/usesrprofile/core/repository/UserProfileRepository.java
@@ -1,0 +1,8 @@
+package org.hilingual.domain.usesrprofile.core.repository;
+
+import org.hilingual.domain.usesrprofile.UserProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserProfileRepository extends JpaRepository<UserProfile, Long> {
+    boolean existsByNickname(String nickname);
+}

--- a/src/main/java/org/hilingual/domain/voca/Voca.java
+++ b/src/main/java/org/hilingual/domain/voca/Voca.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hilingual.common.domain.BaseTimeEntity;
 import org.hilingual.domain.recommend.Recommend;
-import org.hilingual.domain.user.User;
+import org.hilingual.domain.user.core.domain.User;
 
 import static org.hilingual.domain.voca.VocaTableConstants.*;
 


### PR DESCRIPTION
## Related issue 🛠
- closed #16 

## Work Description ✏️
- 닉네임 사용가능 검사
  - 중복 확인
  - 특수문자/이모지 포함여부 확인
  - 글자수 확인
- 에러 핸들링
  - 400 
  - 404 (파라미터 누락 시)
  - 405 (잘못된 HTTP 메소드)
  - 500 (기타 에러)

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 닉네임 검사 API | <img width="365" alt="image" src="https://github.com/user-attachments/assets/34176313-1f74-4a49-8be3-033a1e733467" />|
| 특수문자 포함된 닉네임 | <img width="461" alt="image" src="https://github.com/user-attachments/assets/64b51a76-cd8e-478f-8d46-571fc26026cd" /> |
| 이모지 포함된 닉네임(글자수보다 우선검사) | <img width="389" alt="image" src="https://github.com/user-attachments/assets/21f1de18-dba8-4c00-a2ec-c6f475a4e383" /> |
| 2글자 미만 닉네임 | <img width="347" alt="image" src="https://github.com/user-attachments/assets/42e459c1-0e8b-490d-a653-8b65f1480983" /> |
| 10자 초과 닉네임 | <img width="410" alt="image" src="https://github.com/user-attachments/assets/2f469fef-701a-4e34-b7ce-6d53a8a847a4" /> |
| 중복된 닉네임 | <img width="377" alt="image" src="https://github.com/user-attachments/assets/ce56c9eb-c215-41f0-9d5e-d3ba9ba7b229" /> |
| 잘못된 HTTP 메소드(405) | <img width="375" alt="image" src="https://github.com/user-attachments/assets/59c6633e-3cda-4d72-a61f-1b0ef5d2504c" /> |
| 파라미터 누락 시(404) | <img width="421" alt="image" src="https://github.com/user-attachments/assets/06a31a33-3895-4b4d-bd58-739cc35ea632" /> |


## Uncompleted Tasks 😅
- [ ] 400은 어떻게 테스트해보죠?ㅋ.ㅋ

## To Reviewers 📢
검사 순서를 고민했습니다.
클라 분들이 어느정도 필터링하고 넘겨주실테니 글자수나 이모지 검사하는 리소스를 들이지 않고 일단 DB에 접근하는 중복 검사부터 진행하는 것이 좋을지,
아니면 간단한 검사부터 진행해 가장 시간이 오래 걸리는 중복 검사까지 갈 가능성을 줄이는 것이 좋을지..

0.3초마다 검사라 UI단에서 놓치거나 클라 분들이 아예 검사 없이 보낼 수도 있다고 생각하고 다 검사해야 한다는 마인드로 일단 특수문자/이모지 -> 글자수 -> 중복검사 순으로 if문 작성해 두었습니다!
특수문자/이모지가 글자수보다 우선되는 이유는 이모지가 글자수 여러개를 잡아 먹는데 이거 하나하나 검사하기보다는 그냥 존재 유무를 먼저 판단하면 쉬울 것 같아서 그렇게 했어용.

그리고 영주가 exception 피알에서 엔드포인트 못 찾을 때 내주는 404가 안 된다고 했는데,,
```
@ExceptionHandler(MissingServletRequestParameterException.class)
    public ResponseEntity<BaseResponseDto<Void>> handleMissingParam(MissingServletRequestParameterException e) {
        return ResponseEntity
                .status(GlobalErrorCode.NOT_FOUND_END_POINT.getHttpStatus())
                .body(BaseResponseDto.fail(GlobalErrorCode.NOT_FOUND_END_POINT));
    }
```
제 쪽에서 nickname 파라미터가 빠진 경우 에러를 내주기 위해서 필요한 부분이 있어서! `MissingServletRequestParameterException`를 추가했습니다.