### PR TITLE
[feat] #48 작성되지 않은 일기 주제 조회 API

### DIFF
--- a/src/main/java/org/hilingual/common/domain/Topic.java
+++ b/src/main/java/org/hilingual/common/domain/Topic.java
@@ -3,9 +3,11 @@ package org.hilingual.common.domain;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import lombok.Getter;
 
 import java.time.LocalDate;
 
+@Getter
 @Entity
 public class Topic {
     @Id

--- a/src/main/java/org/hilingual/common/repository/TopicRepository.java
+++ b/src/main/java/org/hilingual/common/repository/TopicRepository.java
@@ -1,0 +1,15 @@
+package org.hilingual.common.repository;
+
+import org.hilingual.common.domain.Topic;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Repository
+public interface TopicRepository extends JpaRepository<Topic, LocalDate> {
+    Optional<Topic> findByDate(LocalDate date);
+}
+
+

--- a/src/main/java/org/hilingual/domain/usercalendar/api/controller/UserCalendarController.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/api/controller/UserCalendarController.java
@@ -2,6 +2,7 @@ package org.hilingual.domain.usercalendar.api.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.hilingual.domain.usercalendar.api.dto.res.UserCalendarDiarySummaryResponse;
+import org.hilingual.domain.usercalendar.api.dto.res.UserCalendarTopicResponse;
 import org.hilingual.domain.usercalendar.api.exception.UserCalendarApiErrorCode;
 import org.hilingual.domain.usercalendar.api.exception.UserCalendarInvalidDateFormatException;
 import org.hilingual.domain.usercalendar.api.service.UserCalendarService;
@@ -33,5 +34,19 @@ public class UserCalendarController {
         }
 
         return ResponseEntity.ok(userCalendarService.getDiarySummary(parsedDate, userId));
+    }
+
+    @GetMapping("/{date}/topic")
+    public ResponseEntity<UserCalendarTopicResponse> getTopicByDate(@PathVariable final String date) {
+        final Long userId = 1L; // TODO: 로그인 연동 후 대체
+        final LocalDate parsedDate;
+
+        try {
+            parsedDate = LocalDate.parse(date);
+        } catch (DateTimeParseException e) {
+            throw new UserCalendarInvalidDateFormatException(UserCalendarApiErrorCode.INVALID_DATE_FORMAT);
+        }
+
+        return ResponseEntity.ok(userCalendarService.getTopicByDate(parsedDate, userId));
     }
 }

--- a/src/main/java/org/hilingual/domain/usercalendar/api/dto/res/UserCalendarTopicResponse.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/api/dto/res/UserCalendarTopicResponse.java
@@ -1,0 +1,11 @@
+package org.hilingual.domain.usercalendar.api.dto.res;
+
+public record UserCalendarTopicResponse(
+        String topicKor,
+        String topicEn,
+        int remainingTime
+) {
+    public static UserCalendarTopicResponse of(String topicKor, String topicEn, int remainingTime) {
+        return new UserCalendarTopicResponse(topicKor, topicEn, remainingTime);
+    }
+}

--- a/src/main/java/org/hilingual/domain/usercalendar/api/service/UserCalendarService.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/api/service/UserCalendarService.java
@@ -2,6 +2,7 @@ package org.hilingual.domain.usercalendar.api.service;
 
 import lombok.RequiredArgsConstructor;
 import org.hilingual.domain.usercalendar.api.dto.res.UserCalendarDiarySummaryResponse;
+import org.hilingual.domain.usercalendar.api.dto.res.UserCalendarTopicResponse;
 import org.hilingual.domain.usercalendar.api.exception.FutureDateNotAllowedException;
 import org.hilingual.domain.usercalendar.api.exception.UserCalendarApiErrorCode;
 import org.hilingual.domain.usercalendar.core.facade.UserCalendarRetriever;
@@ -23,4 +24,12 @@ public class UserCalendarService {
         }
         return userCalendarRetriever.findDiaryByDate(userId, date);
     }
+
+    public UserCalendarTopicResponse getTopicByDate(final LocalDate date, final Long userId) {
+        if (date.isAfter(LocalDate.now())) {
+            throw new FutureDateNotAllowedException(UserCalendarApiErrorCode.FUTURE_DATE_NOT_ALLOWED);
+        }
+        return userCalendarRetriever.findTopicByDate(date);
+    }
+
 }

--- a/src/main/java/org/hilingual/domain/usercalendar/core/exception/UserCalendarCoreErrorCode.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/core/exception/UserCalendarCoreErrorCode.java
@@ -7,7 +7,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum UserCalendarCoreErrorCode implements ErrorCode{
 
-    DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, 40405, "해당 날짜에 작성된 일기가 없습니다.");
+    DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, 40405, "해당 날짜에 작성된 일기가 없습니다."),
+    TOPIC_NOT_FOUND(HttpStatus.NOT_FOUND, 40406, "해당 날짜에 주제가 존재하지 않습니다.");
+
 
     private final HttpStatus httpStatus;
     private final int code;

