### PR TITLE
[fix] #109 북마크 해제 시에도 새로고침 전에 단어 상세조회 가능하도록 로직 수정

### DIFF
--- a/src/main/java/org/hilingual/domain/recommend/core/facade/RecommendRetriever.java
+++ b/src/main/java/org/hilingual/domain/recommend/core/facade/RecommendRetriever.java
@@ -5,6 +5,8 @@ import org.hilingual.domain.recommend.core.domain.Recommend;
 import org.hilingual.domain.recommend.core.exception.RecommendCoreErrorCode;
 import org.hilingual.domain.recommend.core.exception.RecommendNotFoundException;
 import org.hilingual.domain.recommend.core.repository.RecommendRepository;
+import org.hilingual.domain.voca.core.exception.VocaCoreErrorCode;
+import org.hilingual.domain.voca.core.exception.VocaNotFoundException;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -23,4 +25,10 @@ public class RecommendRetriever {
         return recommendRepository.findById(phraseId)
                 .orElseThrow(()-> new RecommendNotFoundException(RecommendCoreErrorCode.RECOMMEND_NOT_FOUND));
     }
+
+    public Recommend findByUserIdAndPhraseId(final Long userId, final Long phraseId) {
+        return recommendRepository.findPhraseByIdAndUserId(phraseId, userId)
+                .orElseThrow(() -> new VocaNotFoundException(VocaCoreErrorCode.VOCA_NOT_FOUND));
+    }
+
 }

--- a/src/main/java/org/hilingual/domain/recommend/core/repository/RecommendRepository.java
+++ b/src/main/java/org/hilingual/domain/recommend/core/repository/RecommendRepository.java
@@ -6,11 +6,20 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface RecommendRepository extends JpaRepository<Recommend, Long> {
 
     @Query("select r from Recommend r where r.id in (select v.recommend.id from Voca v where v.id = :vocaId)")
     List<Recommend> findAllByVocaId(@Param("vocaId") Long vocaId);
+
     List<Recommend> findByDiaryId(Long diaryId);
 
+    @Query("""
+    SELECT r FROM Recommend r
+    JOIN FETCH r.diary d
+    WHERE r.id = :phraseId AND d.user.id = :userId
+""")
+    Optional<Recommend> findPhraseByIdAndUserId(@Param("phraseId") Long phraseId,
+                                                @Param("userId") Long userId);
 }

--- a/src/main/java/org/hilingual/domain/voca/api/dto/res/VocaDetailResponse.java
+++ b/src/main/java/org/hilingual/domain/voca/api/dto/res/VocaDetailResponse.java
@@ -1,6 +1,6 @@
 package org.hilingual.domain.voca.api.dto.res;
 
