### PR TITLE
[fix] #85 s3 절대경로 포함하여 이미지 반환

### DIFF
--- a/src/main/java/org/hilingual/domain/diary/api/service/DiaryService.java
+++ b/src/main/java/org/hilingual/domain/diary/api/service/DiaryService.java
@@ -44,6 +44,8 @@ public class DiaryService {
     private final DiaryRetriever diaryRetriever;
     private final DiaryValidator diaryValidator;
 
+    private static final String S3_BASE_URL = "https://hilingual-bucket.s3.ap-northeast-2.amazonaws.com/";
+
     @Transactional
     public DiaryDto getFeedbacks(Long userId, String originalText, LocalDate writtenDate, MultipartFile imageFile) {
         String imageUrl = null;
@@ -89,9 +91,14 @@ public class DiaryService {
 
         String originalText = diary.getOriginalText();
         String rewriteText = diary.getRewriteText();
-        String imageUrl = diary.getImageUrl();
+        String imageUrlKey = diary.getImageUrl();
 
-        String date = diary.getCreatedAt().format(DateTimeFormatter.ofPattern("M월 d일 EEEE", Locale.KOREAN));
+        String imageUrl = (imageUrlKey != null && !imageUrlKey.isBlank())
+                ? S3_BASE_URL + imageUrlKey
+                : null;
+
+        String date = diary.getCreatedAt()
+                .format(DateTimeFormatter.ofPattern("M월 d일 EEEE", Locale.KOREAN));
 
         List<DiaryDetails.DiffRange> diffRanges = diaryDiffService.extractDiffRanges(originalText, rewriteText);
 


### PR DESCRIPTION
## Related issue 🛠
- closed #85 

## Work Description ✏️
일기 상세 정보 조회할 때 image Url에 key만 담기는거 절대경로로 수정했습니다.


## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
|        일기 상세 정보 API      | <img width="1113" height="768" alt="image" src="https://github.com/user-attachments/assets/b442e3fc-73ab-4f8c-897e-1d20cc407a88" /> |