### PR TITLE
[fix] #92 단어장 정렬 기준 변경 

### DIFF
--- a/src/main/java/org/hilingual/domain/usercalendar/core/facade/UserCalendarRetriever.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/core/facade/UserCalendarRetriever.java
@@ -57,8 +57,8 @@ public class UserCalendarRetriever {
 
     private int calculateRemainingMinutesUntilDeadline(final LocalDate topicDate) {
 
-        final ZoneId seoulZone = ZoneId.of("Asia/Seoul");
-        final LocalDateTime now = LocalDateTime.now(seoulZone);
+        final LocalDateTime now = LocalDateTime.now();
+
 
         // 작성 가능 시각: 주제 날짜 + 2일 00시 = 48시간 후
         final LocalDateTime deadline = topicDate.plusDays(2).atStartOfDay();

--- a/src/main/java/org/hilingual/domain/userprofile/core/facade/UserProfileUpdater.java
+++ b/src/main/java/org/hilingual/domain/userprofile/core/facade/UserProfileUpdater.java
@@ -17,7 +17,6 @@ public class UserProfileUpdater {
     private final UserProfileRetriever userProfileRetriever;
     private final DiaryRetriever diaryRetriever;
 
-    private static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
     private static final long STREAK_WINDOW_HOURS = 48L;
 
     @Transactional
@@ -28,7 +27,7 @@ public class UserProfileUpdater {
 
         profile.updateTotalDiaries(diaryTimestamps.size());
 
-        LocalDateTime now = LocalDateTime.now(ZONE_ID);
+        LocalDateTime now = LocalDateTime.now();
 
         if (hasWrittenInLast48Hours(diaryTimestamps, now)) {
             profile.updateStreak(profile.getStreak() + 1);

--- a/src/main/java/org/hilingual/domain/voca/core/facade/VocaGroupFactory.java
+++ b/src/main/java/org/hilingual/domain/voca/core/facade/VocaGroupFactory.java
@@ -1,5 +1,6 @@
 package org.hilingual.domain.voca.core.facade;
 
+import jakarta.annotation.PostConstruct;
 import org.hilingual.domain.voca.api.dto.res.VocaItemResponse;
 import org.hilingual.domain.voca.api.dto.res.VocaListResponse;
 import org.hilingual.domain.voca.api.dto.res.WordGroup;
@@ -15,8 +16,6 @@ import java.util.*;
 
 @Component
 public class VocaGroupFactory {
-
-    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
 
     public VocaListResponse create(final List<Voca> vocas, final int sort) {
         return switch (sort) {
@@ -46,8 +45,8 @@ public class VocaGroupFactory {
     }
 
     private VocaListResponse groupByDateGroup(final List<Voca> vocas) {
-        LocalDate today = LocalDate.now(SEOUL_ZONE);
-        LocalDateTime todayStart = LocalDateTime.of(today, java.time.LocalTime.MIDNIGHT);
+        LocalDate today = LocalDate.now();
+        LocalDateTime todayStart = today.atStartOfDay();
         LocalDateTime sevenDaysAgo = today.minusDays(6).atStartOfDay();
         LocalDateTime thirtyDaysAgo = today.minusDays(29).atStartOfDay();
 

--- a/src/main/java/org/hilingual/domain/voca/core/facade/VocaGroupFactory.java
+++ b/src/main/java/org/hilingual/domain/voca/core/facade/VocaGroupFactory.java
@@ -20,8 +20,8 @@ public class VocaGroupFactory {
 
     public VocaListResponse create(final List<Voca> vocas, final int sort) {
         return switch (sort) {
-            case 1 -> groupByFirstLetter(vocas);
-            case 2 -> groupByDateGroup(vocas);
+            case 1 -> groupByDateGroup(vocas);
+            case 2 -> groupByFirstLetter(vocas);
             default -> throw new VocaInvalidSortTypeException(VocaApiErrorCode.INVALID_SORT_TYPE);
         };
     }

--- a/src/main/java/org/hilingual/domain/voca/core/facade/VocaRetriever.java
+++ b/src/main/java/org/hilingual/domain/voca/core/facade/VocaRetriever.java
@@ -24,8 +24,8 @@ public class VocaRetriever {
 
     public VocaListResponse findGroupedVoca(final Long userId, final int sort) {
         final List<Voca> vocas = switch (sort) {
-            case 1 -> vocaRepository.findAllByUserIdOrderByPhraseAsc(userId);
-            case 2 -> vocaRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
+            case 1 -> vocaRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
+            case 2 -> vocaRepository.findAllByUserIdOrderByPhraseAsc(userId);
             default -> throw new VocaInvalidSortTypeException(VocaApiErrorCode.INVALID_SORT_TYPE);
         };
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         show_sql: true


### PR DESCRIPTION
## Related issue 🛠
- closed #92 

## Work Description ✏️
- 단어장 정렬을 1:최신순(default) 2:AZ순으로 변경하였습니다.

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
<img width="1128" height="762" alt="스크린샷 2025-07-15 오후 8 56 10" src="https://github.com/user-attachments/assets/6cf35238-7927-44d2-a010-cbf5bcc07c0d" />
<img width="1278" height="753" alt="스크린샷 2025-07-15 오후 8 56 22" src="https://github.com/user-attachments/assets/07c489a3-6a0a-4b02-8f46-2347aa936983" />

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
@HAJIEUN02 @choyeongju 
- 일기를 작성하고 북마크를 했음에도 today가 아닌 7days로 뜨는 것은 TimeZone 설정의 불일치 인것으로 테스트를 통해 확인했습니다.
- 현재 BaseTimeEntity를 통해 생성되는 createdAt은 UTC 기준이고, 현재 단어장 목록 조회에서의 기준은 Asia/Seoul 기준(KST)를 사용하기에 특정시간(00시~08시 정도)에는 날짜가 맞지않아서 조회가 안되는 것처럼 보이는 문제가 발생했습니다.