### PR TITLE
[feat] #33 북마크 지정/해제 API

### DIFF
--- a/src/main/java/org/hilingual/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/hilingual/advice/GlobalExceptionHandler.java
@@ -12,6 +12,8 @@ import org.hilingual.domain.token.api.exception.JwtBaseException;
 import org.hilingual.external.openai.exception.OpenAiBaseException;
 import org.hilingual.external.s3.exception.S3BaseException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
@@ -77,6 +79,26 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<BaseResponseDto<Void>> handleConstraintViolation(ConstraintViolationException e) {
         log.warn("[ConstraintViolationException] {}", e.getMessage(), e);
+
+        return ResponseEntity
+                .status(GlobalErrorCode.INVALID_INPUT_VALUE.getHttpStatus())
+                .body(BaseResponseDto.fail(GlobalErrorCode.INVALID_INPUT_VALUE));
+    }
+
+    //  JSON 요청 바디가 비어있거나, 잘못된 형식일 때
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<BaseResponseDto<Void>> handleHttpMessageNotReadable(HttpMessageNotReadableException e) {
+        log.error("[HttpMessageNotReadableException] message: {}", e.getMessage(), e);
+
+        return ResponseEntity
+                .status(GlobalErrorCode.INVALID_INPUT_VALUE.getHttpStatus())
+                .body(BaseResponseDto.fail(GlobalErrorCode.INVALID_INPUT_VALUE));
+    }
+
+    // 지원하지 않는 Content-Type으로 요청할 때
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    public ResponseEntity<BaseResponseDto<Void>> handleHttpMediaTypeNotSupported(HttpMediaTypeNotSupportedException e) {
+        log.error("[HttpMediaTypeNotSupportedException] message: {}", e.getMessage(), e);
 
         return ResponseEntity
                 .status(GlobalErrorCode.INVALID_INPUT_VALUE.getHttpStatus())

--- a/src/main/java/org/hilingual/common/exception/code/GlobalErrorCode.java
+++ b/src/main/java/org/hilingual/common/exception/code/GlobalErrorCode.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum GlobalErrorCode implements ErrorCode {
     // 400
-    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, 40000, "잘못된 요청 값입니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, 40000, "비어있거나 잘못된 요청 값입니다."),
 
     // 401
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 40100, "인증되지 않은 사용자입니다."),

--- a/src/main/java/org/hilingual/domain/recommend/api/controller/RecommendController.java
+++ b/src/main/java/org/hilingual/domain/recommend/api/controller/RecommendController.java
@@ -1,7 +1,9 @@
 package org.hilingual.domain.recommend.api.controller;
 
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import org.hilingual.domain.recommend.api.dto.req.BookmarkRequest;
 import org.hilingual.domain.recommend.api.dto.res.RecommendList;
 import org.hilingual.domain.recommend.api.service.RecommendService;
 import org.springframework.http.ResponseEntity;
@@ -24,4 +26,12 @@ public class RecommendController {
         return ResponseEntity.ok(recommendService.getRecommendList(1L, diaryId));
     }
 
+    @PatchMapping("/v1/diaries/{phraseId}")
+    public ResponseEntity<Void> bookMark(
+            // @RequestHeader("Authorization") Long userId // TODO 소셜 로그인 연동
+            @PathVariable @Validated @Min(1) Long phraseId,
+            @RequestBody @NotNull BookmarkRequest bookmarkRequest
+    ){
+        return ResponseEntity.ok(recommendService.bookMark(1L, phraseId, bookmarkRequest.isBookmarked()));
+    }
 }

--- a/src/main/java/org/hilingual/domain/recommend/api/dto/req/BookmarkRequest.java
+++ b/src/main/java/org/hilingual/domain/recommend/api/dto/req/BookmarkRequest.java
@@ -1,0 +1,6 @@
+package org.hilingual.domain.recommend.api.dto.req;
+
+public record BookmarkRequest(
+        boolean isBookmarked
+) {
+}

--- a/src/main/java/org/hilingual/domain/recommend/api/exception/RecommendBaseException.java
+++ b/src/main/java/org/hilingual/domain/recommend/api/exception/RecommendBaseException.java
@@ -1,0 +1,16 @@
+package org.hilingual.domain.recommend.api.exception;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.hilingual.common.exception.base.HilingualBaseException;
+import org.hilingual.common.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class RecommendBaseException extends HilingualBaseException {
+
+    private final ErrorCode errorCode;
+    public abstract HttpStatus getStatus();
+}

--- a/src/main/java/org/hilingual/domain/recommend/api/service/RecommendService.java
+++ b/src/main/java/org/hilingual/domain/recommend/api/service/RecommendService.java
@@ -1,11 +1,18 @@
 package org.hilingual.domain.recommend.api.service;
 
 import lombok.RequiredArgsConstructor;
