### PR TITLE
[feat] #90 일기 쓰면서 UserCalendar 에도 기록되도록 수정 및 하루에 한 번만 일기 쓸 수 있도록 검증

### DIFF
--- a/src/main/java/org/hilingual/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/hilingual/advice/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.hilingual.common.exception.code.ErrorCode;
 import org.hilingual.common.exception.code.GlobalErrorCode;
 import org.hilingual.domain.diary.api.exception.DiaryBaseException;
 import org.hilingual.domain.recommend.api.exception.RecommendBaseException;
+import org.hilingual.domain.user.api.exception.UserBaseException;
 import org.hilingual.domain.usercalendar.api.exception.UserCalendarBaseException;
 import org.hilingual.domain.token.api.exception.JwtBaseException;
 import org.hilingual.external.openai.exception.OpenAiBaseException;
@@ -31,6 +32,15 @@ import java.util.Map;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(UserBaseException.class)
+    public ResponseEntity<BaseResponseDto<Void>> handleUserBaseException(UserBaseException e) {
+        log.error("[UserBaseException] message: {}", e.getMessage(), e);
+
+        return ResponseEntity
+                .status(e.getStatus())
+                .body(BaseResponseDto.fail(e.getErrorCode()));
+    }
 
     @ExceptionHandler(RecommendBaseException.class)
     public ResponseEntity<BaseResponseDto<Void>> handleRecommendBaseException(RecommendBaseException e) {
@@ -183,7 +193,5 @@ public class GlobalExceptionHandler {
                 .status(GlobalErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
                 .body(BaseResponseDto.fail(GlobalErrorCode.INTERNAL_SERVER_ERROR));
     }
-
-
 
 }

--- a/src/main/java/org/hilingual/domain/diary/api/service/DiaryService.java
+++ b/src/main/java/org/hilingual/domain/diary/api/service/DiaryService.java
@@ -14,6 +14,7 @@ import org.hilingual.domain.recommend.core.domain.Recommend;
 import org.hilingual.domain.recommend.api.service.RecommendService;
 import org.hilingual.domain.user.api.service.UserService;
 import org.hilingual.domain.user.core.domain.User;
+import org.hilingual.domain.usercalendar.api.service.UserCalendarService;
 import org.hilingual.external.openai.OpenAiService;
 import org.hilingual.external.s3.S3Service;
 import org.springframework.stereotype.Service;
@@ -44,10 +45,15 @@ public class DiaryService {
     private final DiaryRetriever diaryRetriever;
     private final DiaryValidator diaryValidator;
 
+    private final UserCalendarService userCalendarService;
+
     private static final String S3_BASE_URL = "https://hilingual-bucket.s3.ap-northeast-2.amazonaws.com/";
 
     @Transactional
     public DiaryDto getFeedbacks(Long userId, String originalText, LocalDate writtenDate, MultipartFile imageFile) {
+        User user = userService.findById(userId);
+        diaryRetriever.validateDiaryNotExists(user, writtenDate);
+
         String imageUrl = null;
         if (imageFile != null && !imageFile.isEmpty()) {
             imageUrl = s3Service.uploadImage("diaries", imageFile);
@@ -59,8 +65,8 @@ public class DiaryService {
         List<Map<String, Object>> feedbackList = (List<Map<String, Object>>) aiResponse.get("feedbackList");
         List<Map<String, Object>> phraseList = (List<Map<String, Object>>) aiResponse.get("phraseList");
 
-        User user = userService.findById(userId);
         Diary diary = diarySaver.save(user, originalText, rewriteText, imageUrl, writtenDate);
+        userCalendarService.markWrittenDate(user, writtenDate);
 
         feedbackList.stream()
                 .map(f -> DiaryFeedback.create(

--- a/src/main/java/org/hilingual/domain/diary/core/exception/AlreadyWrittenDiaryException.java
+++ b/src/main/java/org/hilingual/domain/diary/core/exception/AlreadyWrittenDiaryException.java
@@ -1,0 +1,15 @@
+package org.hilingual.domain.diary.core.exception;
+
+import org.hilingual.common.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class AlreadyWrittenDiaryException extends DiaryCoreException  {
+    public AlreadyWrittenDiaryException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.CONFLICT;
+    }
+}

--- a/src/main/java/org/hilingual/domain/diary/core/exception/DiaryCoreErrorCode.java
+++ b/src/main/java/org/hilingual/domain/diary/core/exception/DiaryCoreErrorCode.java
@@ -12,6 +12,9 @@ public enum DiaryCoreErrorCode implements ErrorCode {
 
     // 404
     DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, 40004, "id에 해당하는 일기가 존재하지 않습니다."),
+
+    // 409
+    ALREADY_WRITTEN_DIARY(HttpStatus.CONFLICT, 40901, "해당 날짜에 이미 작성된 일기가 있습니다."),
     ;
 
     public final HttpStatus httpStatus;

--- a/src/main/java/org/hilingual/domain/diary/core/facade/DiaryRetriever.java
+++ b/src/main/java/org/hilingual/domain/diary/core/facade/DiaryRetriever.java
@@ -2,11 +2,14 @@ package org.hilingual.domain.diary.core.facade;
 
 import lombok.RequiredArgsConstructor;
 import org.hilingual.domain.diary.core.domain.Diary;
+import org.hilingual.domain.diary.core.exception.AlreadyWrittenDiaryException;
 import org.hilingual.domain.diary.core.exception.DiaryCoreErrorCode;
 import org.hilingual.domain.diary.core.exception.DiaryNotFoundException;
 import org.hilingual.domain.diary.core.repository.DiaryRepository;
+import org.hilingual.domain.user.core.domain.User;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -16,6 +19,12 @@ import java.util.Optional;
 public class DiaryRetriever {
 
     private final DiaryRepository diaryRepository;
+
+    public void validateDiaryNotExists(User user, LocalDate writtenDate) {
+        if (diaryRepository.existsByUserAndWrittenDate(user, writtenDate)) {
+            throw new AlreadyWrittenDiaryException(DiaryCoreErrorCode.ALREADY_WRITTEN_DIARY);
+        }
+    }
 
     public Diary findById(final long diaryId) {
         return diaryRepository.findById(diaryId)
@@ -29,6 +38,5 @@ public class DiaryRetriever {
     public Optional<LocalDateTime> findLatestDiaryCreatedAt(final Long userId) {
         return diaryRepository.findLatestCreatedAtByUserId(userId);
     }
-
 
 }

--- a/src/main/java/org/hilingual/domain/diary/core/repository/DiaryRepository.java
+++ b/src/main/java/org/hilingual/domain/diary/core/repository/DiaryRepository.java
@@ -1,6 +1,7 @@
 package org.hilingual.domain.diary.core.repository;
 
 import org.hilingual.domain.diary.core.domain.Diary;
+import org.hilingual.domain.user.core.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,6 +12,9 @@ import java.util.List;
 import java.util.Optional;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
+
+    boolean existsByUserAndWrittenDate(User user, LocalDate writtenDate);
+
     @Query("""
     SELECT d FROM Diary d
     WHERE d.user.id = :userId

--- a/src/main/java/org/hilingual/domain/usercalendar/api/service/UserCalendarService.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/api/service/UserCalendarService.java
@@ -1,6 +1,7 @@
 package org.hilingual.domain.usercalendar.api.service;
 
 import lombok.RequiredArgsConstructor;
+import org.hilingual.domain.user.core.domain.User;
 import org.hilingual.domain.usercalendar.api.dto.res.UserCalendarDiarySummaryResponse;
 import org.hilingual.domain.usercalendar.api.dto.res.UserCalendarMonthlyResponse;
 import org.hilingual.domain.usercalendar.api.dto.res.UserCalendarTopicResponse;
@@ -19,6 +20,10 @@ import java.util.List;
 public class UserCalendarService {
 
     private final UserCalendarRetriever userCalendarRetriever;
+
+    public void markWrittenDate(final User user, final LocalDate writtenDate){
+        userCalendarRetriever.markWrittenDate(user, writtenDate);
+    };
 
     public UserCalendarDiarySummaryResponse getDiarySummary(final LocalDate date, final Long userId) {
         if (date.isAfter(LocalDate.now())) {

--- a/src/main/java/org/hilingual/domain/usercalendar/core/domain/UserCalendar.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/core/domain/UserCalendar.java
@@ -13,7 +13,10 @@ import java.time.LocalDate;
 import static org.hilingual.domain.usercalendar.core.domain.UserCalendarTableConstants.*;
 
 @Entity
-@Table(name = TABLE_USER_CALENDAR)
+@Table(
+        name = TABLE_USER_CALENDAR,
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "date"})
+)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -29,4 +32,12 @@ public class UserCalendar extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = COLUMN_USER_ID, nullable = false)
     private User user;
+
+    public void markWritten(){
+        this.isWritten = true;
+    }
+
+    public static UserCalendar create(LocalDate date, Boolean isWritten, User user) {
+        return new UserCalendar(date, isWritten, user);
+    }
 }

--- a/src/main/java/org/hilingual/domain/usercalendar/core/facade/UserCalendarRetriever.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/core/facade/UserCalendarRetriever.java
@@ -2,15 +2,17 @@ package org.hilingual.domain.usercalendar.core.facade;
 
 import lombok.RequiredArgsConstructor;
 import org.hilingual.common.domain.Topic;
-import org.hilingual.domain.diary.core.domain.Diary;
 import org.hilingual.domain.diary.core.repository.DiaryRepository;
+import org.hilingual.domain.user.core.domain.User;
 import org.hilingual.domain.usercalendar.api.dto.res.UserCalendarDiarySummaryResponse;
 import org.hilingual.domain.usercalendar.api.dto.res.UserCalendarTopicResponse;
 import org.hilingual.domain.usercalendar.api.exception.UserCalendarDiaryNotFoundException;
+import org.hilingual.domain.usercalendar.core.domain.UserCalendar;
 import org.hilingual.domain.usercalendar.core.exception.UserCalendarCoreErrorCode;
 import org.hilingual.domain.usercalendar.core.exception.UserCalendarTopicNotFoundException;
 import org.hilingual.domain.usercalendar.core.repository.UserCalendarRepository;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.time.LocalDate;
@@ -23,7 +25,19 @@ import java.util.List;
 public class UserCalendarRetriever {
 
     private final DiaryRepository diaryRepository;
+    private final UserCalendarRepository userCalendarRepository;
     private final org.hilingual.common.repository.TopicRepository topicRepository;
+
+    @Transactional
+    public void markWrittenDate(User user, LocalDate writtenDate) {
+        userCalendarRepository.findByUserAndDate(user, writtenDate)
+                .ifPresentOrElse(
+                        UserCalendar::markWritten,
+                        () -> userCalendarRepository.save(
+                                UserCalendar.create(writtenDate, true, user)
+                        )
+                );
+    }
 
     public UserCalendarDiarySummaryResponse findDiaryByDate(final Long userId, final LocalDate date) {
         LocalDateTime startOfDay = date.atStartOfDay(); // 00:00
@@ -73,7 +87,6 @@ public class UserCalendarRetriever {
             return (int) Math.ceil(secondsRemaining / 60.0);
         }
     }
-    private final UserCalendarRepository userCalendarRepository;
 
     public List<LocalDate> findWrittenDatesByMonth(final Long userId, final int year, final int month) {
         return userCalendarRepository.findWrittenDatesByUserIdAndYearAndMonth(userId, year, month);

--- a/src/main/java/org/hilingual/domain/usercalendar/core/repository/UserCalendarRepository.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/core/repository/UserCalendarRepository.java
@@ -1,14 +1,18 @@
 package org.hilingual.domain.usercalendar.core.repository;
 
+import org.hilingual.domain.user.core.domain.User;
 import org.hilingual.domain.usercalendar.core.domain.UserCalendar;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
-public interface UserCalendarRepository extends Repository<UserCalendar, LocalDate> {
+public interface UserCalendarRepository extends JpaRepository<UserCalendar, LocalDate> {
+
+    Optional<UserCalendar> findByUserAndDate(User user, LocalDate date);
 
     @Query("""
         SELECT uc.date FROM UserCalendar uc


### PR DESCRIPTION
## Related issue 🛠
- closed #90 
- closed #91 

## Work Description ✏️
- 일기 쓰면서 UserCalendar 에도 기록되도록 함
- 하루에 한 번만 일기 쓸 수 있도록 검증 추가함(AlreadyWrittenDiaryException 발생)
- 기존에 누락되어있던 UserBaseException 을 GlobalExceptionHandler 에 추가

- UserCalendar 테이블 구조 개선
기존의 UserCalendar 는 아래 조건을 보장하지 못했었음.
> “같은 유저가 같은 날짜에 여러 개의 UserCalendar 레코드를 생성할 수 없도록 막아야 한다”

왜냐면
- date만 PK라서 모든 유저에 대해 날짜는 단 하나만 저장 가능
- 즉, 여러 유저가 같은 날짜에 저장 못 함 → 유저가 달라도 date가 같으면 충돌 발생함 

그래서 
> 유니크 제약조건을 userId + date 로 걸어서 해결!



## Screenshot 📸
| 설명 | 사진 |
|:--:|:--:|
| 이미 일기 쓴 날에 또 일기 쓰려고 할 경우 예외 | <img width="833" alt="image" src="https://github.com/user-attachments/assets/d3e74649-005c-4d2f-a061-0c38800d7e6d" /> |
| UserCalendar 테이블에도 기록됨 | <img width="1007" alt="image" src="https://github.com/user-attachments/assets/1540c9da-560f-4760-905b-9ce68ad758e8" /> |
