### PR TITLE
[fix] #56 단어장 도메인 응답에 isMarked 필드 추가

### DIFF
--- a/src/main/java/org/hilingual/domain/voca/api/dto/res/VocaDetailResponse.java
+++ b/src/main/java/org/hilingual/domain/voca/api/dto/res/VocaDetailResponse.java
@@ -11,7 +11,8 @@ public record VocaDetailResponse(
         String phrase,
         List<String> phraseType,
         String explanation,
-        String createdAt
+        String createdAt,
+        Boolean isMarked
 ) {
 
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yy.MM.dd");
@@ -22,7 +23,8 @@ public record VocaDetailResponse(
                 voca.getRecommend().getPhrase(),
                 parsePhraseTypes(voca.getRecommend().getPhraseType()),
                 voca.getRecommend().getExplanation(),
-                voca.getCreatedAt().format(FORMATTER)
+                voca.getCreatedAt().format(FORMATTER),
+                voca.getRecommend().getIsMarked()
         );
     }
 

--- a/src/main/java/org/hilingual/domain/voca/api/dto/res/VocaItemResponse.java
+++ b/src/main/java/org/hilingual/domain/voca/api/dto/res/VocaItemResponse.java
@@ -8,13 +8,15 @@ import java.util.List;
 public record VocaItemResponse(
         Long phraseId,
         String phrase,
-        List<String> phraseType
+        List<String> phraseType,
+        Boolean isMarked
 ) {
     public static VocaItemResponse from(final Voca voca) {
         return new VocaItemResponse(
                 voca.getRecommend().getId(),
                 voca.getRecommend().getPhrase(),
-                parsePhraseTypes(voca.getRecommend().getPhraseType())
+                parsePhraseTypes(voca.getRecommend().getPhraseType()),
+                voca.getRecommend().getIsMarked()
         );
     }
 

--- a/src/main/java/org/hilingual/domain/voca/api/dto/res/VocaSearchListResponse.java
+++ b/src/main/java/org/hilingual/domain/voca/api/dto/res/VocaSearchListResponse.java
@@ -19,13 +19,15 @@ public record VocaSearchListResponse(
     public record Item(
             Long phraseId,
             String phrase,
-            List<String> phraseType
+            List<String> phraseType,
+            Boolean isMarked
     ) {
         public static Item from(final Voca voca) {
             return new Item(
                     voca.getRecommend().getId(),
                     voca.getRecommend().getPhrase(),
-                    parsePhraseTypes(voca.getRecommend().getPhraseType())
+                    parsePhraseTypes(voca.getRecommend().getPhraseType()),
+                    voca.getRecommend().getIsMarked()
             );
         }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #56 

## Work Description ✏️
- 단어장 도메인 응답에 isMarked 필드를 추가로 내려줍니다

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
<img width="1116" height="762" alt="스크린샷 2025-07-14 오전 2 37 18" src="https://github.com/user-attachments/assets/3b2d1b5d-6736-4b68-9a97-c47f7d6fa84f" />
<img width="1132" height="909" alt="스크린샷 2025-07-14 오전 2 34 47" src="https://github.com/user-attachments/assets/26cb3a94-2ab8-4248-b1d1-bf0a4664c9ab" />
910-40c3-939e-146342909bd8" />

## Uncompleted Tasks 😅

## To Reviewers 📢
