### PR TITLE
[init] #12 프로메테우스 설정 추가 및 디스코드 웹훅 설정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,5 @@ COPY ${JAR_FILE} app.jar
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-jar", "app.jar", "--spring.profiles.active=blue"]
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ pipeline {
         DEPLOY_SERVER = "ubuntu@43.200.125.20"
         PROJECT_PATH = "/home/ubuntu/hilingual"
         JAR_NAME = "HILINGUAL-SERVER-1.0-SNAPSHOT.jar"
+        DISCORD_WEBHOOK_URL = credentials('discord-webhook-url')
     }
 
     stages {
@@ -48,5 +49,19 @@ pipeline {
                 }
             }
         }
-    }
-}
+  stage('Notify to Discord') {
+              when {
+                  expression { env.BRANCH_NAME == 'develop' }
+              }
+              steps {
+                  sh '''
+                      curl -X POST "$DISCORD_WEBHOOK_URL" \
+                      -H "Content-Type: application/json" \
+                      -d '{
+                            "content": ":rocket: *[Hilingual]* `develop` 브랜치에 코드가 푸시되고 배포되었습니다!\\n커밋 메시지: '${GIT_COMMIT}'"
+                          }'
+                  '''
+              }
+          }
+      }
+  }

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+echo "[INFO] 도커 이미지 빌드 시작"
+docker compose build --no-cache
+
 EXIST_BLUE=$(docker ps | grep "hilingual-blue" | grep Up)
 
 if [ -z "$EXIST_BLUE" ]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,12 @@ services:
     container_name: hilingual-blue
     ports:
       - "8080:8080"
+    env_file:
+      - .env
     environment:
       - SPRING_PROFILES_ACTIVE=blue
-      - DB_URL=${DB_URL}
-      - DB_ID=${DB_ID}
-      - DB_PW=${DB_PW}
+    networks:
+      - hilingual-network
 
   spring-green:
     build:
@@ -21,11 +22,12 @@ services:
     container_name: hilingual-green
     ports:
       - "8081:8080"
+    env_file:
+      - .env
     environment:
       - SPRING_PROFILES_ACTIVE=green
-      - DB_URL=${DB_URL}
-      - DB_ID=${DB_ID}
-      - DB_PW=${DB_PW}
+    networks:
+      - hilingual-network
 
   nginx:
     image: nginx:latest
@@ -36,4 +38,14 @@ services:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./nginx/.env:/etc/nginx/.env
     environment:
-      - deployment_target
+      - deployment_target=${deployment_target}
+    depends_on:
+      - spring-blue
+      - spring-green
+    networks:
+      - hilingual-network
+
+networks:
+  hilingual-network:
+    driver: bridge
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,11 +14,15 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
 
+logging:
+  file:
+    name: /home/ubuntu/logs/app.log
+
 management:
   endpoints:
     web:
       exposure:
-        include: health,info
+        include: health,info,prometheus
   endpoint:
     health:
       show-details: always
@@ -40,3 +44,4 @@ spring:
       on-profile: green
 server:
   port: 8081
+


### PR DESCRIPTION
## Related issue 🛠
- closed #12

## Work Description ✏️
- application.yml 파일에서 prometheus의 접근을 허용했습니다

- Prometheus + Grafana + Loki + Promtail을 활용하여 모니터링 서버를 구축했습니다. (레포를 따로 파서 올리진 않겠습니다! yaml파일이랑 구축 과정들은 문서화해서 노션에 올리두겠습니다!)

- Spring Boot 애플리케이션 로그(`/home/ubuntu/logs/app.log`에 저장)를 Promtail이 수집하고, Loki로 전송하도록 설정했습니다.

- Prometheus는 Spring Boot Actuator 메트릭(`/actuator/prometheus`)을 수집하고 있으며, Grafana에서 시각화할 수 있습니다.

- PR, commit, merge에 대해서 디스코드에 알람 설정했습니다!


## To Reviewers 📢
- 마지막 인프라 구축입니다. 자세한 내용은 노션에 문서화해두겠습니다!