### PR TITLE
[fix] #71 특정 단어 세부내용 조회 API 에서 phraseId 로 조회할 수 있도록 변경

### DIFF
--- a/src/main/java/org/hilingual/domain/voca/api/controller/VocaController.java
+++ b/src/main/java/org/hilingual/domain/voca/api/controller/VocaController.java
@@ -50,12 +50,12 @@ public class VocaController {
         return ResponseEntity.ok(vocaService.searchVocaList(userId, keyword.trim()));
     }
 
-    @GetMapping("/{vocaId}")
-    public ResponseEntity<VocaDetailResponse> getVocaDetail(
-            @PathVariable final Long vocaId
+    @GetMapping("/{phraseId}")
+    public ResponseEntity<VocaDetailResponse> getVocaDetails(
+            @PathVariable final Long phraseId
     ) {
         final Long userId = 1L; // TODO: 로그인 연동 후 수정
-        return ResponseEntity.ok(vocaService.getVocaDetail(userId, vocaId));
+        return ResponseEntity.ok(vocaService.getVocaDetails(userId, phraseId));
     }
 
 }

--- a/src/main/java/org/hilingual/domain/voca/api/service/VocaService.java
+++ b/src/main/java/org/hilingual/domain/voca/api/service/VocaService.java
@@ -30,8 +30,8 @@ public class VocaService {
     }
 
     //특정 단어 세부 조회
-    public VocaDetailResponse getVocaDetail(final Long userId, final Long vocaId) {
-        final Voca voca = vocaRetriever.findByUserIdAndVocaId(userId, vocaId);
+    public VocaDetailResponse getVocaDetails(final Long userId, final Long phraseId) {
+        final Voca voca = vocaRetriever.findByUserIdAndPhraseId(userId, phraseId);
         return VocaDetailResponse.from(voca);
     }
 

--- a/src/main/java/org/hilingual/domain/voca/core/exception/VocaCoreErrorCode.java
+++ b/src/main/java/org/hilingual/domain/voca/core/exception/VocaCoreErrorCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum VocaCoreErrorCode implements ErrorCode {
 
-    VOCA_NOT_FOUND(HttpStatus.NOT_FOUND, 40404, "vocaId에 해당하는 단어가 없습니다");
+    VOCA_NOT_FOUND(HttpStatus.NOT_FOUND, 40404, "phraseId에 해당하는 단어가 없습니다");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/hilingual/domain/voca/core/facade/VocaRetriever.java
+++ b/src/main/java/org/hilingual/domain/voca/core/facade/VocaRetriever.java
@@ -42,10 +42,9 @@ public class VocaRetriever {
     }
 
 
-    public Voca findByUserIdAndVocaId(final Long userId, final Long vocaId) {
-        return vocaRepository.findByIdAndUserId(vocaId, userId)
+    public Voca findByUserIdAndPhraseId(final Long userId, final Long phraseId) {
+        return vocaRepository.findByPhraseIdAndUserId(phraseId, userId)
                 .orElseThrow(() -> new VocaNotFoundException(VocaCoreErrorCode.VOCA_NOT_FOUND));
     }
-
 
 }

--- a/src/main/java/org/hilingual/domain/voca/core/repository/VocaRepository.java
+++ b/src/main/java/org/hilingual/domain/voca/core/repository/VocaRepository.java
@@ -50,9 +50,9 @@ public interface VocaRepository extends JpaRepository<Voca, Long> {
     @Query("""
     SELECT v FROM Voca v
     JOIN FETCH v.recommend r
-    WHERE v.id = :vocaId
+    WHERE r.id = :phraseId
       AND v.user.id = :userId
 """)
-    Optional<Voca> findByIdAndUserId(@Param("vocaId") Long vocaId, @Param("userId") Long userId);
+    Optional<Voca> findByPhraseIdAndUserId(@Param("phraseId") Long phraseId, @Param("userId") Long userId);
 }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #71 

## Work Description ✏️
/api/v1/voca/{vocaId} → /api/v1/voca/{phraseId} 로 API 경로 변경
- 기존에는 vocaId(단어장 PK)를 기준으로 단어장 상세 조회를 구현했으나, 실제 서비스에서 의미 있는 식별자는 phraseId(추천 표현의 ID)임
- vocaId 기준이라면 단어장 목록 조회 시에도 굳이 vocaId와 phraseId를 함께 내려줘야 하는 불편함이 생김
- 단어장 관리에서 vocaId는 단순히 테이블 저장 순서에 불과하므로, 클라이언트 입장에서 유의미하지 않음
=> 따라서 단일 식별자로서 phraseId만 사용하는 것이 더 직관적이고 설계적으로도 적절하다고 판단

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
|        단어장 목록 조회 결과    | <img width="1087" height="786" alt="image" src="https://github.com/user-attachments/assets/317b6a28-cc89-42b5-95d1-77d3fd2b95b6" /> |
| 단어장에서 phraseId 가 1인 단어 세부조회 결과  | <img width="1089" height="707" alt="image" src="https://github.com/user-attachments/assets/65ddb4e9-f5aa-4392-b8a9-baa2c932f9b9" />|
