### PR TITLE
[feat] #54 월별 조회 API 구현 및 잘못된 월 입력 형식 예외처리

### DIFF
--- a/src/main/java/org/hilingual/domain/usercalendar/api/controller/UserCalendarController.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/api/controller/UserCalendarController.java
@@ -2,7 +2,9 @@ package org.hilingual.domain.usercalendar.api.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.hilingual.domain.usercalendar.api.dto.res.UserCalendarDiarySummaryResponse;
+import org.hilingual.domain.usercalendar.api.dto.res.UserCalendarMonthlyResponse;
 import org.hilingual.domain.usercalendar.api.dto.res.UserCalendarTopicResponse;
+import org.hilingual.domain.usercalendar.api.exception.InvalidMonthException;
 import org.hilingual.domain.usercalendar.api.exception.UserCalendarApiErrorCode;
 import org.hilingual.domain.usercalendar.api.exception.UserCalendarInvalidDateFormatException;
 import org.hilingual.domain.usercalendar.api.service.UserCalendarService;
@@ -49,4 +51,18 @@ public class UserCalendarController {
 
         return ResponseEntity.ok(userCalendarService.getTopicByDate(parsedDate, userId));
     }
+
+    @GetMapping("/month")
+    public ResponseEntity<UserCalendarMonthlyResponse> getMonthlyCalendar(
+            @RequestParam final int year,
+            @RequestParam final int month
+    ) {
+        final Long userId = 1L; // TODO: 인증 연동 후 교체
+
+        if (month < 1 || month > 12) {
+            throw new InvalidMonthException(UserCalendarApiErrorCode.INVALID_MONTH);
+        }
+        return ResponseEntity.ok(userCalendarService.getWrittenDatesOfMonth(userId, year, month));
+    }
+
 }

--- a/src/main/java/org/hilingual/domain/usercalendar/api/dto/res/UserCalendarMonthlyResponse.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/api/dto/res/UserCalendarMonthlyResponse.java
@@ -1,0 +1,16 @@
+package org.hilingual.domain.usercalendar.api.dto.res;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record UserCalendarMonthlyResponse(
+        List<DateDto> dateList
+) {
+    public static UserCalendarMonthlyResponse from(List<LocalDate> dates) {
+        return new UserCalendarMonthlyResponse(
+                dates.stream().map(DateDto::new).toList()
+        );
+    }
+
+    public record DateDto(LocalDate date) {}
+}

--- a/src/main/java/org/hilingual/domain/usercalendar/api/exception/InvalidMonthException.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/api/exception/InvalidMonthException.java
@@ -1,0 +1,15 @@
+package org.hilingual.domain.usercalendar.api.exception;
+
+import org.hilingual.common.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class InvalidMonthException extends UserCalendarApiException {
+    public InvalidMonthException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/src/main/java/org/hilingual/domain/usercalendar/api/exception/UserCalendarApiErrorCode.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/api/exception/UserCalendarApiErrorCode.java
@@ -9,7 +9,10 @@ public enum UserCalendarApiErrorCode implements ErrorCode {
 
     // 400
     FUTURE_DATE_NOT_ALLOWED(HttpStatus.BAD_REQUEST,40009, "미래 날짜에 대한 요청은 허용되지 않습니다."),
-    INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST,40010, "날짜 형식이 올바르지 않습니다. yyyy-MM-dd 형식이어야 합니다.");
+    INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST,40010, "날짜 형식이 올바르지 않습니다. yyyy-MM-dd 형식이어야 합니다."),
+    INVALID_MONTH(HttpStatus.BAD_REQUEST, 40011, "유효하지 않은 월(month) 값입니다. 1부터 12 사이여야 합니다.");
+
+
 
     private final HttpStatus httpStatus;
     private final int code;

--- a/src/main/java/org/hilingual/domain/usercalendar/api/service/UserCalendarService.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/api/service/UserCalendarService.java
@@ -2,6 +2,7 @@ package org.hilingual.domain.usercalendar.api.service;
 
 import lombok.RequiredArgsConstructor;
 import org.hilingual.domain.usercalendar.api.dto.res.UserCalendarDiarySummaryResponse;