--- a/src/main/java/org/hilingual/domain/usercalendar/core/exception/UserCalendarTopicNotFoundException.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/core/exception/UserCalendarTopicNotFoundException.java
@@ -1,0 +1,16 @@
+package org.hilingual.domain.usercalendar.core.exception;
+
+import org.hilingual.common.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class UserCalendarTopicNotFoundException extends UserCalendarCoreException {
+
+    public UserCalendarTopicNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.NOT_FOUND;
+    }
+}

--- a/src/main/java/org/hilingual/domain/usercalendar/core/facade/UserCalendarRetriever.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/core/facade/UserCalendarRetriever.java
@@ -1,21 +1,27 @@
 package org.hilingual.domain.usercalendar.core.facade;
 
 import lombok.RequiredArgsConstructor;
+import org.hilingual.common.domain.Topic;
 import org.hilingual.domain.diary.core.domain.Diary;
 import org.hilingual.domain.diary.core.repository.DiaryRepository;
 import org.hilingual.domain.usercalendar.api.dto.res.UserCalendarDiarySummaryResponse;
+import org.hilingual.domain.usercalendar.api.dto.res.UserCalendarTopicResponse;
 import org.hilingual.domain.usercalendar.api.exception.UserCalendarDiaryNotFoundException;
 import org.hilingual.domain.usercalendar.core.exception.UserCalendarCoreErrorCode;
+import org.hilingual.domain.usercalendar.core.exception.UserCalendarTopicNotFoundException;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 @Component
 @RequiredArgsConstructor
 public class UserCalendarRetriever {
 
     private final DiaryRepository diaryRepository;
+    private final org.hilingual.common.repository.TopicRepository topicRepository;
 
     public UserCalendarDiarySummaryResponse findDiaryByDate(final Long userId, final LocalDate date) {
         LocalDateTime startOfDay = date.atStartOfDay(); // 00:00
@@ -36,4 +42,30 @@ public class UserCalendarRetriever {
                         new UserCalendarDiaryNotFoundException(UserCalendarCoreErrorCode.DIARY_NOT_FOUND)
                 );
     }
+    public UserCalendarTopicResponse findTopicByDate(final LocalDate date) {
+        final Topic topic = topicRepository.findByDate(date)
+                .orElseThrow(() -> new UserCalendarTopicNotFoundException(UserCalendarCoreErrorCode.TOPIC_NOT_FOUND));
+
+        final int remainingTime = calculateRemainingMinutesUntilDeadline(date);
+
+        return UserCalendarTopicResponse.of(topic.getTopicKor(), topic.getTopicEn(), remainingTime);
+    }
+    private int calculateRemainingMinutesUntilDeadline(final LocalDate topicDate) {
+        final ZoneId seoulZone = ZoneId.of("Asia/Seoul");
+        final LocalDateTime now = LocalDateTime.now(seoulZone);
+
+        // 작성 가능 시각: 주제 날짜 + 2일 00시 = 48시간 후
+        final LocalDateTime deadline = topicDate.plusDays(2).atStartOfDay();
+
+        long secondsRemaining = Duration.between(now, deadline).getSeconds();
+
+        if (secondsRemaining <= 0) {
+            return 0; // 작성 불가
+        } else if (secondsRemaining <= 60) {
+            return 1; // 1초~60초 = 1분
+        } else {
+            return (int) Math.ceil(secondsRemaining / 60.0);
+        }
+    }
+
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #48 

## Work Description ✏️
  - 사용자가 선택한 날짜의 일기 작성 주제를 조회
  
  -`remainingTime` 로직 구현  
    - 주제 날짜 기준 48시간까지 작성 가능  
    - `Asia/Seoul` 기준으로 현재 시간을 계산하고, 작성 마감까지 남은 시간을 분 단위로 반환  
    - 60초 이하 남았을 경우에도 최소 1분 반환, 0초 이하일 경우는 0 반환  
    
  - 예외처리
    - 작성한 날짜의 일기 썸네일 조회 API와 동일하게  요청 경로의 날짜(PathVariable)를 `LocalDate`로 파싱하고, 형식 오류에 대해 예외 처리  
    - 미래날짜 접근 불가, 해당 날짜 주제 없음 에러처리 구현



## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
<img width="1286" height="680" alt="스크린샷 2025-07-12 오후 1 07 46" src="https://github.com/user-attachments/assets/f53004ae-a788-4f97-99e8-274018770c38" />
<img width="1286" height="690" alt="스크린샷 2025-07-12 오후 1 06 08" src="https://github.com/user-attachments/assets/c9740c28-d5ea-4578-9ee7-177529f0f1ff" />
<img width="1298" height="714" alt="스크린샷 2025-07-12 오후 1 06 21" src="https://github.com/user-attachments/assets/64bfc102-
![Uploading 스크린샷 2025-07-12 오후 1.06.36.png…]()
17b3-49a0-a446-e83a8e280f4d" />
<img width="1288" height="668" alt="스크린샷 2025-07-12 오후 1 06 51" src="https://github.com/user-attachments/assets/02f12af3-6a40-4855-83fd-3756fc5d23f9" />


## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to retrieve the topic for a specific date in the user calendar.
  * Users now receive topic details (in Korean and English) and the remaining time until the topic deadline.
  * Improved error handling with a specific message when a topic is not found for the given date.

* **Bug Fixes**
  * Enhanced validation to prevent requests for topics on future dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->