### PR TITLE
[feat] #18 S3 이미지 업로드/삭제 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ dependencies {
     // Spring Actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    // Multipart file
+    implementation("software.amazon.awssdk:bom:2.21.0")
+    implementation("software.amazon.awssdk:s3:2.21.0")
+
 }
 
 test {

--- a/src/main/java/org/hilingual/Main.java
+++ b/src/main/java/org/hilingual/Main.java
@@ -2,12 +2,15 @@ package org.hilingual;
 
 
 import io.github.cdimascio.dotenv.Dotenv;
+import org.hilingual.external.s3.AWSProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@EnableConfigurationProperties(AWSProperties.class)
 public class Main {
     public static void main(String[] args) {
         Dotenv dotenv = Dotenv.configure()

--- a/src/main/java/org/hilingual/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/hilingual/advice/GlobalExceptionHandler.java
@@ -1,9 +1,11 @@
 package org.hilingual.advice;
 
+import lombok.extern.slf4j.Slf4j;
 import org.hilingual.common.dto.BaseResponseDto;
 import org.hilingual.common.exception.code.ErrorCode;
 import org.hilingual.common.exception.code.GlobalErrorCode;
 import org.hilingual.domain.diary.api.exception.DiaryBaseException;
+import org.hilingual.external.s3.exception.S3BaseException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -19,6 +21,13 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(DiaryBaseException.class)
     public ResponseEntity<BaseResponseDto<Void>> handleDiaryBaseException(DiaryBaseException e) {
+        return ResponseEntity
+                .status(e.getStatus())
+                .body(BaseResponseDto.fail(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(S3BaseException.class)
+    public ResponseEntity<BaseResponseDto<Void>> handleS3BaseException(S3BaseException e) {
         return ResponseEntity
                 .status(e.getStatus())
                 .body(BaseResponseDto.fail(e.getErrorCode()));

--- a/src/main/java/org/hilingual/external/s3/AWSConfig.java
+++ b/src/main/java/org/hilingual/external/s3/AWSConfig.java
@@ -1,0 +1,42 @@
+package org.hilingual.external.s3;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+@RequiredArgsConstructor
+public class AWSConfig {
+
+    private final AWSProperties awsProperties;
+
+    @Bean
+    public S3Client s3Client() {
+        boolean hasAccessKey = awsProperties.getAccessKey() != null && !awsProperties.getAccessKey().isBlank();
+        boolean hasSecretKey = awsProperties.getSecretKey() != null && !awsProperties.getSecretKey().isBlank();
+
+        if (hasAccessKey && hasSecretKey) {
+            return S3Client.builder()
+                    .region(Region.of(awsProperties.getAwsRegion()))
+                    .credentialsProvider(
+                            StaticCredentialsProvider.create(
+                                    AwsBasicCredentials.create(
+                                            awsProperties.getAccessKey(),
+                                            awsProperties.getSecretKey()
+                                    )
+                            )
+                    )
+                    .build();
+        } else {
+            return S3Client.builder()
+                    .region(Region.of(awsProperties.getAwsRegion()))
+                    .credentialsProvider(DefaultCredentialsProvider.create())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/hilingual/external/s3/AWSProperties.java
+++ b/src/main/java/org/hilingual/external/s3/AWSProperties.java
@@ -1,0 +1,15 @@
+package org.hilingual.external.s3;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "aws-property")
+public class AWSProperties {
+    private String accessKey;
+    private String secretKey;
+    private String awsRegion;
+    private String bucketName;
+}

--- a/src/main/java/org/hilingual/external/s3/S3Service.java
+++ b/src/main/java/org/hilingual/external/s3/S3Service.java
@@ -1,0 +1,88 @@
+package org.hilingual.external.s3;
+
+import lombok.RequiredArgsConstructor;
+import org.hilingual.external.s3.exception.InvalidImageException;
+import org.hilingual.external.s3.exception.S3ApiException;
+import org.hilingual.external.s3.exception.S3ErrorCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Component
+public class S3Service {
+
+    private final AWSProperties awsProperties;
+    private final S3Client s3Client;
+
+    private static final List<String> IMAGE_EXTENSIONS = Arrays.asList(
+            "image/jpeg", "image/png", "image/jpg", "image/webp", "image/heic", "image/heif"
+    );
+    private static final Long MAX_FILE_SIZE = 7 * 1024 * 1024L;
+
+    public String uploadImage(String directoryPath, MultipartFile image) {
+
+        System.out.println("메서드 진입");
+
+        validateExtension(image);
+        validateFileSize(image);
+
+        final String key = directoryPath + generateImageFileName();
+
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(awsProperties.getBucketName())
+                .key(key)
+                .contentType(image.getContentType())
+                .contentDisposition("inline")
+                .build();
+
+        try {
+            RequestBody requestBody = RequestBody.fromBytes(image.getBytes());
+            s3Client.putObject(request, requestBody);
+            return key;
+        } catch (IOException e) {
+            throw new S3ApiException(S3ErrorCode.FILE_PROCESSING_FAILED);
+        } catch (S3Exception e) {
+            throw new S3ApiException(S3ErrorCode.S3_UPLOAD_FAILED);
+        }
+    }
+
+    public void deleteImage(String key) {
+        DeleteObjectRequest request = DeleteObjectRequest.builder()
+                .bucket(awsProperties.getBucketName())
+                .key(key)
+                .build();
+
+        try {
+            s3Client.deleteObject(request);
+        } catch (S3Exception e) {
+            throw new S3ApiException(S3ErrorCode.S3_DELETE_FAILED);
+        }
+    }
+
+    private String generateImageFileName() {
+        return UUID.randomUUID() + ".jpg";
+    }
+
+    private void validateExtension(MultipartFile image) {
+        String contentType = image.getContentType();
+        if (!IMAGE_EXTENSIONS.contains(contentType)) {
+            throw new InvalidImageException(S3ErrorCode.INVALID_IMAGE_EXTENSION);
+        }
+    }
+
+    private void validateFileSize(MultipartFile image) {
+        if (image.getSize() > MAX_FILE_SIZE) {
+            throw new InvalidImageException(S3ErrorCode.INVALID_IMAGE_SIZE);
+        }
+    }
+}

--- a/src/main/java/org/hilingual/external/s3/S3Service.java
+++ b/src/main/java/org/hilingual/external/s3/S3Service.java
@@ -34,7 +34,7 @@ public class S3Service {
     );
 
     private static final List<String> ALLOWED_CONTENT_TYPES = List.copyOf(EXTENSION_MAP.keySet());
-    private static final Long MAX_FILE_SIZE = 7 * 1024 * 1024L;
+    private static final Long MAX_FILE_SIZE = 10 * 1024 * 1024L;
 
     public String uploadImage(String directoryPath, MultipartFile image) {
 

--- a/src/main/java/org/hilingual/external/s3/exception/InvalidImageException.java
+++ b/src/main/java/org/hilingual/external/s3/exception/InvalidImageException.java
@@ -1,0 +1,15 @@
+package org.hilingual.external.s3.exception;
+
+import org.hilingual.common.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class InvalidImageException extends S3BaseException{
+    public InvalidImageException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/src/main/java/org/hilingual/external/s3/exception/S3ApiException.java
+++ b/src/main/java/org/hilingual/external/s3/exception/S3ApiException.java
@@ -1,0 +1,15 @@
+package org.hilingual.external.s3.exception;
+
+import org.hilingual.common.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class S3ApiException extends S3BaseException {
+    public S3ApiException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.SERVICE_UNAVAILABLE;
+    }
+}

--- a/src/main/java/org/hilingual/external/s3/exception/S3BaseException.java
+++ b/src/main/java/org/hilingual/external/s3/exception/S3BaseException.java
@@ -1,0 +1,17 @@
+package org.hilingual.external.s3.exception;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.hilingual.common.exception.base.HilingualBaseException;
+import org.hilingual.common.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class S3BaseException extends HilingualBaseException {
+
+    private final ErrorCode errorCode;
+
+    public abstract HttpStatus getStatus();
+}

--- a/src/main/java/org/hilingual/external/s3/exception/S3ErrorCode.java
+++ b/src/main/java/org/hilingual/external/s3/exception/S3ErrorCode.java
@@ -1,0 +1,41 @@
+package org.hilingual.external.s3.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.hilingual.common.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum S3ErrorCode implements ErrorCode {
+    // 400
+    INVALID_IMAGE_EXTENSION(HttpStatus.BAD_REQUEST, 40001, "허용되지 않은 이미지 확장자입니다."),
+    INVALID_IMAGE_SIZE(HttpStatus.BAD_REQUEST, 40002, "이미지 용량은 최대 7MB까지 가능합니다."),
+
+    // 500
+    FILE_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 50001, "파일 처리 중 오류가 발생했습니다."),
+
+    // 503
+    S3_UPLOAD_FAILED(HttpStatus.SERVICE_UNAVAILABLE, 50300, "S3 이미지 업로드 중 오류가 발생했습니다."),
+    S3_DELETE_FAILED(HttpStatus.SERVICE_UNAVAILABLE, 50301, "S3 이미지 삭제 중 오류가 발생했습니다.");
+    ;
+
+    public final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus(){
+        return httpStatus;
+    }
+
+    @Override
+    public int getCode(){
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/org/hilingual/external/s3/exception/S3ErrorCode.java
+++ b/src/main/java/org/hilingual/external/s3/exception/S3ErrorCode.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum S3ErrorCode implements ErrorCode {
     // 400
     INVALID_IMAGE_EXTENSION(HttpStatus.BAD_REQUEST, 40001, "허용되지 않은 이미지 확장자입니다."),
-    INVALID_IMAGE_SIZE(HttpStatus.BAD_REQUEST, 40002, "이미지 용량은 최대 7MB까지 가능합니다."),
+    INVALID_IMAGE_SIZE(HttpStatus.BAD_REQUEST, 40002, "이미지 용량은 최대 10MB까지 가능합니다."),
 
     // 500
     FILE_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 50001, "파일 처리 중 오류가 발생했습니다."),

--- a/src/main/java/org/hilingual/external/s3/exception/S3SuccessCode.java
+++ b/src/main/java/org/hilingual/external/s3/exception/S3SuccessCode.java
@@ -1,0 +1,33 @@
+package org.hilingual.external.s3.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.hilingual.common.exception.code.SuccessCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum S3SuccessCode implements SuccessCode {
+    S3_UPLOAD_SUCCESS(HttpStatus.OK, 20000, "이미지 업로드 성공"),
+    S3_DELETE_SUCCESS(HttpStatus.OK, 20000, "이미지 삭제 성공"),
+    ;
+
+    public final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus(){
+        return httpStatus;
+    }
+
+    @Override
+    public int getCode(){
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/org/hilingual/test/ImageController.java
+++ b/src/main/java/org/hilingual/test/ImageController.java
@@ -1,0 +1,34 @@
+package org.hilingual.test;
+
+import lombok.RequiredArgsConstructor;
+import org.hilingual.common.dto.BaseResponseDto;
+import org.hilingual.external.s3.S3Service;
+import org.hilingual.external.s3.exception.S3SuccessCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/v1/test/images")
+@RequiredArgsConstructor
+public class ImageController {
+
+    private final S3Service s3Service;
+
+    @PostMapping("/upload")
+    public ResponseEntity<BaseResponseDto<String>> uploadImage(
+            @RequestParam("image") MultipartFile image
+    ) {
+        String imageUrl = s3Service.uploadImage("diary/", image);
+        return ResponseEntity.ok(BaseResponseDto.success(S3SuccessCode.S3_UPLOAD_SUCCESS, imageUrl));
+    }
+
+    @DeleteMapping("/delete")
+    public ResponseEntity<BaseResponseDto<Void>> deleteImage(
+            @RequestParam("key") String key
+    ) {
+        s3Service.deleteImage(key);
+        return ResponseEntity.ok(BaseResponseDto.success(S3SuccessCode.S3_DELETE_SUCCESS));
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,11 @@ spring:
     username: ${DB_ID}
     password: ${DB_PW}
     driver-class-name: com.mysql.cj.jdbc.Driver
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 10MB
+      max-request-size: 10MB
 
   jpa:
     hibernate:
@@ -22,6 +27,12 @@ management:
   endpoint:
     health:
       show-details: always
+
+aws-property:
+  access-key: ${AWS_ACCESS_KEY}
+  secret-key: ${AWS_SECRET_KEY}
+  aws-region: ${AWS_REGION}
+  bucket-name: ${AWS_BUCKET_NAME}
 
 ---
 


### PR DESCRIPTION
## Related issue 🛠
- closed #18 

## Work Description ✏️
## 🔵 Flow

> Presigned URL 방식이 아닌, 서버가 S3에 직접 올리고 관리하는 구조.
추후 스프린트에서 Presigned URL 방식으로 개선할 것 같음
> 

1. 클라이언트에서 서버로 사진과 함께 요청을 보낸다
2. 서버는 사진을 AWS에 저장하고, 해당 사진의 위치를 나타내는 객체 URL AWS S3로 부터 가져온다.
3. 서버는 Database에 사진의 url을 저장합니다.
4. 클라이언트에서 사진 정보가 필요할 때, Database에 저장한 URL을 내려준다.

## 🔵 적용

### ✅ 기본 설정

```groovy
dependencies {
	// Multipart file
	implementation("software.amazon.awssdk:bom:2.21.0")
	implementation("software.amazon.awssdk:s3:2.21.0")
}
```

**[깨알 트슈]**

스프링부트 2.0 이상부터는 Multipart 요청이 자동 활성화라고 하길래 아래 `enabled: true` 를 안넣었었는데, 분명 코드는 제대로 된 것 같은데 500이 나서… 1시간 넘게 헤매다가 yml파일에 아래 내용 추가했더니 바로 되었습니다ㅠ 

```yaml
  servlet:
    multipart:
      enabled: true               # 멀티파트 요청 활성화 (파일 업로드 가능 여부)
      max-file-size: 10MB         # 단일 파일의 최대 크기 제한
      max-request-size: 10MB      # 요청 전체의 최대 크기 제한 (여러 파일 포함 가능)
```


### ✅ `AWSConfig.java`, `AWSProperties.java`

- AWSProperties 클래스에서 S3 관련 설정 값을 주입받아 관리
- AWSConfig에서 로컬 개발 환경과 EC2 배포 환경에 따라 S3Client의 인증 방식을 유연하게 선택할 수 있음
    - accessKey와 secretKey 값이 존재하면 StaticCredentialsProvider 사용(.env),
    - 없으면 DefaultCredentialsProvider 사용 (EC2 IAM Role 사용)

---

### ✅ 7.7 23:20 수정사항
- 기존에는 .png 파일을 업로드해도 S3에는 항상 .jpg 확장자로 저장되었지만, 이를 이미지의 Content-Type에 맞는 확장자로 저장되도록 로직을 수정했습니다.
- 디렉토리 path에서 \가 누락될 경우를 방지하기 위한 로직을 추가했습니다.


## Screenshot 📸

| 설명               | 사진 |
|:------------------|:-----|
| **이미지 업로드 테스트** | ![image](https://github.com/user-attachments/assets/ba63d8bc-229a-4f01-ba00-d133f07bc07b) |
| **업로드 성공**       | ![image](https://github.com/user-attachments/assets/5a0a544d-0f98-4a0a-bae2-eee88706bdef) |
| **이미지 삭제 테스트** | ![image](https://github.com/user-attachments/assets/4680f77f-5d86-42e1-ae7f-d1ae862e06e7) |
| **삭제 성공**        | ![image](https://github.com/user-attachments/assets/38744985-0a4e-45e3-bf9c-0bdfe338280e) |

## To Reviewers 📢
이미지 업로드, 삭제 관련은 요 서비스 이용하시면 됩니다.
사실 일기 작성 후 수정 불가능하므로 아직 deleteImage() 메서드도 필요없지만, 그냥 나중을 위해 기본적으로 넣어두었습니다.
추후, 이미지 관리할 때 필요한 메서드들 더 생기면 추가해서 사용하면 됨!
