### PR TITLE
[hotfix] #104 UserCalendar 스키마 변경

### DIFF
--- a/src/main/java/org/hilingual/domain/usercalendar/core/domain/UserCalendar.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/core/domain/UserCalendar.java
@@ -23,7 +23,10 @@ import static org.hilingual.domain.usercalendar.core.domain.UserCalendarTableCon
 public class UserCalendar extends BaseTimeEntity {
 
     @Id
-    @Column(name = COLUMN_DATE)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = COLUMN_DATE, nullable = false)
     private LocalDate date;
 
     @Column(name = COLUMN_IS_WRITTEN, nullable = false)
@@ -38,6 +41,6 @@ public class UserCalendar extends BaseTimeEntity {
     }
 
     public static UserCalendar create(LocalDate date, Boolean isWritten, User user) {
-        return new UserCalendar(date, isWritten, user);
+        return new UserCalendar(null, date, isWritten, user); // id=null
     }
 }

--- a/src/main/java/org/hilingual/domain/usercalendar/core/repository/UserCalendarRepository.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/core/repository/UserCalendarRepository.java
@@ -10,7 +10,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-public interface UserCalendarRepository extends JpaRepository<UserCalendar, LocalDate> {
+public interface UserCalendarRepository extends JpaRepository<UserCalendar, Long> {
 
     Optional<UserCalendar> findByUserAndDate(User user, LocalDate date);
 
@@ -23,7 +23,7 @@ public interface UserCalendarRepository extends JpaRepository<UserCalendar, Loca
     """)
     List<LocalDate> findWrittenDatesByUserIdAndYearAndMonth(
             @Param("userId") Long userId,
-            @Param("year") int year,
-            @Param("month") int month
+            @Param("year")   int  year,
+            @Param("month")  int  month
     );
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         show_sql: true


### PR DESCRIPTION
## Related issue 🛠
- closed #104 

## Work Description ✏️
- 현재 usercalendar에서 PK 가 date 하나라서 모든 유저가 같은 날짜를 공유하게 됩니다.
- 다른 유저가 같은 날짜 2025-07-17로 save()를 호출하면 Hibernate 는 이미 id = 2025-07-17 인 엔티티가 있으니 update를 수행하게 되어서, user_id 와 is_written 을 덮어써 버립니다.
- 그래서 앞서 작성한 유저에게는 더 이상 월별조회에 해당 날짜가 나오지 않게 됩니다.

- 스키마 변경 (PK변경: date -> id(추가))
- 

## To Reviewers 📢
이렇게 하고 그냥 ddl-auto update로 돌리면 문제 없을까요?
GPT는 flyway로 마이그레이션 하라는데, 어차피 DB 밀거면 필요없을 것 같기도 하고,,
도와주세요 ㅠㅠ