+import org.hilingual.domain.diary.core.facade.DiaryRetriever;
 import org.hilingual.domain.diaryfeedback.core.facade.DiaryValidator;
 import org.hilingual.domain.recommend.api.dto.res.RecommendList;
 import org.hilingual.domain.recommend.core.domain.Recommend;
 import org.hilingual.domain.recommend.core.facade.RecommendRetriever;
 import org.hilingual.domain.recommend.core.facade.RecommendSaver;
+import org.hilingual.domain.user.core.domain.User;
+import org.hilingual.domain.user.core.facade.UserRetriever;
+import org.hilingual.domain.voca.core.domain.Voca;
+import org.hilingual.domain.voca.core.facade.VocaRemover;
+import org.hilingual.domain.voca.core.facade.VocaRetriever;
+import org.hilingual.domain.voca.core.facade.VocaSaver;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +28,10 @@ public class RecommendService {
     private final RecommendSaver recommendSaver;
     private final RecommendRetriever recommendRetriever;
     private final DiaryValidator diaryValidator;
+    private final VocaRetriever vocaRetriever;
+    private final VocaRemover vocaRemover;
+    private final VocaSaver vocaSaver;
+    private final UserRetriever userRetriever;
 
     @Transactional
     public void saveRecommend(Recommend recommend) {
@@ -42,6 +53,22 @@ public class RecommendService {
                         ))
                         .collect(Collectors.toList());
         return new RecommendList(phrases);
+    }
+
+    @Transactional(readOnly = false)
+    public Void bookMark(final long userId, final long phraseId, final boolean isBookMarked){
+        Recommend recommend = recommendRetriever.findById(phraseId);
+        User user = userRetriever.findByUserId(userId);
+        recommend.updateMarkStatus(isBookMarked);
+
+        if (isBookMarked) {
+            Voca voca = new Voca(user, recommend);
+            vocaSaver.saveIfNotExists(voca);
+        } else {
+            vocaRemover.delete(user, recommend);
+        }
+
+        return null;
     }
 
     private List<String> parsePhraseType(String phraseType) {

--- a/src/main/java/org/hilingual/domain/recommend/core/domain/Recommend.java
+++ b/src/main/java/org/hilingual/domain/recommend/core/domain/Recommend.java
@@ -45,4 +45,7 @@ public class Recommend extends BaseTimeEntity {
         return new Recommend(null, phrase, phraseType, explanation, false, reason, diary);
     }
 
+    public void updateMarkStatus(boolean isMarked) {
+        this.isMarked = isMarked;
+    }
 }

--- a/src/main/java/org/hilingual/domain/recommend/core/exception/RecommendCoreErrorCode.java
+++ b/src/main/java/org/hilingual/domain/recommend/core/exception/RecommendCoreErrorCode.java
@@ -1,0 +1,32 @@
+package org.hilingual.domain.recommend.core.exception;
+
+import lombok.RequiredArgsConstructor;
+import org.hilingual.common.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum RecommendCoreErrorCode implements ErrorCode {
+
+    // 404
+    RECOMMEND_NOT_FOUND(HttpStatus.NOT_FOUND, 40403, "id 해당하는 추천표현이 없습니다."),
+    ;
+
+    public final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus(){
+        return httpStatus;
+    }
+
+    @Override
+    public int getCode(){
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/org/hilingual/domain/recommend/core/exception/RecommendCoreException.java
+++ b/src/main/java/org/hilingual/domain/recommend/core/exception/RecommendCoreException.java
@@ -1,0 +1,10 @@
+package org.hilingual.domain.recommend.core.exception;
+
+import org.hilingual.common.exception.code.ErrorCode;
+import org.hilingual.domain.recommend.api.exception.RecommendBaseException;
+
+public abstract class RecommendCoreException extends RecommendBaseException {
+    protected RecommendCoreException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/hilingual/domain/recommend/core/exception/RecommendNotFoundException.java
+++ b/src/main/java/org/hilingual/domain/recommend/core/exception/RecommendNotFoundException.java
@@ -1,0 +1,15 @@
+package org.hilingual.domain.recommend.core.exception;
+
+import org.hilingual.common.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class RecommendNotFoundException extends RecommendCoreException{
+    public RecommendNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.NOT_FOUND;
+    }
+}

--- a/src/main/java/org/hilingual/domain/recommend/core/facade/RecommendRetriever.java
+++ b/src/main/java/org/hilingual/domain/recommend/core/facade/RecommendRetriever.java
@@ -2,6 +2,8 @@ package org.hilingual.domain.recommend.core.facade;
 
 import lombok.RequiredArgsConstructor;
 import org.hilingual.domain.recommend.core.domain.Recommend;
+import org.hilingual.domain.recommend.core.exception.RecommendCoreErrorCode;
+import org.hilingual.domain.recommend.core.exception.RecommendNotFoundException;
 import org.hilingual.domain.recommend.core.repository.RecommendRepository;
 import org.springframework.stereotype.Component;
 
@@ -17,4 +19,8 @@ public class RecommendRetriever {
         return recommendRepository.findByDiaryId(diaryId);
     }
 
+    public Recommend findById(final long phraseId){
+        return recommendRepository.findById(phraseId)
+                .orElseThrow(()-> new RecommendNotFoundException(RecommendCoreErrorCode.RECOMMEND_NOT_FOUND));
+    }
 }

--- a/src/main/java/org/hilingual/domain/voca/core/domain/Voca.java
+++ b/src/main/java/org/hilingual/domain/voca/core/domain/Voca.java
@@ -30,4 +30,9 @@ public class Voca extends BaseTimeEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = COLUMN_RECOMMEND_ID, nullable = false, unique = true)
     private Recommend recommend;
