### PR TITLE
[fix] 2차 QA 서버 보완사항 반영

### DIFF
--- a/src/main/java/org/hilingual/domain/user/api/service/UserService.java
+++ b/src/main/java/org/hilingual/domain/user/api/service/UserService.java
@@ -21,7 +21,7 @@ public class UserService {
     }
 
     public BaseResponseDto<NicknameAvailableResponse> getNicknameAvailable(String nickname) {
-        if (!nickname.matches("^[ㄱ-ㅎ가-힣a-zA-Z0-9]+$")) {
+        if (!nickname.matches("^[가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9]+$")) {
             return unavailableNickname(UserSuccessCode.NICKNAME_SPECIAL_SYMBOLS);
         }
         if (nickname.length() < 2 || nickname.length() > 10) {


### PR DESCRIPTION
## Related issue 🛠
- closed #106 

## Work Description ✏️
- [x] 닉네임 검사 API에서 에러 케이스를 상세하게 핸들링합니다.
    - [x] ㅏㅏㅓㅓ와 같이 모음만 보냈을 때 NICKNAME_SPECIAL_SYMBOLS success code가 발생함.

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 닉네임 검사 API - 모음 입력 가능하도록 | <img width="559" height="499" alt="image" src="https://github.com/user-attachments/assets/ed172263-843b-4a03-a63b-691158c6b01c" /> |


## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A