### PR TITLE
[fix] #108 연속작성일수(streak) 로직 변경

### DIFF
--- a/src/main/java/org/hilingual/Main.java
+++ b/src/main/java/org/hilingual/Main.java
@@ -8,8 +8,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 @EnableConfigurationProperties({AWSProperties.class, OpenAiProperties.class})
 public class Main {

--- a/src/main/java/org/hilingual/domain/diary/api/service/DiaryService.java
+++ b/src/main/java/org/hilingual/domain/diary/api/service/DiaryService.java
@@ -66,7 +66,6 @@ public class DiaryService {
         List<Map<String, Object>> phraseList = (List<Map<String, Object>>) aiResponse.get("phraseList");
 
         Diary diary = diarySaver.save(user, originalText, rewriteText, imageUrl, writtenDate);
-        userCalendarService.markWrittenDate(user, writtenDate);
 
         feedbackList.stream()
                 .map(f -> DiaryFeedback.create(

--- a/src/main/java/org/hilingual/domain/diary/core/facade/DiarySaver.java
+++ b/src/main/java/org/hilingual/domain/diary/core/facade/DiarySaver.java
@@ -4,9 +4,11 @@ import lombok.RequiredArgsConstructor;
 import org.hilingual.domain.diary.core.domain.Diary;
 import org.hilingual.domain.diary.core.repository.DiaryRepository;
 import org.hilingual.domain.user.core.domain.User;
+import org.hilingual.domain.usercalendar.api.service.UserCalendarService;
 import org.hilingual.domain.userprofile.core.facade.UserProfileUpdater;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+
 
 import java.time.LocalDate;
 
@@ -16,6 +18,8 @@ public class DiarySaver {
 
     private final DiaryRepository diaryRepository;
     private final UserProfileUpdater userProfileUpdater;
+    private final UserCalendarService userCalendarService;
+
 
     @Transactional
     public Diary save(
@@ -25,12 +29,19 @@ public class DiarySaver {
             final String imageUrl,
             final LocalDate writtenDate
     ) {
-
+        // 1) 일기 저장
         Diary diary = Diary.create(user, originalText, rewriteText, imageUrl, writtenDate);
-        Diary savedDiary = diaryRepository.save(diary);
+        Diary saved = diaryRepository.save(diary);
 
-        userProfileUpdater.updateDiaryStats(user.getId());
-        return savedDiary;
+        // 2) calendar에 기록 → streak 로직보다 **반드시 먼저** 호출
+        userCalendarService.markWrittenDate(user, writtenDate);
+
+        // 3) totalDiaries 증가
+        userProfileUpdater.incrementTotalDiaries(user.getId());
+
+        // 4) streak 업데이트
+        userProfileUpdater.updateStreakOnWrite(user.getId(), writtenDate);
+
+        return saved;
     }
-
 }

--- a/src/main/java/org/hilingual/domain/usercalendar/core/repository/UserCalendarRepository.java
+++ b/src/main/java/org/hilingual/domain/usercalendar/core/repository/UserCalendarRepository.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 
 public interface UserCalendarRepository extends JpaRepository<UserCalendar, Long> {
 
+    boolean existsByUserAndDate(User user, LocalDate date);
+
     Optional<UserCalendar> findByUserAndDate(User user, LocalDate date);
 
     @Query("""

--- a/src/main/java/org/hilingual/domain/userprofile/core/facade/UserProfileUpdater.java
+++ b/src/main/java/org/hilingual/domain/userprofile/core/facade/UserProfileUpdater.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -61,7 +62,6 @@ public class UserProfileUpdater {
             }
         }
         // 그 외 날짜: 변경 없음
-
         profile.updateStreak(newStreak);
         userProfileRepository.save(profile);
     }
@@ -72,18 +72,17 @@ public class UserProfileUpdater {
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     @Transactional
     public void resetStreakIfBroken() {
-        LocalDate today      = LocalDate.now(ZoneId.of("Asia/Seoul"));
-        LocalDate yesterday  = today.minusDays(1);
-        LocalDate dayBefore  = today.minusDays(2);
+        LocalDate today     = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        LocalDate dayBefore = today.minusDays(2);
 
-        var all = userProfileRepository.findAll();
+        List<UserProfile> all = userProfileRepository.findAll();
         for (UserProfile profile : all) {
-            boolean hasY = userCalendarRepository
-                    .existsByUserAndDate(profile.getUser(), yesterday);
-            boolean hasD = userCalendarRepository
+            // 그제 작성 여부를 확인
+            boolean hasDayBefore = userCalendarRepository
                     .existsByUserAndDate(profile.getUser(), dayBefore);
 
-            if (!hasY || !hasD) {
+            // 그제가 비어 있으면 streak 리셋, 아니면 유지
+            if (!hasDayBefore) {
                 profile.updateStreak(0);
             }
         }

--- a/src/main/java/org/hilingual/domain/userprofile/core/facade/UserProfileUpdater.java
+++ b/src/main/java/org/hilingual/domain/userprofile/core/facade/UserProfileUpdater.java
@@ -1,43 +1,92 @@
 package org.hilingual.domain.userprofile.core.facade;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.hilingual.domain.diary.core.facade.DiaryRetriever;
+import org.hilingual.domain.usercalendar.core.repository.UserCalendarRepository;
 import org.hilingual.domain.userprofile.core.domain.UserProfile;
+import org.hilingual.domain.userprofile.core.repository.UserProfileRepository;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.time.ZoneId;
-import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 public class UserProfileUpdater {
 
-    private final UserProfileRetriever userProfileRetriever;
-    private final DiaryRetriever diaryRetriever;
+    private final UserProfileRepository userProfileRepository;
+    private final UserProfileRetriever  userProfileRetriever;
+    private final UserCalendarRepository userCalendarRepository;
 
-    private static final long STREAK_WINDOW_HOURS = 48L;
-
+    /**
+     * totalDiaries 증가
+     */
     @Transactional
-    public void updateDiaryStats(final Long userId) {
+    public void incrementTotalDiaries(Long userId) {
         UserProfile profile = userProfileRetriever.findByUserIdOrThrow(userId);
-
-        List<LocalDateTime> diaryTimestamps = diaryRetriever.findDiaryCreatedAts(userId);
-
-        profile.updateTotalDiaries(diaryTimestamps.size());
-
-        LocalDateTime now = LocalDateTime.now();
-
-        if (hasWrittenInLast48Hours(diaryTimestamps, now)) {
-            profile.updateStreak(profile.getStreak() + 1);
-        } else {
-            profile.updateStreak(1); // streak 리셋
-        }
+        profile.updateTotalDiaries(profile.getTotalDiaries() + 1);
+        userProfileRepository.save(profile);
     }
 
-    private boolean hasWrittenInLast48Hours(List<LocalDateTime> diaryTimestamps, LocalDateTime now) {
-        return diaryTimestamps.stream()
-                .anyMatch(writtenAt -> writtenAt.isAfter(now.minusHours(STREAK_WINDOW_HOURS)));
+    /**
+     * 1. 일기를 쓴 순간에 호출 (streak 업데이트)
+     */
+    @Transactional
+    public void updateStreakOnWrite(Long userId, LocalDate writtenDate) {
+        UserProfile profile = userProfileRetriever.findByUserIdOrThrow(userId);
+
+        LocalDate today     = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        LocalDate yesterday = today.minusDays(1);
+
+        int newStreak = profile.getStreak();
+
+        boolean hasYesterday = userCalendarRepository
+                .existsByUserAndDate(profile.getUser(), yesterday);
+        boolean hasToday     = userCalendarRepository
+                .existsByUserAndDate(profile.getUser(), today);
+
+        if (writtenDate.equals(today)) {
+            // 1) 오늘 쓰는 순간 → 어제 썼다면 +1, 아니면 유지
+            if (hasYesterday) {
+                newStreak++;
+            }
+        }
+        else if (writtenDate.equals(yesterday)) {
+            // 2) 어제 보충 쓰는 순간 → 무조건 +1
+            newStreak++;
+            //    + 오늘도 이미 쓰여 있으면 추가 +1
+            if (hasToday) {
+                newStreak++;
+            }
+        }
+        // 그 외 날짜: 변경 없음
+
+        profile.updateStreak(newStreak);
+        userProfileRepository.save(profile);
+    }
+
+    /**
+     * 2. 매일 자정 최근 2일 작성 여부 검사 후 streak 리셋 또는 유지
+     */
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @Transactional
+    public void resetStreakIfBroken() {
+        LocalDate today      = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        LocalDate yesterday  = today.minusDays(1);
+        LocalDate dayBefore  = today.minusDays(2);
+
+        var all = userProfileRepository.findAll();
+        for (UserProfile profile : all) {
+            boolean hasY = userCalendarRepository
+                    .existsByUserAndDate(profile.getUser(), yesterday);
+            boolean hasD = userCalendarRepository
+                    .existsByUserAndDate(profile.getUser(), dayBefore);
+
+            if (!hasY || !hasD) {
+                profile.updateStreak(0);
+            }
+        }
+        userProfileRepository.saveAll(all);
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #108 

## Work Description ✏️
- `DiarySaver.save()`에 `markWrittenDate`, `incrementTotalDiaries`, `updateStreakOnWrite` 호출 통합
- 연속일수(streak) 업데이트 로직 수정 (`UserProfileUpdater.updateStreakOnWrite`)  
  - `writtenDate`가 **오늘**인 경우:  
    - **어제 기록**이 있으면 `streak +1`  
    - 없으면 **유지**  
  - `writtenDate`가 **어제**인 경우:  
    - `streak +1`  
    - **오늘 기록**도 있으면 추가로 `+1`  
- **자정 리셋 스케줄러** 
  - 매일 00:00 (KST) 실행  
  - “그제” 기록이 없으면 `streak = 0`  
  - 아니면 유지