+
+    public Voca(User user, Recommend recommend) {
+        this.user = user;
+        this.recommend = recommend;
+    }
 }

--- a/src/main/java/org/hilingual/domain/voca/core/facade/VocaRemover.java
+++ b/src/main/java/org/hilingual/domain/voca/core/facade/VocaRemover.java
@@ -1,0 +1,20 @@
+package org.hilingual.domain.voca.core.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.hilingual.domain.recommend.core.domain.Recommend;
+import org.hilingual.domain.user.core.domain.User;
+import org.hilingual.domain.voca.core.repository.VocaRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class VocaRemover {
+
+    private final VocaRepository vocaRepository;
+
+    @Transactional
+    public void delete(final User user, final Recommend recommend) {
+        vocaRepository.deleteByUserAndRecommend(user, recommend);
+    }
+}

--- a/src/main/java/org/hilingual/domain/voca/core/facade/VocaSaver.java
+++ b/src/main/java/org/hilingual/domain/voca/core/facade/VocaSaver.java
@@ -1,0 +1,26 @@
+package org.hilingual.domain.voca.core.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.hilingual.domain.voca.core.domain.Voca;
+import org.hilingual.domain.voca.core.repository.VocaRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class VocaSaver {
+
+    private final VocaRepository vocaRepository;
+
+    @Transactional
+    public void saveIfNotExists(final Voca voca) {
+        boolean exists = vocaRepository.existsByUserAndRecommend(
+                voca.getUser(),
+                voca.getRecommend()
+        );
+
+        if (!exists) {
+            vocaRepository.save(voca);
+        }
+    }
+}

--- a/src/main/java/org/hilingual/domain/voca/core/repository/VocaRepository.java
+++ b/src/main/java/org/hilingual/domain/voca/core/repository/VocaRepository.java
@@ -1,14 +1,21 @@
 package org.hilingual.domain.voca.core.repository;
 
+import org.hilingual.domain.recommend.core.domain.Recommend;
+import org.hilingual.domain.user.core.domain.User;
 import org.hilingual.domain.voca.core.domain.Voca;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
-public interface VocaRepository extends Repository<Voca, Long> {
+public interface VocaRepository extends JpaRepository<Voca, Long> {
+
+    void deleteByUserAndRecommend(User user, Recommend recommend);
+
+    boolean existsByUserAndRecommend(User user, Recommend recommend);
+
 
     // AZ순 정렬 (Recommend.phrase 기반)
     @Query("""


### PR DESCRIPTION
## Related issue 🛠  
- closed #33  

## Work Description ✏️  
- 추천 표현(Recommend)에 대해 북마크 지정/해제할 수 있는 API 구현  
- 북마크 지정 시 Voca 테이블에 (user, recommend) 데이터 저장, 중복 저장 방지  
- 북마크 해제 시 Voca 테이블에서 해당 데이터 삭제  

## Screenshot 📸  
| 설명 | 사진 |
|:--:|:--:|
| 북마크 true 요청 | <img width="835" height="502" alt="image" src="https://github.com/user-attachments/assets/279a7669-c21c-4569-89c1-8b772415be30" /> |
| 북마크 true 결과 | <img width="1454" height="210" alt="image" src="https://github.com/user-attachments/assets/59cb6b7c-68c7-4d45-b269-9aa7f3131b26" /> |
| 북마크 false 요청 | <img width="880" height="513" alt="image" src="https://github.com/user-attachments/assets/aa9ac9d8-31e4-4799-8b4f-4d76d9624e2f" /> |
| 북마크 false 결과 | <img width="1437" height="212" alt="image" src="https://github.com/user-attachments/assets/bcaedd2b-39a4-41fd-bb82-5aae507702b4" /> |

## Uncompleted Tasks 😅  
- 소셜 로그인 연동 예정  

## To Reviewers 📢  
N/A