### PR TITLE
[fix] #60 일기 소유 권한 403 에러코드로 수정

### DIFF
--- a/src/main/java/org/hilingual/domain/diary/core/exception/DiaryCoreErrorCode.java
+++ b/src/main/java/org/hilingual/domain/diary/core/exception/DiaryCoreErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 public enum DiaryCoreErrorCode implements ErrorCode {
 
     // 403
-    DIARY_FORBIDDEN(HttpStatus.FORBIDDEN, 40301, "해당 유저의 일기가 아닙니다."),
+    DIARY_FORBIDDEN(HttpStatus.FORBIDDEN, 40300, "해당 유저의 일기가 아닙니다."),
 
     // 404
     DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, 40004, "id에 해당하는 일기가 존재하지 않습니다."),

--- a/src/main/java/org/hilingual/domain/diaryfeedback/core/facade/DiaryValidator.java
+++ b/src/main/java/org/hilingual/domain/diaryfeedback/core/facade/DiaryValidator.java
@@ -3,7 +3,7 @@ package org.hilingual.domain.diaryfeedback.core.facade;
 import lombok.RequiredArgsConstructor;
 import org.hilingual.domain.diary.core.domain.Diary;
 import org.hilingual.domain.diary.core.exception.DiaryCoreErrorCode;
-import org.hilingual.domain.diary.core.exception.DiaryNotFoundException;
+import org.hilingual.domain.diary.core.exception.DiaryForbiddenException;
 import org.hilingual.domain.diary.core.facade.DiaryRetriever;
 import org.springframework.stereotype.Component;
 
@@ -16,7 +16,7 @@ public class DiaryValidator {
     public void validateDiaryOwnership(final long userId, final long diaryId) {
         Diary diary = diaryRetriever.findById(diaryId);
         if (!diary.getUser().getId().equals(userId)) {
-            throw new DiaryNotFoundException(DiaryCoreErrorCode.DIARY_FORBIDDEN);
+            throw new DiaryForbiddenException(DiaryCoreErrorCode.DIARY_FORBIDDEN);
         }
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #60 

## Work Description ✏️
유저 소유 일기 검증 시 올바른 예외를 던져 404 반환을 403으로 던져지게끔 수정했습니다.