+import org.hilingual.domain.usercalendar.api.dto.res.UserCalendarMonthlyResponse;
 import org.hilingual.domain.usercalendar.api.dto.res.UserCalendarTopicResponse;
 import org.hilingual.domain.usercalendar.api.exception.FutureDateNotAllowedException;
 import org.hilingual.domain.usercalendar.api.exception.UserCalendarApiErrorCode;
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -30,6 +32,11 @@ public class UserCalendarService {
             throw new FutureDateNotAllowedException(UserCalendarApiErrorCode.FUTURE_DATE_NOT_ALLOWED);
         }
         return userCalendarRetriever.findTopicByDate(date);
+    }
+
+    public UserCalendarMonthlyResponse getWrittenDatesOfMonth(final Long userId, final int year, final int month) {
+        List<LocalDate> writtenDates = userCalendarRetriever.findWrittenDatesByMonth(userId, year, month);
+        return UserCalendarMonthlyResponse.from(writtenDates);
     }
 
 }

--- a/src/main/java/org/hilingual/domain/usercalendar/core/facade/UserCalendarRetriever.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/core/facade/UserCalendarRetriever.java
@@ -9,12 +9,14 @@ import org.hilingual.domain.usercalendar.api.dto.res.UserCalendarTopicResponse;
 import org.hilingual.domain.usercalendar.api.exception.UserCalendarDiaryNotFoundException;
 import org.hilingual.domain.usercalendar.core.exception.UserCalendarCoreErrorCode;
 import org.hilingual.domain.usercalendar.core.exception.UserCalendarTopicNotFoundException;
+import org.hilingual.domain.usercalendar.core.repository.UserCalendarRepository;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -67,5 +69,9 @@ public class UserCalendarRetriever {
             return (int) Math.ceil(secondsRemaining / 60.0);
         }
     }
+    private final UserCalendarRepository userCalendarRepository;
 
+    public List<LocalDate> findWrittenDatesByMonth(final Long userId, final int year, final int month) {
+        return userCalendarRepository.findWrittenDatesByUserIdAndYearAndMonth(userId, year, month);
+    }
 }

--- a/src/main/java/org/hilingual/domain/usercalendar/core/repository/UserCalendarRepository.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/core/repository/UserCalendarRepository.java
@@ -1,0 +1,25 @@
+package org.hilingual.domain.usercalendar.core.repository;
+
+import org.hilingual.domain.usercalendar.core.domain.UserCalendar;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface UserCalendarRepository extends Repository<UserCalendar, LocalDate> {
+
+    @Query("""
+        SELECT uc.date FROM UserCalendar uc
+        WHERE uc.user.id = :userId
+          AND uc.isWritten = true
+          AND YEAR(uc.date) = :year
+          AND MONTH(uc.date) = :month
+    """)
+    List<LocalDate> findWrittenDatesByUserIdAndYearAndMonth(
+            @Param("userId") Long userId,
+            @Param("year") int year,
+            @Param("month") int month
+    );
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #54 

## Work Description ✏️
- UserCalendar 월별 조회 API (`GET /api/v1/calendar/month`) 추가  
  - 유저가 특정 연도/월에 작성한 일기 날짜 리스트 응답  
  - 작성된 날짜만 필터링하여 반환 (`is_written = true`)  
- 월 유효성 검증 로직 추가 (1~12 범위 체크) 

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----
<img width="1118" height="939" alt="스크린샷 2025-07-14 오전 3 43 07" src="https://github.com/user-attachments/assets/7aba1cb1-937a-4a96-b16f-55f031f67bc0" />
------:|
<img width="1145" height="649" alt="스크린샷 2025-07-14 오전 3 43 23" src="https://github.com/user-attachments/assets/6f9a6f14-3e72-43ea-8116-af56adc5a8d5" />


