### PR TITLE
[fix] #77 Diary 엔티티에 writtenDate 필드 추가

### DIFF
--- a/src/main/java/org/hilingual/domain/diary/api/controller/DiaryController.java
+++ b/src/main/java/org/hilingual/domain/diary/api/controller/DiaryController.java
@@ -12,6 +12,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -23,12 +25,14 @@ public class DiaryController {
     public ResponseEntity<DiaryDto> getFeedbacks(
             // @RequestHeader("Authorization") Long userId,
             @RequestPart("originalText") String originalText,
+            @RequestPart("date") String date,
             @RequestPart(value = "imageFile", required = false) MultipartFile imageFile
     ) {
         if(originalText.length() < 10){
             throw new DiaryContentTooShortException(DiaryApiErrorCode.DIARY_TOO_SHORT);
         }
-        return ResponseEntity.ok(diaryService.getFeedbacks(1L, originalText, imageFile));
+        LocalDate writtenDate = LocalDate.parse(date);
+        return ResponseEntity.ok(diaryService.getFeedbacks(1L, originalText, writtenDate, imageFile));
     }
 
     @GetMapping("/v1/diaries/{diaryId}")

--- a/src/main/java/org/hilingual/domain/diary/api/service/DiaryService.java
+++ b/src/main/java/org/hilingual/domain/diary/api/service/DiaryService.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +44,7 @@ public class DiaryService {
     private final DiaryValidator diaryValidator;
 
     @Transactional
-    public DiaryDto getFeedbacks(Long userId, String originalText, MultipartFile imageFile) {
+    public DiaryDto getFeedbacks(Long userId, String originalText, LocalDate writtenDate, MultipartFile imageFile) {
         String imageUrl = null;
         if (imageFile != null && !imageFile.isEmpty()) {
             imageUrl = s3Service.uploadImage("diaries", imageFile);
@@ -56,7 +57,7 @@ public class DiaryService {
         List<Map<String, Object>> phraseList = (List<Map<String, Object>>) aiResponse.get("phraseList");
 
         User user = userService.findById(userId);
-        Diary diary = diarySaver.save(user, originalText, rewriteText, imageUrl);
+        Diary diary = diarySaver.save(user, originalText, rewriteText, imageUrl, writtenDate);
 
         feedbackList.stream()
                 .map(f -> DiaryFeedback.create(

--- a/src/main/java/org/hilingual/domain/diary/core/domain/Diary.java
+++ b/src/main/java/org/hilingual/domain/diary/core/domain/Diary.java
@@ -10,6 +10,7 @@ import org.hilingual.domain.diaryfeedback.core.domain.DiaryFeedback;
 import org.hilingual.domain.recommend.core.domain.Recommend;
 import org.hilingual.domain.user.core.domain.User;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.hilingual.domain.diary.core.domain.DiaryTableConstants.*;
@@ -35,6 +36,9 @@ public class Diary extends BaseTimeEntity {
     @Column(name = COLUMN_IMAGE_URL)
     private String imageUrl;
 
+    @Column(name = COLUMN_WRITTEN_DATE)
+    private LocalDate writtenDate;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = COLUMN_USER_ID, nullable = false)
     private User user;
@@ -45,8 +49,8 @@ public class Diary extends BaseTimeEntity {
     @OneToMany(mappedBy = "diary", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Recommend> recommends;
 
-    public static Diary create(User user, String originalText, String rewriteText, String imageUrl) {
-        return new Diary(null, originalText, rewriteText, imageUrl, user, null, null);
+    public static Diary create(User user, String originalText, String rewriteText, String imageUrl, LocalDate writtenDate) {
+        return new Diary(null, originalText, rewriteText, imageUrl, writtenDate, user, null, null);
     }
 
 }

--- a/src/main/java/org/hilingual/domain/diary/core/domain/DiaryTableConstants.java
+++ b/src/main/java/org/hilingual/domain/diary/core/domain/DiaryTableConstants.java
@@ -6,5 +6,6 @@ public class DiaryTableConstants {
     public static final String COLUMN_ORIGINAL_TEXT = "original_text";
     public static final String COLUMN_REWRITE_TEXT = "rewrite_text";
     public static final String COLUMN_IMAGE_URL = "image_url";
+    public static final String COLUMN_WRITTEN_DATE = "written_date";
     public static final String COLUMN_USER_ID = "user_id";
 }

--- a/src/main/java/org/hilingual/domain/diary/core/facade/DiarySaver.java
+++ b/src/main/java/org/hilingual/domain/diary/core/facade/DiarySaver.java
@@ -8,6 +8,8 @@ import org.hilingual.domain.userprofile.core.facade.UserProfileUpdater;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+
 @Component
 @RequiredArgsConstructor
 public class DiarySaver {
@@ -15,19 +17,19 @@ public class DiarySaver {
     private final DiaryRepository diaryRepository;
     private final UserProfileUpdater userProfileUpdater;
 
-
     @Transactional
-    public Diary save(final User user,
-                      final String originalText,
-                      final String rewriteText,
-                      final String imageUrl) {
+    public Diary save(
+            final User user,
+            final String originalText,
+            final String rewriteText,
+            final String imageUrl,
+            final LocalDate writtenDate
+    ) {
 
-        Diary diary = Diary.create(user, originalText, rewriteText, imageUrl);
-
+        Diary diary = Diary.create(user, originalText, rewriteText, imageUrl, writtenDate);
         Diary savedDiary = diaryRepository.save(diary);
 
         userProfileUpdater.updateDiaryStats(user.getId());
-
         return savedDiary;
     }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #77 

## Work Description ✏️
일기 피드백 요청 API 의 Request 로 date(일기 작성을 원하는 날짜)를 추가하고,
Diary 도메인 엔티티에 writtenDate 필드를 추가했습니다.

7.14일날 어제인 7.13일 일기를 썼을 때, 이 일기는 생성일(createdAt)과 별개로 7.13일(writtenDate)의 일기임을 명확히 해야합니다.
이는 추후 단어 세부내용 조회 API 에서 "25.07.15 저장됨" 과 같이 띄워주는 곳에서 사용하게 됩니당!
추천 표현을 북마크 한 경우, 북마크한 날짜가 아니라 어떤 일기에서 만들어진 북마크인지를 보여주는 것이므로.

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
|        7.14에 7.13(어제) 일기를 씀      | <img width="411" height="171" alt="image" src="https://github.com/user-attachments/assets/ac8c8f86-209b-4a53-b247-587372d2699e" /> |

## Uncompleted Tasks 😅
@Sihun23 
단어 세부내용 조회 API 에서 createAt 대신, 해당 단어가 저장된 diary의 writtenDate 필드를 가져와서 내려주어야합니다.
반영해서 fix 부탁드립니다!