### PR TITLE
[feat] #44  작성된 일기 썸네일 조회 API 구현

### DIFF
--- a/src/main/java/org/hilingual/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/hilingual/advice/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.hilingual.common.exception.code.ErrorCode;
 import org.hilingual.common.exception.code.GlobalErrorCode;
 import org.hilingual.domain.diary.api.exception.DiaryBaseException;
 import org.hilingual.domain.security.token.api.exception.JwtBaseException;
+import org.hilingual.domain.usercalendar.api.exception.UserCalendarBaseException;
 import org.hilingual.external.openai.exception.OpenAiBaseException;
 import org.hilingual.external.s3.exception.S3BaseException;
 import org.springframework.http.ResponseEntity;
@@ -66,6 +67,14 @@ public class GlobalExceptionHandler {
     public ResponseEntity<BaseResponseDto<Void>> handleOpenAiBaseException(OpenAiBaseException e) {
         log.error("[OpenAiBaseException] message: {}", e.getMessage(), e);
 
+        return ResponseEntity
+                .status(e.getStatus())
+                .body(BaseResponseDto.fail(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(UserCalendarBaseException.class)
+    public ResponseEntity<BaseResponseDto<Void>> handleUserCalendarBaseException(UserCalendarBaseException e) {
+        log.error("[UserCalendarBaseException] message: {}", e.getMessage(), e);
         return ResponseEntity
                 .status(e.getStatus())
                 .body(BaseResponseDto.fail(e.getErrorCode()));

--- a/src/main/java/org/hilingual/domain/diary/core/repository/DiaryRepository.java
+++ b/src/main/java/org/hilingual/domain/diary/core/repository/DiaryRepository.java
@@ -2,6 +2,25 @@ package org.hilingual.domain.diary.core.repository;
 
 import org.hilingual.domain.diary.core.domain.Diary;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
+    @Query("""
+    SELECT d FROM Diary d
+    WHERE d.user.id = :userId
+      AND d.createdAt >= :startOfDay
+      AND d.createdAt < :endOfDay
+""")
+    List<Diary> findByUserIdAndCreatedAtBetween(
+            @Param("userId") Long userId,
+            @Param("startOfDay") LocalDateTime startOfDay,
+            @Param("endOfDay") LocalDateTime endOfDay
+    );
+
 }

--- a/src/main/java/org/hilingual/domain/usercalendar/api/controller/UserCalendarController.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/api/controller/UserCalendarController.java
@@ -2,12 +2,14 @@ package org.hilingual.domain.usercalendar.api.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.hilingual.domain.usercalendar.api.dto.res.UserCalendarDiarySummaryResponse;
+import org.hilingual.domain.usercalendar.api.exception.UserCalendarApiErrorCode;
+import org.hilingual.domain.usercalendar.api.exception.UserCalendarInvalidDateFormatException;
 import org.hilingual.domain.usercalendar.api.service.UserCalendarService;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 
 @RestController
 @RequestMapping("/api/v1/calendar")
@@ -18,9 +20,17 @@ public class UserCalendarController {
 
     @GetMapping("/{date}")
     public ResponseEntity<UserCalendarDiarySummaryResponse> getDiarySummaryByDate(
-            @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) final LocalDate date
+            @PathVariable final String date
     ) {
         final Long userId = 1L; // TODO: 로그인 연동 후 대체
-        return ResponseEntity.ok(userCalendarService.getDiarySummary(date, userId));
+
+        final LocalDate parsedDate;
+        try {
+            parsedDate = LocalDate.parse(date);
+        } catch (DateTimeParseException e) {
+            throw new UserCalendarInvalidDateFormatException(UserCalendarApiErrorCode.INVALID_DATE_FORMAT);
+        }
+
+        return ResponseEntity.ok(userCalendarService.getDiarySummary(parsedDate, userId));
     }
 }

--- a/src/main/java/org/hilingual/domain/usercalendar/api/controller/UserCalendarController.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/api/controller/UserCalendarController.java
@@ -1,0 +1,26 @@
+package org.hilingual.domain.usercalendar.api.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.hilingual.domain.usercalendar.api.dto.res.UserCalendarDiarySummaryResponse;
+import org.hilingual.domain.usercalendar.api.service.UserCalendarService;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/api/v1/calendar")
+@RequiredArgsConstructor
+public class UserCalendarController {
+
+    private final UserCalendarService userCalendarService;
+
+    @GetMapping("/{date}")
+    public ResponseEntity<UserCalendarDiarySummaryResponse> getDiarySummaryByDate(
+            @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) final LocalDate date
+    ) {
+        final Long userId = 1L; // TODO: 로그인 연동 후 대체
+        return ResponseEntity.ok(userCalendarService.getDiarySummary(date, userId));
+    }
+}

--- a/src/main/java/org/hilingual/domain/usercalendar/api/controller/UserCalendarController.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/api/controller/UserCalendarController.java
@@ -25,6 +25,7 @@ public class UserCalendarController {
         final Long userId = 1L; // TODO: 로그인 연동 후 대체
 
         final LocalDate parsedDate;
+
         try {
             parsedDate = LocalDate.parse(date);
         } catch (DateTimeParseException e) {

--- a/src/main/java/org/hilingual/domain/usercalendar/api/dto/res/UserCalendarDiarySummaryResponse.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/api/dto/res/UserCalendarDiarySummaryResponse.java
@@ -1,0 +1,21 @@
+package org.hilingual.domain.usercalendar.api.dto.res;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public record UserCalendarDiarySummaryResponse(
+        Long diaryId,
+        String createdAt,
+        String imageUrl,
+        String originalText
+) {
+    public static UserCalendarDiarySummaryResponse of(
+            Long diaryId,
+            LocalDateTime createdAt,
+            String imageUrl,
+            String originalText
+    ) {
+        String formattedTime = createdAt.format(DateTimeFormatter.ofPattern("HH:mm"));
+        return new UserCalendarDiarySummaryResponse(diaryId, formattedTime, imageUrl, originalText);
+    }
+}

--- a/src/main/java/org/hilingual/domain/usercalendar/api/exception/FutureDateNotAllowedException.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/api/exception/FutureDateNotAllowedException.java
@@ -1,0 +1,15 @@
+package org.hilingual.domain.usercalendar.api.exception;
+
+import org.hilingual.common.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class FutureDateNotAllowedException extends UserCalendarApiException {
+    public FutureDateNotAllowedException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/src/main/java/org/hilingual/domain/usercalendar/api/exception/UserCalendarApiErrorCode.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/api/exception/UserCalendarApiErrorCode.java
@@ -1,0 +1,32 @@
+package org.hilingual.domain.usercalendar.api.exception;
+
+import lombok.RequiredArgsConstructor;
+import org.hilingual.common.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum UserCalendarApiErrorCode implements ErrorCode {
+
+    FUTURE_DATE_NOT_ALLOWED(HttpStatus.BAD_REQUEST,40009, "미래 날짜에 대한 요청은 허용되지 않습니다."),
+    INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST,40010, "날짜 형식이 올바르지 않습니다. yyyy-MM-dd 형식이어야 합니다."),
+    DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, 40405, "해당 날짜에 작성된 일기가 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public int getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/org/hilingual/domain/usercalendar/api/exception/UserCalendarApiException.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/api/exception/UserCalendarApiException.java
@@ -1,0 +1,9 @@
+package org.hilingual.domain.usercalendar.api.exception;
+
+import org.hilingual.common.exception.code.ErrorCode;
+
+public abstract class UserCalendarApiException extends UserCalendarBaseException {
+    protected UserCalendarApiException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/hilingual/domain/usercalendar/api/exception/UserCalendarBaseException.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/api/exception/UserCalendarBaseException.java
@@ -1,18 +1,16 @@
 package org.hilingual.domain.usercalendar.api.exception;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.hilingual.common.exception.base.HilingualBaseException;
 import org.hilingual.common.exception.code.ErrorCode;
 import org.springframework.http.HttpStatus;
 
+
 @Getter
+@RequiredArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public abstract class UserCalendarBaseException extends HilingualBaseException {
     private final ErrorCode errorCode;
-
-    protected UserCalendarBaseException(ErrorCode errorCode) {
-        super();
-        this.errorCode = errorCode;
-    }
 
     @Override
     public String getMessage() {

--- a/src/main/java/org/hilingual/domain/usercalendar/api/exception/UserCalendarBaseException.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/api/exception/UserCalendarBaseException.java
@@ -1,0 +1,23 @@
+package org.hilingual.domain.usercalendar.api.exception;
+
+import lombok.Getter;
+import org.hilingual.common.exception.base.HilingualBaseException;
+import org.hilingual.common.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public abstract class UserCalendarBaseException extends HilingualBaseException {
+    private final ErrorCode errorCode;
+
+    protected UserCalendarBaseException(ErrorCode errorCode) {
+        super();
+        this.errorCode = errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return errorCode.getMessage();
+    }
+
+    public abstract HttpStatus getStatus();
+}

--- a/src/main/java/org/hilingual/domain/usercalendar/api/exception/UserCalendarDiaryNotFoundException.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/api/exception/UserCalendarDiaryNotFoundException.java
@@ -1,0 +1,16 @@
+package org.hilingual.domain.usercalendar.api.exception;
+
+import org.hilingual.common.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class UserCalendarDiaryNotFoundException extends UserCalendarApiException {
+
+    public UserCalendarDiaryNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.NOT_FOUND;
+    }
+}

--- a/src/main/java/org/hilingual/domain/usercalendar/api/exception/UserCalendarInvalidDateFormatException.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/api/exception/UserCalendarInvalidDateFormatException.java
@@ -1,0 +1,16 @@
+package org.hilingual.domain.usercalendar.api.exception;
+
+import org.hilingual.common.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class UserCalendarInvalidDateFormatException extends UserCalendarApiException {
+
+    public UserCalendarInvalidDateFormatException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/src/main/java/org/hilingual/domain/usercalendar/api/service/UserCalendarService.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/api/service/UserCalendarService.java
@@ -2,6 +2,8 @@ package org.hilingual.domain.usercalendar.api.service;
 
 import lombok.RequiredArgsConstructor;
 import org.hilingual.domain.usercalendar.api.dto.res.UserCalendarDiarySummaryResponse;
+import org.hilingual.domain.usercalendar.api.exception.FutureDateNotAllowedException;
+import org.hilingual.domain.usercalendar.api.exception.UserCalendarApiErrorCode;
 import org.hilingual.domain.usercalendar.core.facade.UserCalendarRetriever;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +18,9 @@ public class UserCalendarService {
     private final UserCalendarRetriever userCalendarRetriever;
 
     public UserCalendarDiarySummaryResponse getDiarySummary(final LocalDate date, final Long userId) {
+        if (date.isAfter(LocalDate.now())) {
+            throw new FutureDateNotAllowedException(UserCalendarApiErrorCode.FUTURE_DATE_NOT_ALLOWED);
+        }
         return userCalendarRetriever.findDiaryByDate(userId, date);
     }
 }

--- a/src/main/java/org/hilingual/domain/usercalendar/api/service/UserCalendarService.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/api/service/UserCalendarService.java
@@ -1,0 +1,21 @@
+package org.hilingual.domain.usercalendar.api.service;
+
+import lombok.RequiredArgsConstructor;
+import org.hilingual.domain.usercalendar.api.dto.res.UserCalendarDiarySummaryResponse;
+import org.hilingual.domain.usercalendar.core.facade.UserCalendarRetriever;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserCalendarService {
+
+    private final UserCalendarRetriever userCalendarRetriever;
+
+    public UserCalendarDiarySummaryResponse getDiarySummary(final LocalDate date, final Long userId) {
+        return userCalendarRetriever.findDiaryByDate(userId, date);
+    }
+}

--- a/src/main/java/org/hilingual/domain/usercalendar/core/domain/UserCalendar.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/core/domain/UserCalendar.java
@@ -1,4 +1,4 @@
-package org.hilingual.domain.usercalendar;
+package org.hilingual.domain.usercalendar.core.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -10,7 +10,7 @@ import org.hilingual.domain.user.core.domain.User;
 
 import java.time.LocalDate;
 
-import static org.hilingual.domain.usercalendar.UserCalendarTableConstants.*;
+import static org.hilingual.domain.usercalendar.core.domain.UserCalendarTableConstants.*;
 
 @Entity
 @Table(name = TABLE_USER_CALENDAR)

--- a/src/main/java/org/hilingual/domain/usercalendar/core/domain/UserCalendarTableConstants.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/core/domain/UserCalendarTableConstants.java
@@ -1,4 +1,4 @@
-package org.hilingual.domain.usercalendar;
+package org.hilingual.domain.usercalendar.core.domain;
 
 public class UserCalendarTableConstants {
     public static final String TABLE_USER_CALENDAR = "user_calendar";

--- a/src/main/java/org/hilingual/domain/usercalendar/core/exception/UserCalendarCoreErrorCode.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/core/exception/UserCalendarCoreErrorCode.java
@@ -1,15 +1,13 @@
-package org.hilingual.domain.usercalendar.api.exception;
+package org.hilingual.domain.usercalendar.core.exception;
 
 import lombok.RequiredArgsConstructor;
 import org.hilingual.common.exception.code.ErrorCode;
 import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
-public enum UserCalendarApiErrorCode implements ErrorCode {
+public enum UserCalendarCoreErrorCode implements ErrorCode{
 
-    // 400
-    FUTURE_DATE_NOT_ALLOWED(HttpStatus.BAD_REQUEST,40009, "미래 날짜에 대한 요청은 허용되지 않습니다."),
-    INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST,40010, "날짜 형식이 올바르지 않습니다. yyyy-MM-dd 형식이어야 합니다.");
+    DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, 40405, "해당 날짜에 작성된 일기가 없습니다.");
 
     private final HttpStatus httpStatus;
     private final int code;
@@ -29,4 +27,5 @@ public enum UserCalendarApiErrorCode implements ErrorCode {
     public String getMessage() {
         return message;
     }
+
 }

--- a/src/main/java/org/hilingual/domain/usercalendar/core/exception/UserCalendarCoreException.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/core/exception/UserCalendarCoreException.java
@@ -1,0 +1,11 @@
+package org.hilingual.domain.usercalendar.core.exception;
+
+import org.hilingual.common.exception.code.ErrorCode;
+import org.hilingual.domain.usercalendar.api.exception.UserCalendarBaseException;
+
+public abstract class UserCalendarCoreException extends UserCalendarBaseException {
+    protected UserCalendarCoreException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+}

--- a/src/main/java/org/hilingual/domain/usercalendar/core/exception/UserCalendarDiaryNotFoundException.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/core/exception/UserCalendarDiaryNotFoundException.java
@@ -1,0 +1,17 @@
+package org.hilingual.domain.usercalendar.core.exception;
+
+import org.hilingual.common.exception.code.ErrorCode;
+import org.hilingual.domain.usercalendar.api.exception.UserCalendarBaseException;
+import org.springframework.http.HttpStatus;
+
+public class UserCalendarDiaryNotFoundException extends UserCalendarBaseException {
+    public UserCalendarDiaryNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.NOT_FOUND;
+    }
+
+}

--- a/src/main/java/org/hilingual/domain/usercalendar/core/facade/UserCalendarRetriever.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/core/facade/UserCalendarRetriever.java
@@ -5,7 +5,7 @@ import org.hilingual.domain.diary.core.domain.Diary;
 import org.hilingual.domain.diary.core.repository.DiaryRepository;
 import org.hilingual.domain.usercalendar.api.dto.res.UserCalendarDiarySummaryResponse;
 import org.hilingual.domain.usercalendar.api.exception.UserCalendarDiaryNotFoundException;
-import org.hilingual.domain.usercalendar.api.exception.UserCalendarApiErrorCode;
+import org.hilingual.domain.usercalendar.core.exception.UserCalendarCoreErrorCode;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
@@ -33,7 +33,7 @@ public class UserCalendarRetriever {
                         )
                 )
                 .orElseThrow(() ->
-                        new UserCalendarDiaryNotFoundException(UserCalendarApiErrorCode.DIARY_NOT_FOUND)
+                        new UserCalendarDiaryNotFoundException(UserCalendarCoreErrorCode.DIARY_NOT_FOUND)
                 );
     }
 }

--- a/src/main/java/org/hilingual/domain/usercalendar/core/facade/UserCalendarRetriever.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/core/facade/UserCalendarRetriever.java
@@ -1,0 +1,39 @@
+package org.hilingual.domain.usercalendar.core.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.hilingual.domain.diary.core.domain.Diary;
+import org.hilingual.domain.diary.core.repository.DiaryRepository;
+import org.hilingual.domain.usercalendar.api.dto.res.UserCalendarDiarySummaryResponse;
+import org.hilingual.domain.usercalendar.api.exception.UserCalendarDiaryNotFoundException;
+import org.hilingual.domain.usercalendar.api.exception.UserCalendarApiErrorCode;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class UserCalendarRetriever {
+
+    private final DiaryRepository diaryRepository;
+
+    public UserCalendarDiarySummaryResponse findDiaryByDate(final Long userId, final LocalDate date) {
+        LocalDateTime startOfDay = date.atStartOfDay(); // 00:00
+        LocalDateTime endOfDay = date.plusDays(1).atStartOfDay(); // 다음날 00:00
+
+        return diaryRepository.findByUserIdAndCreatedAtBetween(userId, startOfDay, endOfDay)
+                .stream()
+                .findFirst()
+                .map(d ->
+                        UserCalendarDiarySummaryResponse.of(
+                                d.getId(),
+                                d.getCreatedAt(),
+                                d.getImageUrl(),
+                                d.getOriginalText()
+                        )
+                )
+                .orElseThrow(() ->
+                        new UserCalendarDiaryNotFoundException(UserCalendarApiErrorCode.DIARY_NOT_FOUND)
+                );
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #44 

## Work Description ✏️
  - `@PathVariable`로 전달받은 LocalDate를 기반으로, 해당 날짜에 작성된 일기 요약 조회
  - `DiaryRepository.findByUserIdAndCreatedAtBetween(userId, startOfDay, endOfDay)` 호출하여,
    해당 유저가 특정 날짜에 작성한 일기 조회
    - 시간 범위 기반 between 조건으로 조회
  - 조회된 Diary를 `UserCalendarDiarySummaryResponse.of(...)`로 가공하여 시간(HH:mm), 이미지 URL, 원본 텍스트 리턴
  - 일기 없을 시 'UserCalendarDiaryNotFoundException'
  - 미래 날짜 요청 시 'UserCalendarFutureDateException'
  - 잘못된 날짜 형식 (ex. `/calendar/2025adf`) 시 `UserCalendarInvalidDateFormatException`


## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
<img width="1281" height="680" alt="스크린샷 2025-07-12 오전 1 16 56" src="https://github.com/user-attachments/assets/cb305e42-c6ee-4001-b45d-2ee4e49b9286" />
<img width="1279" height="623" alt="스크린샷 2025-07-12 오전 1 17 06" src="https://github.com/user-attachments/assets/23a7df1b-0151-4535-9c0e-8188a079eed9" />
<img width="1292" height="588" alt="스크린샷 2025-07-12 오전 1 17 18" src="https://github.com/user-attachments/assets/cf95cf49-9a02-435e-8650-24ee3d4e7fd3" />
<img width="1254" height="653" alt="스크린샷 2025-07-12 오전 1 17 31" src="https://github.com/user-attachments/assets/a26f4707-f454-4411-857a-fc864fa07ca0" />


## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A