### PR TITLE
[fix] #75 북마크 표시 isBookmarked 로 네이밍 통일

### DIFF
--- a/src/main/java/org/hilingual/domain/recommend/api/service/RecommendService.java
+++ b/src/main/java/org/hilingual/domain/recommend/api/service/RecommendService.java
@@ -1,7 +1,6 @@
 package org.hilingual.domain.recommend.api.service;
 
 import lombok.RequiredArgsConstructor;
-import org.hilingual.domain.diary.core.facade.DiaryRetriever;
 import org.hilingual.domain.diaryfeedback.core.facade.DiaryValidator;
 import org.hilingual.domain.recommend.api.dto.res.RecommendList;
 import org.hilingual.domain.recommend.core.domain.Recommend;
@@ -49,7 +48,7 @@ public class RecommendService {
                                 r.getPhrase(),
                                 r.getExplanation(),
                                 r.getReason(),
-                                r.getIsMarked()
+                                r.getIsBookmarked()
                         ))
                         .collect(Collectors.toList());
         return new RecommendList(phrases);

--- a/src/main/java/org/hilingual/domain/recommend/core/domain/Recommend.java
+++ b/src/main/java/org/hilingual/domain/recommend/core/domain/Recommend.java
@@ -31,8 +31,8 @@ public class Recommend extends BaseTimeEntity {
     @Column(name = COLUMN_EXPLANATION, nullable = false)
     private String explanation;
 
-    @Column(name = COLUMN_IS_MARKED, nullable = false)
-    private Boolean isMarked;
+    @Column(name = COLUMN_IS_BOOKMARKED, nullable = false)
+    private Boolean isBookmarked;
 
     @Column(name = COLUMN_REASON, nullable = false)
     private String reason;
@@ -45,7 +45,7 @@ public class Recommend extends BaseTimeEntity {
         return new Recommend(null, phrase, phraseType, explanation, false, reason, diary);
     }
 
-    public void updateMarkStatus(boolean isMarked) {
-        this.isMarked = isMarked;
+    public void updateMarkStatus(boolean isBookmarked) {
+        this.isBookmarked = isBookmarked;
     }
 }

--- a/src/main/java/org/hilingual/domain/recommend/core/domain/RecommendTableConstants.java
+++ b/src/main/java/org/hilingual/domain/recommend/core/domain/RecommendTableConstants.java
@@ -6,7 +6,7 @@ public class RecommendTableConstants {
     public static final String COLUMN_PHRASE = "phrase";
     public static final String COLUMN_PHRASE_TYPE = "phrase_type";
     public static final String COLUMN_EXPLANATION = "explanation";
-    public static final String COLUMN_IS_MARKED = "is_marked";
+    public static final String COLUMN_IS_BOOKMARKED = "is_bookmarked";
     public static final String COLUMN_REASON = "reason";
     public static final String COLUMN_DIARY_ID = "diary_id";
 }

--- a/src/main/java/org/hilingual/domain/voca/api/dto/res/VocaDetailResponse.java
+++ b/src/main/java/org/hilingual/domain/voca/api/dto/res/VocaDetailResponse.java
@@ -12,7 +12,7 @@ public record VocaDetailResponse(
         List<String> phraseType,
         String explanation,
         String createdAt,
-        Boolean isMarked
+        Boolean isBookmarked
 ) {
 
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yy.MM.dd");
@@ -24,7 +24,7 @@ public record VocaDetailResponse(
                 parsePhraseTypes(voca.getRecommend().getPhraseType()),
                 voca.getRecommend().getExplanation(),
                 voca.getCreatedAt().format(FORMATTER),
-                voca.getRecommend().getIsMarked()
+                voca.getRecommend().getIsBookmarked()
         );
     }
 

--- a/src/main/java/org/hilingual/domain/voca/api/dto/res/VocaItemResponse.java
+++ b/src/main/java/org/hilingual/domain/voca/api/dto/res/VocaItemResponse.java
@@ -9,14 +9,14 @@ public record VocaItemResponse(
         Long phraseId,
         String phrase,
         List<String> phraseType,
-        Boolean isMarked
+        Boolean isBookmarked
 ) {
     public static VocaItemResponse from(final Voca voca) {
         return new VocaItemResponse(
                 voca.getRecommend().getId(),
                 voca.getRecommend().getPhrase(),
                 parsePhraseTypes(voca.getRecommend().getPhraseType()),
-                voca.getRecommend().getIsMarked()
+                voca.getRecommend().getIsBookmarked()
         );
     }
 

--- a/src/main/java/org/hilingual/domain/voca/api/dto/res/VocaSearchListResponse.java
+++ b/src/main/java/org/hilingual/domain/voca/api/dto/res/VocaSearchListResponse.java
@@ -20,14 +20,14 @@ public record VocaSearchListResponse(
             Long phraseId,
             String phrase,
             List<String> phraseType,
-            Boolean isMarked
+            Boolean isBookmarked
     ) {
         public static Item from(final Voca voca) {
             return new Item(
                     voca.getRecommend().getId(),
                     voca.getRecommend().getPhrase(),
                     parsePhraseTypes(voca.getRecommend().getPhraseType()),
-                    voca.getRecommend().getIsMarked()
+                    voca.getRecommend().getIsBookmarked()
             );
         }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,6 +50,9 @@ spring:
             token-uri: https://appleid.apple.com/auth/token
             jwk-set-uri: https://appleid.apple.com/auth/keys
             user-name-attribute: sub
+  jackson:
+    deserialization:
+      fail-on-unknown-properties: true
 
 apple:
   oauth:
@@ -70,7 +73,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,prometheus
+        include: health,info
   endpoint:
     health:
       show-details: always


### PR DESCRIPTION
## Related issue 🛠
- closed #75 

## Work Description ✏️
- application.yml 에 아래와 같은 설정 추가
```
spring:
   jackson:
    deserialization:
      fail-on-unknown-properties: true
```
원래 isBookmarked만 동작해야 하는데, isMarked도 요청이 200으로 내려오는 문제가 발생! (정상 작동은 안함)
이유를 알아보았더니.. Jackson이 자동으로 연관성을 판단해서 매핑하려고 시도했기 때문이었다!!!!
그래서 설정을 추가해주니 isBookmarked 외에 다른 요청 바디가 전달되면 400이 내려옴~

- 단어장 목록 조회 API와 특정 단어 세부내용 조회 API 의 isMarked를 isBookmarked로 변경 및 통일

## Screenshot 📸
N/A

## Uncompleted Tasks 😅
아직 "단어장 목록 조회 API" 명세서에는 해당 변경사항 아직 업데이트 안되어있습니다.
@Sihun23 반영해주세요~~!!