### PR TITLE
[fix] #112 일기 작성일 writtenDate 기준으로 반환하도록 수정

### DIFF
--- a/src/main/java/org/hilingual/domain/diary/api/service/DiaryService.java
+++ b/src/main/java/org/hilingual/domain/diary/api/service/DiaryService.java
@@ -103,7 +103,7 @@ public class DiaryService {
                 ? S3_BASE_URL + imageUrlKey
                 : null;
 
-        String date = diary.getCreatedAt()
+        String date = diary.getWrittenDate()
                 .format(DateTimeFormatter.ofPattern("M월 d일 EEEE", Locale.KOREAN));
 
         List<DiaryDetails.DiffRange> diffRanges = diaryDiffService.extractDiffRanges(originalText, rewriteText);


### PR DESCRIPTION
## Related issue 🛠
- closed #112 

## Work Description ✏️
일기 작성일을 createdAt 아니라, writtenDate 기준으로 반환하도록 수정

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
|        18일에 17일 일기를 씀     | <img width="482" height="170" alt="image" src="https://github.com/user-attachments/assets/79066bd6-dd5e-4bea-a8be-7eda6b42ad33" /> |
| 17일 눌러서 상세조회 했을때 17일에 작성했다고 뜸 | <img width="851" height="634" alt="image" src="https://github.com/user-attachments/assets/0be4c0d5-1e84-4b43-86d3-c36827546985" /> |