-import org.hilingual.domain.voca.core.domain.Voca;
+import org.hilingual.domain.recommend.core.domain.Recommend;
 
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
@@ -17,17 +17,17 @@ public record VocaDetailResponse(
 
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yy.MM.dd");
 
-    public static VocaDetailResponse from(final Voca voca) {
+    public static VocaDetailResponse from(final Recommend recommend) {
         return new VocaDetailResponse(
-                voca.getRecommend().getId(),
-                voca.getRecommend().getPhrase(),
-                parsePhraseTypes(voca.getRecommend().getPhraseType()),
-                voca.getRecommend().getExplanation(),
-                voca.getRecommend()
+                recommend.getId(),
+                recommend.getPhrase(),
+                parsePhraseTypes(recommend.getPhraseType()),
+                recommend.getExplanation(),
+                recommend
                         .getDiary()
                         .getWrittenDate()
                         .format(FORMATTER),
-                voca.getRecommend().getIsBookmarked()
+                recommend.getIsBookmarked()
         );
     }
 

--- a/src/main/java/org/hilingual/domain/voca/api/service/VocaService.java
+++ b/src/main/java/org/hilingual/domain/voca/api/service/VocaService.java
@@ -1,6 +1,8 @@
 package org.hilingual.domain.voca.api.service;
 
 import lombok.RequiredArgsConstructor;
+import org.hilingual.domain.recommend.core.domain.Recommend;
+import org.hilingual.domain.recommend.core.facade.RecommendRetriever;
 import org.hilingual.domain.voca.api.dto.res.VocaDetailResponse;
 import org.hilingual.domain.voca.api.dto.res.VocaListResponse;
 import org.hilingual.domain.voca.api.dto.res.VocaSearchListResponse;
@@ -16,6 +18,7 @@ import java.util.List;
 public class VocaService {
 
     private final VocaRetriever vocaRetriever;
+    private final RecommendRetriever recommendRetriever;
 
 
     // 단어장 목록 조회
@@ -31,8 +34,8 @@ public class VocaService {
 
     //특정 단어 세부 조회
     public VocaDetailResponse getVocaDetails(final Long userId, final Long phraseId) {
-        final Voca voca = vocaRetriever.findByUserIdAndPhraseId(userId, phraseId);
-        return VocaDetailResponse.from(voca);
+        final Recommend recommend = recommendRetriever.findByUserIdAndPhraseId(userId, phraseId);
+        return VocaDetailResponse.from(recommend);
     }
 
 }

--- a/src/main/java/org/hilingual/domain/voca/core/facade/VocaRetriever.java
+++ b/src/main/java/org/hilingual/domain/voca/core/facade/VocaRetriever.java
@@ -41,10 +41,4 @@ public class VocaRetriever {
         return vocas;
     }
 
-
-    public Voca findByUserIdAndPhraseId(final Long userId, final Long phraseId) {
-        return vocaRepository.findByPhraseIdAndUserId(phraseId, userId)
-                .orElseThrow(() -> new VocaNotFoundException(VocaCoreErrorCode.VOCA_NOT_FOUND));
-    }
-
 }

--- a/src/main/java/org/hilingual/domain/voca/core/repository/VocaRepository.java
+++ b/src/main/java/org/hilingual/domain/voca/core/repository/VocaRepository.java
@@ -47,14 +47,5 @@ public interface VocaRepository extends JpaRepository<Voca, Long> {
             @Param("keyword") String keyword
     );
 
-    @Query("""
-    SELECT v FROM Voca v
-    JOIN FETCH v.recommend r
-    JOIN FETCH r.diary d
-    WHERE r.id = :phraseId
-      AND v.user.id = :userId
-""")
-    Optional<Voca> findByPhraseIdAndUserId(@Param("phraseId") Long phraseId,
-                                           @Param("userId")  Long userId);
 }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #109 

## Work Description ✏️
클라 및 기획 선생님들과 과 길고 긴 논의를 했습니다.

서버측에서 북마크가 해제되었을때도 새로고침 전에는 단어 상세 정보를 볼 수 있도록 처리했습니다.

- 사용자가 단어장에서 북마크를 해제해도, 해당 추천 표현은 뷰에 회색 상태로 남아 다시 확인할 수 있습니다.
- 뷰에 남아 있는 추천 표현을 클릭하면, 기존처럼 추천 이유와 예문 등의 상세 정보 조회가 가능합니다.
- 다시 북마크를 누르면 회색 처리된 단어가 원래대로 복구됩니다. (클라가 뷰에서 처리)

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
|      단어장에서 북마크 해제      | <img width="833" height="482" alt="image" src="https://github.com/user-attachments/assets/60ac6ef7-1dd7-4569-b47e-76c7892fcc8b" /> |
| 해제 했음에도 조회는 가넝~ | <img width="866" height="658" alt="image" src="https://github.com/user-attachments/assets/a92828f3-1025-4b32-9a31-093fa81b4a49" /> |

## Uncompleted Tasks 😅
추후 캐싱 등 최적화 할 수 있는 방법을 고민해보면 참 좋을 것 같아요.