### PR TITLE
[feat] #42 특정단어 세부내용조회 API 구현

### DIFF
--- a/src/main/java/org/hilingual/domain/voca/api/controller/VocaController.java
+++ b/src/main/java/org/hilingual/domain/voca/api/controller/VocaController.java
@@ -1,6 +1,7 @@
 package org.hilingual.domain.voca.api.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.hilingual.domain.voca.api.dto.res.VocaDetailResponse;
 import org.hilingual.domain.voca.api.dto.res.VocaListResponse;
 import org.hilingual.domain.voca.api.dto.res.VocaSearchListResponse;
 import org.hilingual.domain.voca.api.exception.VocaApiErrorCode;
@@ -47,6 +48,14 @@ public class VocaController {
         }
 
         return ResponseEntity.ok(vocaService.searchVocaList(userId, keyword.trim()));
+    }
+
+    @GetMapping("/{vocaId}")
+    public ResponseEntity<VocaDetailResponse> getVocaDetail(
+            @PathVariable final Long vocaId
+    ) {
+        final Long userId = 1L; // TODO: 로그인 연동 후 수정
+        return ResponseEntity.ok(vocaService.getVocaDetail(userId, vocaId));
     }
 
 }

--- a/src/main/java/org/hilingual/domain/voca/api/dto/res/VocaDetailResponse.java
+++ b/src/main/java/org/hilingual/domain/voca/api/dto/res/VocaDetailResponse.java
@@ -1,0 +1,38 @@
+package org.hilingual.domain.voca.api.dto.res;
+
+import org.hilingual.domain.voca.core.domain.Voca;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+
+public record VocaDetailResponse(
+        Long phraseId,
+        String phrase,
+        List<String> phraseType,
+        String explanation,
+        String createdAt
+) {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yy.MM.dd");
+
+    public static VocaDetailResponse from(final Voca voca) {
+        return new VocaDetailResponse(
+                voca.getRecommend().getId(),
+                voca.getRecommend().getPhrase(),
+                parsePhraseTypes(voca.getRecommend().getPhraseType()),
+                voca.getRecommend().getExplanation(),
+                voca.getCreatedAt().format(FORMATTER)
+        );
+    }
+
+    private static List<String> parsePhraseTypes(String phraseTypeRaw) {
+        if (phraseTypeRaw == null || phraseTypeRaw.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(phraseTypeRaw.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+    }
+}

--- a/src/main/java/org/hilingual/domain/voca/api/service/VocaService.java
+++ b/src/main/java/org/hilingual/domain/voca/api/service/VocaService.java
@@ -1,6 +1,7 @@
 package org.hilingual.domain.voca.api.service;
 
 import lombok.RequiredArgsConstructor;
+import org.hilingual.domain.voca.api.dto.res.VocaDetailResponse;
 import org.hilingual.domain.voca.api.dto.res.VocaListResponse;
 import org.hilingual.domain.voca.api.dto.res.VocaSearchListResponse;
 import org.hilingual.domain.voca.core.domain.Voca;
@@ -29,4 +30,12 @@ public class VocaService {
         final List<Voca> vocas = vocaRetriever.findStartsWithVoca(userId, keyword);
         return VocaSearchListResponse.from(vocas);
     }
+
+    //특정 단어 세부 조회
+    @Transactional(readOnly = true)
+    public VocaDetailResponse getVocaDetail(final Long userId, final Long vocaId) {
+        final Voca voca = vocaRetriever.findByUserIdAndVocaId(userId, vocaId);
+        return VocaDetailResponse.from(voca);
+    }
+
 }

--- a/src/main/java/org/hilingual/domain/voca/api/service/VocaService.java
+++ b/src/main/java/org/hilingual/domain/voca/api/service/VocaService.java
@@ -8,8 +8,6 @@ import org.hilingual.domain.voca.core.domain.Voca;
 import org.hilingual.domain.voca.core.facade.VocaRetriever;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-
 import java.util.List;
 
 @Service
@@ -32,7 +30,6 @@ public class VocaService {
     }
 
     //특정 단어 세부 조회
-    @Transactional(readOnly = true)
     public VocaDetailResponse getVocaDetail(final Long userId, final Long vocaId) {
         final Voca voca = vocaRetriever.findByUserIdAndVocaId(userId, vocaId);
         return VocaDetailResponse.from(voca);

--- a/src/main/java/org/hilingual/domain/voca/core/exception/VocaCoreErrorCode.java
+++ b/src/main/java/org/hilingual/domain/voca/core/exception/VocaCoreErrorCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum VocaCoreErrorCode implements ErrorCode {
 
-    VOCA_NOT_FOUND(HttpStatus.NOT_FOUND, 40410, "요청한 단어장이 존재하지 않습니다.");
+    VOCA_NOT_FOUND(HttpStatus.NOT_FOUND, 40404, "vocaId에 해당하는 단어가 없습니다");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/hilingual/domain/voca/core/exception/VocaNotFoundException.java
+++ b/src/main/java/org/hilingual/domain/voca/core/exception/VocaNotFoundException.java
@@ -5,7 +5,7 @@ import org.hilingual.domain.voca.api.exception.VocaApiErrorCode;
 import org.hilingual.domain.voca.core.exception.VocaCoreErrorCode;
 import org.springframework.http.HttpStatus;
 
-// TODO : User 도메인 구현되면 구현 예정
+
 public class VocaNotFoundException extends VocaCoreException {
 
     public VocaNotFoundException(ErrorCode errorCode) {

--- a/src/main/java/org/hilingual/domain/voca/core/facade/VocaRetriever.java
+++ b/src/main/java/org/hilingual/domain/voca/core/facade/VocaRetriever.java
@@ -5,6 +5,8 @@ import org.hilingual.domain.voca.api.dto.res.VocaListResponse;
 import org.hilingual.domain.voca.api.exception.VocaApiErrorCode;
 import org.hilingual.domain.voca.api.exception.VocaInvalidKoreanKeywordException;
 import org.hilingual.domain.voca.core.domain.Voca;
+import org.hilingual.domain.voca.core.exception.VocaCoreErrorCode;
+import org.hilingual.domain.voca.core.exception.VocaNotFoundException;
 import org.hilingual.domain.voca.core.repository.VocaRepository;
 import org.springframework.stereotype.Component;
 import org.hilingual.domain.voca.api.exception.VocaInvalidSortTypeException;
@@ -30,6 +32,8 @@ public class VocaRetriever {
         return vocaGroupFactory.create(vocas, sort);
     }
 
+    // TODO : 검색 한글 예외처리 추가 (단어장 사용 시)
+
     public List<Voca> findStartsWithVoca(final Long userId, final String keyword) {
 
         final List<Voca> vocas = vocaRepository.findAllByUserIdAndPhraseStartsWith(userId, keyword);
@@ -37,7 +41,11 @@ public class VocaRetriever {
         return vocas;
     }
 
-    // TODO : 한글 예외처리
+
+    public Voca findByUserIdAndVocaId(final Long userId, final Long vocaId) {
+        return vocaRepository.findByIdAndUserId(vocaId, userId)
+                .orElseThrow(() -> new VocaNotFoundException(VocaCoreErrorCode.VOCA_NOT_FOUND));
+    }
 
 
 }

--- a/src/main/java/org/hilingual/domain/voca/core/repository/VocaRepository.java
+++ b/src/main/java/org/hilingual/domain/voca/core/repository/VocaRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface VocaRepository extends Repository<Voca, Long> {
 
@@ -39,5 +40,12 @@ public interface VocaRepository extends Repository<Voca, Long> {
             @Param("keyword") String keyword
     );
 
+    @Query("""
+    SELECT v FROM Voca v
+    JOIN FETCH v.recommend r
+    WHERE v.id = :vocaId
+      AND v.user.id = :userId
+""")
+    Optional<Voca> findByIdAndUserId(@Param("vocaId") Long vocaId, @Param("userId") Long userId);
 }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #42 

## Work Description ✏️
- 특정 단어 세부조회 API 구현  
- created_at 필드 Date -> 포매팅 (XX.XX.XX) -> String으로 형변환해서 응답 
  - 존재하지 않는 vocaId 요청 시 404 응답  

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|

| ex. 게시글 전체 조회(페이지 넘어간 경우 404) | <캡처 이미지 첨부> |
<img width="1281" height="882" alt="스크린샷 2025-07-11 오후 10 02 34" src="https://github.com/user-attachments/assets/fc751176-12e0-4454-98b6-152bc73f6db6" />
<img width="1281" height="708" alt="스크린샷 2025-07-11 오후 10 03 04" src="https://github.com/user-attachments/assets/3ae9af58-287b-45e4-8db6-8a7a3b76125b" />

## Uncompleted Tasks 😅

## To Reviewers 📢
