### PR TITLE
[feat] #149 유저 차단/차단 해제 API 구현

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/block/api/BlockController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/block/api/BlockController.java
@@ -1,0 +1,32 @@
+package org.sopt.controller.block.api;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.sopt.controller.block.service.BlockService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class BlockController {
+
+    private final BlockService blockService;
+
+    @PutMapping("/{userId}/block")
+    public ResponseEntity<Void> blockUser(
+            @PathVariable("userId") @NotNull Long blockedId
+    ) {
+        Long blockerId = 1L;
+        // TODO Long blockerId = UserAuthenticationUtils.getCurrentUserId();
+
+        return ResponseEntity.ok(blockService.blockUser(blockerId, blockedId));
+    }
+
+    @DeleteMapping("/{userId}/unblock")
+    public ResponseEntity<Void> unblockUser(
+            @PathVariable("userId") @NotNull Long userId
+    ) {
+        return ResponseEntity.ok(blockService.unblockUser(userId));
+    }
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/block/api/BlockController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/block/api/BlockController.java
@@ -25,8 +25,10 @@ public class BlockController {
 
     @DeleteMapping("/{userId}/unblock")
     public ResponseEntity<Void> unblockUser(
-            @PathVariable("userId") @NotNull Long userId
+            @PathVariable("userId") @NotNull Long unblockedId
     ) {
-        return ResponseEntity.ok(blockService.unblockUser(userId));
+        Long blockerId = 1L;
+        // TODO Long blockerId = UserAuthenticationUtils.getCurrentUserId();
+        return ResponseEntity.ok(blockService.unblockUser(blockerId, unblockedId));
     }
 }

--- a/hilingual-api/src/main/java/org/sopt/controller/block/exception/BlockApiErrorCode.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/block/exception/BlockApiErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 public enum BlockApiErrorCode implements ErrorCode {
     // 400
     CANNOT_SELF_BLOCK(HttpStatus.BAD_REQUEST, 40015, "자기 자신은 차단할 수 없습니다."),
+    CANNOT_SELF_UNBLOCK(HttpStatus.BAD_REQUEST, 40015, "자기 자신은 차단 해제할 수 없습니다.")
     ;
 
     public final HttpStatus httpStatus;

--- a/hilingual-api/src/main/java/org/sopt/controller/block/exception/BlockApiErrorCode.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/block/exception/BlockApiErrorCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum BlockApiErrorCode implements ErrorCode {
     // 400
-    CANNOT_SELF_BLOCK(HttpStatus.BAD_REQUEST, 400, "자기 자신은 차단할 수 없습니다."),
+    CANNOT_SELF_BLOCK(HttpStatus.BAD_REQUEST, 40005, "자기 자신은 차단할 수 없습니다."),
     ;
 
     public final HttpStatus httpStatus;

--- a/hilingual-api/src/main/java/org/sopt/controller/block/exception/BlockApiErrorCode.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/block/exception/BlockApiErrorCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum BlockApiErrorCode implements ErrorCode {
     // 400
-    CANNOT_SELF_BLOCK(HttpStatus.BAD_REQUEST, 40005, "자기 자신은 차단할 수 없습니다."),
+    CANNOT_SELF_BLOCK(HttpStatus.BAD_REQUEST, 40015, "자기 자신은 차단할 수 없습니다."),
     ;
 
     public final HttpStatus httpStatus;

--- a/hilingual-api/src/main/java/org/sopt/controller/block/exception/BlockApiErrorCode.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/block/exception/BlockApiErrorCode.java
@@ -1,0 +1,31 @@
+package org.sopt.controller.block.exception;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum BlockApiErrorCode implements ErrorCode {
+    // 400
+    CANNOT_SELF_BLOCK(HttpStatus.BAD_REQUEST, 400, "자기 자신은 차단할 수 없습니다."),
+    ;
+
+    public final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus(){
+        return httpStatus;
+    }
+
+    @Override
+    public int getCode(){
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/block/exception/BlockApiException.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/block/exception/BlockApiException.java
@@ -1,0 +1,11 @@
+package org.sopt.controller.block.exception;
+
+import org.sopt.exception.base.HilingualBaseException;
+import org.sopt.exception.code.ErrorCode;
+
+public abstract class BlockApiException extends HilingualBaseException {
+
+    protected BlockApiException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/block/exception/CannotSelfBlockException.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/block/exception/CannotSelfBlockException.java
@@ -1,0 +1,11 @@
+package org.sopt.controller.block.exception;
+
+import org.sopt.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class CannotSelfBlockException extends BlockApiException {
+    public CannotSelfBlockException(ErrorCode errorCode) { super(errorCode); }
+
+    @Override
+    public HttpStatus getStatus() { return HttpStatus.BAD_REQUEST; }
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/block/exception/CannotSelfUnblockException.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/block/exception/CannotSelfUnblockException.java
@@ -1,0 +1,11 @@
+package org.sopt.controller.block.exception;
+
+import org.sopt.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class CannotSelfUnblockException extends BlockApiException {
+    public CannotSelfUnblockException(ErrorCode errorCode) { super(errorCode); }
+
+    @Override
+    public HttpStatus getStatus() { return HttpStatus.BAD_REQUEST; }
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/block/service/BlockService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/block/service/BlockService.java
@@ -1,0 +1,44 @@
+package org.sopt.controller.block.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.block.facade.BlockFacade;
+import org.sopt.controller.block.exception.BlockApiErrorCode;
+import org.sopt.controller.block.exception.CannotSelfBlockException;
+import org.sopt.jwt.auth.util.UserAuthenticationUtils;
+import org.sopt.user.domain.User;
+import org.sopt.user.facade.UserFacade;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BlockService {
+
+    private final UserFacade userFacade;
+    private final BlockFacade blockFacade;
+
+    @Transactional
+    public Void blockUser(Long blockerId, Long blockedId) {
+        // 자기 자신인지 확인
+        if(blockerId.equals(blockedId)) {
+            throw new CannotSelfBlockException(BlockApiErrorCode.CANNOT_SELF_BLOCK);
+        }
+
+        Long firstId = Math.min(blockerId, blockedId);
+        long secondId = Math.max(blockerId, blockedId);
+
+        User firstUser = userFacade.getUserByIdWithLock(firstId);
+        User secondUser = userFacade.getUserByIdWithLock(secondId);
+
+        User blocker = (firstId.equals(blockerId)) ? firstUser : secondUser;
+        User blocked = (firstId.equals(blockedId)) ? firstUser : secondUser;
+
+        blockFacade.block(blocker, blocked);
+        return null;
+    }
+
+    public Void unblockUser(final Long userId) {
+
+        return null;
+    }
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/block/service/BlockService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/block/service/BlockService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.block.facade.BlockFacade;
 import org.sopt.controller.block.exception.BlockApiErrorCode;
 import org.sopt.controller.block.exception.CannotSelfBlockException;
+import org.sopt.controller.block.exception.CannotSelfUnblockException;
 import org.sopt.jwt.auth.util.UserAuthenticationUtils;
 import org.sopt.user.domain.User;
 import org.sopt.user.facade.UserFacade;
@@ -37,8 +38,16 @@ public class BlockService {
         return null;
     }
 
-    public Void unblockUser(final Long userId) {
+    @Transactional
+    public Void unblockUser(Long blockerId, Long unblockedId) {
+        if(blockerId.equals(unblockedId)) {
+            throw new CannotSelfUnblockException(BlockApiErrorCode.CANNOT_SELF_UNBLOCK);
+        }
 
+        User blocker = userFacade.getUserById(blockerId);
+        User unblocked = userFacade.getUserById(unblockedId);
+
+        blockFacade.unblock(blocker, unblocked);
         return null;
     }
 }

--- a/hilingual-api/src/main/resources/application.yml
+++ b/hilingual-api/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         show_sql: true

--- a/hilingual-domain/src/main/java/org/sopt/block/domain/Block.java
+++ b/hilingual-domain/src/main/java/org/sopt/block/domain/Block.java
@@ -1,4 +1,4 @@
-package org.sopt.block;
+package org.sopt.block.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -8,7 +8,17 @@ import lombok.NoArgsConstructor;
 import org.sopt.user.domain.User;
 
 @Entity
-@Table(name = BlockTableConstants.TABLE_BLOCK)
+@Table(
+        name = BlockTableConstants.TABLE_BLOCK,
+        uniqueConstraints = {
+        @UniqueConstraint(
+                columnNames = {
+                        BlockTableConstants.COLUMN_BLOCKER_ID,
+                        BlockTableConstants.COLUMN_BLOCKED_ID
+                }
+        )
+}
+)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter

--- a/hilingual-domain/src/main/java/org/sopt/block/domain/BlockTableConstants.java
+++ b/hilingual-domain/src/main/java/org/sopt/block/domain/BlockTableConstants.java
@@ -1,4 +1,4 @@
-package org.sopt.block;
+package org.sopt.block.domain;
 
 public class BlockTableConstants {
     public static final String TABLE_BLOCK = "Block";

--- a/hilingual-domain/src/main/java/org/sopt/block/exception/AlreadyBlockedUserException.java
+++ b/hilingual-domain/src/main/java/org/sopt/block/exception/AlreadyBlockedUserException.java
@@ -1,0 +1,11 @@
+package org.sopt.block.exception;
+
+import org.sopt.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class AlreadyBlockedUserException extends BlockCoreException {
+    public AlreadyBlockedUserException(ErrorCode errorCode) { super(errorCode); }
+
+    @Override
+    public HttpStatus getStatus() { return HttpStatus.CONFLICT; }
+}

--- a/hilingual-domain/src/main/java/org/sopt/block/exception/BlockCoreErrorCode.java
+++ b/hilingual-domain/src/main/java/org/sopt/block/exception/BlockCoreErrorCode.java
@@ -1,0 +1,33 @@
+package org.sopt.block.exception;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum BlockCoreErrorCode implements ErrorCode {
+
+    // 409
+    UNBLOCKABLE_USER(HttpStatus.CONFLICT, 40901, "차단할 수 없는 사용자입니다.."),
+    ALREADY_BLOCKED_USER(HttpStatus.CONFLICT, 40901, "이미 차단한 사용자입니다."),
+    ;
+
+    public final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus(){
+        return httpStatus;
+    }
+
+    @Override
+    public int getCode(){
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/hilingual-domain/src/main/java/org/sopt/block/exception/BlockCoreErrorCode.java
+++ b/hilingual-domain/src/main/java/org/sopt/block/exception/BlockCoreErrorCode.java
@@ -7,6 +7,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum BlockCoreErrorCode implements ErrorCode {
 
+    // 404
+    BLOCKED_NOT_FOUND(HttpStatus.NOT_FOUND, 40407, "차단 관계가 존재하지 않습니다."),
+
     // 409
     UNBLOCKABLE_USER(HttpStatus.CONFLICT, 40902, "차단할 수 없는 사용자입니다."),
     ALREADY_BLOCKED_USER(HttpStatus.CONFLICT, 40903, "이미 차단한 사용자입니다."),

--- a/hilingual-domain/src/main/java/org/sopt/block/exception/BlockCoreErrorCode.java
+++ b/hilingual-domain/src/main/java/org/sopt/block/exception/BlockCoreErrorCode.java
@@ -8,8 +8,8 @@ import org.springframework.http.HttpStatus;
 public enum BlockCoreErrorCode implements ErrorCode {
 
     // 409
-    UNBLOCKABLE_USER(HttpStatus.CONFLICT, 40901, "차단할 수 없는 사용자입니다.."),
-    ALREADY_BLOCKED_USER(HttpStatus.CONFLICT, 40901, "이미 차단한 사용자입니다."),
+    UNBLOCKABLE_USER(HttpStatus.CONFLICT, 40902, "차단할 수 없는 사용자입니다."),
+    ALREADY_BLOCKED_USER(HttpStatus.CONFLICT, 40903, "이미 차단한 사용자입니다."),
     ;
 
     public final HttpStatus httpStatus;

--- a/hilingual-domain/src/main/java/org/sopt/block/exception/BlockCoreException.java
+++ b/hilingual-domain/src/main/java/org/sopt/block/exception/BlockCoreException.java
@@ -1,0 +1,10 @@
+package org.sopt.block.exception;
+
+import org.sopt.exception.base.HilingualBaseException;
+import org.sopt.exception.code.ErrorCode;
+
+public abstract class BlockCoreException extends HilingualBaseException {
+    protected BlockCoreException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/hilingual-domain/src/main/java/org/sopt/block/exception/BlockedNotFoundException.java
+++ b/hilingual-domain/src/main/java/org/sopt/block/exception/BlockedNotFoundException.java
@@ -1,0 +1,11 @@
+package org.sopt.block.exception;
+
+import org.sopt.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class BlockedNotFoundException  extends BlockCoreException {
+    public BlockedNotFoundException(ErrorCode errorCode) { super(errorCode); }
+
+    @Override
+    public HttpStatus getStatus() { return HttpStatus.NOT_FOUND; }
+}

--- a/hilingual-domain/src/main/java/org/sopt/block/exception/UnblockableUserException.java
+++ b/hilingual-domain/src/main/java/org/sopt/block/exception/UnblockableUserException.java
@@ -1,0 +1,11 @@
+package org.sopt.block.exception;
+
+import org.sopt.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class UnblockableUserException  extends BlockCoreException {
+    public UnblockableUserException(ErrorCode errorCode) { super(errorCode); }
+
+    @Override
+    public HttpStatus getStatus() { return HttpStatus.CONFLICT; }
+}

--- a/hilingual-domain/src/main/java/org/sopt/block/facade/BlockFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/block/facade/BlockFacade.java
@@ -1,0 +1,32 @@
+package org.sopt.block.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.block.exception.AlreadyBlockedUserException;
+import org.sopt.block.exception.BlockCoreErrorCode;
+import org.sopt.block.exception.UnblockableUserException;
+import org.sopt.user.domain.User;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class BlockFacade {
+
+    private final BlockRetriever blockRetriever;
+    private final BlockSaver blockSaver;
+
+    @Transactional
+    public void block(User blocker, User blocked) {
+        // 역방향 존재 확인 (상대가 이미 나를 차단했는지)
+        if (blockRetriever.existsByReverseBlockerAndBlocked(blocker, blocked)) {
+            throw new UnblockableUserException(BlockCoreErrorCode.UNBLOCKABLE_USER);
+        }
+
+        // 정방향 존재 확인 (이미 내가 차단했는지)
+        if (blockRetriever.existsByBlockerAndBlocked(blocker, blocked)) {
+            throw new AlreadyBlockedUserException(BlockCoreErrorCode.ALREADY_BLOCKED_USER);
+        }
+
+        blockSaver.save(blocker, blocked);
+    }
+}

--- a/hilingual-domain/src/main/java/org/sopt/block/facade/BlockFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/block/facade/BlockFacade.java
@@ -1,8 +1,10 @@
 package org.sopt.block.facade;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.block.domain.Block;
 import org.sopt.block.exception.AlreadyBlockedUserException;
 import org.sopt.block.exception.BlockCoreErrorCode;
+import org.sopt.block.exception.BlockedNotFoundException;
 import org.sopt.block.exception.UnblockableUserException;
 import org.sopt.user.domain.User;
 import org.springframework.stereotype.Component;
@@ -28,5 +30,13 @@ public class BlockFacade {
         }
 
         blockSaver.save(blocker, blocked);
+    }
+
+    @Transactional
+    public void unblock(User blocker, User unblocked) {
+        Block relation = blockRetriever.findRelation(blocker, unblocked)
+                .orElseThrow(() -> new BlockedNotFoundException(BlockCoreErrorCode.BLOCKED_NOT_FOUND));
+
+        blockSaver.delete(relation);
     }
 }

--- a/hilingual-domain/src/main/java/org/sopt/block/facade/BlockRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/block/facade/BlockRetriever.java
@@ -1,0 +1,28 @@
+package org.sopt.block.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.block.domain.Block;
+import org.sopt.block.repository.BlockRepository;
+import org.sopt.user.domain.User;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class BlockRetriever {
+
+    private final BlockRepository blockRepository;
+
+    public boolean existsByBlockerAndBlocked(User blocker, User blocked) {
+        return blockRepository.existsByBlockerAndBlocked(blocker, blocked);
+    }
+
+    public boolean existsByReverseBlockerAndBlocked(User blocker, User blocked) {
+        return blockRepository.existsByReverseBlockerAndBlocked(blocker, blocked);
+    }
+
+    public Optional<Block> findRelation(User blocker, User blocked) {
+        return blockRepository.findByBlockerAndBlocked(blocker, blocked);
+    }
+}

--- a/hilingual-domain/src/main/java/org/sopt/block/facade/BlockSaver.java
+++ b/hilingual-domain/src/main/java/org/sopt/block/facade/BlockSaver.java
@@ -24,4 +24,9 @@ public class BlockSaver {
             throw new AlreadyBlockedUserException(BlockCoreErrorCode.ALREADY_BLOCKED_USER);
         }
     }
+
+    @Transactional
+    public void delete(Block block) {
+        blockRepository.delete(block);
+    }
 }

--- a/hilingual-domain/src/main/java/org/sopt/block/facade/BlockSaver.java
+++ b/hilingual-domain/src/main/java/org/sopt/block/facade/BlockSaver.java
@@ -1,0 +1,27 @@
+package org.sopt.block.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.block.domain.Block;
+import org.sopt.block.exception.AlreadyBlockedUserException;
+import org.sopt.block.exception.BlockCoreErrorCode;
+import org.sopt.block.repository.BlockRepository;
+import org.sopt.user.domain.User;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class BlockSaver {
+
+    private final BlockRepository blockRepository;
+
+    @Transactional
+    public Block save(User blocker, User blocked) {
+        try {
+            return blockRepository.save(Block.create(blocker, blocked));
+        } catch (DataIntegrityViolationException e) {
+            throw new AlreadyBlockedUserException(BlockCoreErrorCode.ALREADY_BLOCKED_USER);
+        }
+    }
+}

--- a/hilingual-domain/src/main/java/org/sopt/block/repository/BlockRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/block/repository/BlockRepository.java
@@ -1,0 +1,36 @@
+package org.sopt.block.repository;
+
+import org.sopt.block.domain.Block;
+import org.sopt.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface BlockRepository extends JpaRepository<Block, Long> {
+
+    @Query("""
+           SELECT CASE WHEN EXISTS (
+               SELECT 1 FROM Block b
+               WHERE b.blocker = :blocker AND b.blocked = :blocked
+           ) THEN true ELSE false END
+           """)
+    boolean existsByBlockerAndBlocked(@Param("blocker") User blocker, @Param("blocked") User blocked);
+
+    @Query("""
+           SELECT CASE WHEN EXISTS (
+               SELECT 1 FROM Block b
+               WHERE b.blocker = :blocked AND b.blocked = :blocker
+           ) THEN true ELSE false END
+           """)
+    boolean existsByReverseBlockerAndBlocked(@Param("blocker") User blocker, @Param("blocked") User blocked);
+
+    @Query("""
+           SELECT b FROM Block b
+           WHERE b.blocker = :blocker AND b.blocked = :blocked
+           """)
+    Optional<Block> findByBlockerAndBlocked(@Param("blocker") User blocker,
+                                            @Param("blocked") User blocked);
+
+}

--- a/hilingual-domain/src/main/java/org/sopt/follow/domain/Follow.java
+++ b/hilingual-domain/src/main/java/org/sopt/follow/domain/Follow.java
@@ -1,4 +1,4 @@
-package org.sopt.follow;
+package org.sopt.follow.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/hilingual-domain/src/main/java/org/sopt/follow/domain/FollowTableConstants.java
+++ b/hilingual-domain/src/main/java/org/sopt/follow/domain/FollowTableConstants.java
@@ -1,4 +1,4 @@
-package org.sopt.follow;
+package org.sopt.follow.domain;
 
 public class FollowTableConstants {
     public static final String TABLE_FOLLOW = "Follow";

--- a/hilingual-domain/src/main/java/org/sopt/user/facade/UserFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/user/facade/UserFacade.java
@@ -15,6 +15,10 @@ public class UserFacade {
         return userRetriever.findByUserId(userId);
     }
 
+    public User getUserByIdWithLock(final long userId){
+        return userRetriever.findByUserIdWithLock(userId);
+    }
+
     public void save(final User user){
         userSaver.save(user);
     }

--- a/hilingual-domain/src/main/java/org/sopt/user/facade/UserRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/user/facade/UserRetriever.java
@@ -21,6 +21,11 @@ public class UserRetriever {
                 .orElseThrow(() -> new UserNotFoundException(UserCoreErrorCode.USER_NOT_FOUND));
     }
 
+    public User findByUserIdWithLock(final long userId) {
+        return userRepository.findByIdWithLock(userId)
+                .orElseThrow(() -> new UserNotFoundException(UserCoreErrorCode.USER_NOT_FOUND));
+    }
+
     public boolean isNicknameExists(String nickname) {
         return userProfileRepository.existsByNickname(nickname);
     }

--- a/hilingual-domain/src/main/java/org/sopt/user/repository/UserRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/user/repository/UserRepository.java
@@ -1,11 +1,20 @@
 package org.sopt.user.repository;
 
 
+import jakarta.persistence.LockModeType;
 import org.sopt.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+
     Optional<User> findByProviderAndProviderId(String provider, String providerId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT u FROM User u WHERE u.id = :id")
+    Optional<User> findByIdWithLock(@Param("id") Long userId);
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #149 

## Work Description ✏️
- 유저 차단 API 구현
- 유저 차단 해제 API 구현

## Screenshot 📸
### 유저 차단 API

|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 성공 (200) | <img width="350" height="489" alt="image" src="https://github.com/user-attachments/assets/2b48b61d-9823-4193-aa84-f8f1d3b0580d" /> |
| 자기 자신 차단하는 경우(400) | <img width="361" height="491" alt="image" src="https://github.com/user-attachments/assets/e32ba5e9-538c-40f3-88e2-7c6955292f37" /> |
| 액세스 토큰 오류(401) | <img width="308" height="511" alt="image" src="https://github.com/user-attachments/assets/13c31b40-d3c4-429e-a74e-952c7f68ba6e" /> | 이미 차단한 유저(409) | <img width="329" height="466" alt="image" src="https://github.com/user-attachments/assets/90d8a338-e3ba-4697-9212-f790fd4e5d54" /> |
| 차단할 수 없는 사용자. 나를 차단한 사용자를 차단하려고 할 때(409) | <img width="430" height="491" alt="image" src="https://github.com/user-attachments/assets/1ab980e7-b219-46c8-9458-5730a6334c21" /> |

### 유저 차단 해제 API

|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 성공(200)      | <img width="401" height="497" alt="image" src="https://github.com/user-attachments/assets/53758d88-03d1-46d0-95e8-4411779fabc2" /> |
| 자기 자신 차단 해제하는 경우(400) | <img width="341" height="490" alt="image" src="https://github.com/user-attachments/assets/b965f018-4280-49ef-a249-7ae1e4fbb8b9" /> | 나를 차단한 유저(404)를 차단 해제하는 경우 | <img width="385" height="491" alt="image" src="https://github.com/user-attachments/assets/0992a36a-c83f-4e76-9f17-505b5c3b752a" /> |
| 차단 관계가 없는 유저를 차단 해제하는 경우(404) | <img width="379" height="499" alt="image" src="https://github.com/user-attachments/assets/84e86e6c-de33-43cb-8134-9e0414f25b18" /> |
| 존재하지 않는 사용자를 차단 해제하는 경우(404) | <img width="401" height="489" alt="image" src="https://github.com/user-attachments/assets/0a869568-6b26-46a9-ba59-7da5441ac2ad" /> |



## Uncompleted Tasks 😅
N/A

## To Reviewers 📢

> ### ✅차단 로직
1. 차단하고 싶은 유저 ID(blocked_id)를 param으로 받음
3. 액세스 토큰을 바탕으로 차단을 요청한 유저 ID(blocker_id)를 찾음
    1. blocked_id와 blocker_id가 같은 경우 예외 처리 “자기 자신은 차단할 수 없습니다.”
4. Block DB에 접근
    1. blocker_id - blocked_id 쌍이 존재하지 않는 경우
        1. blocker_id - blocked_id 쌍 DB에 집어넣기
    2. Block DB에 blocker_id - blocked_id 쌍이 존재하는 경우
        1. 예외 처리 “이미 차단된 유저입니다.”
 
<br>

> ### ✅안정성을 위한 예외 처리
1. DB레벨에서 unique제약
2. Service레벨에서 중복 차단 유저 조합 있는지 확인
3. 예외 처리

<br> 

> ### 🤔동시에 두 유저가 서로를 차단하려고 하면 어떡하지?

- A가 B를 차단하면 B는 A의 프로필조차 볼 수 없어서 차단 자체가 불가능함.
- 하지만 만약에 A와 B가 각자 서로의 프로필을 켜두고 동시에 차단 버튼을 누르는 상황이 있다면?
→ 0.01ms라도 빨리 누른 사람을 blocker_id로 해야 함. 그리고 더 늦게 누른 사람에겐 차단할 수 없는 유저라는 식의 예외 처리를 해야 함. 

<br>

**Block 테이블에서 (blocker_id, blocked_id) 에 unique 쌍을 걸어주었으나, 이 경우 (blocked_id, blocker_id) 경우를 걸러내줄 수 없음.**
따라서,
1. 애플리케이션 레벨에서 양방향 1쌍만 존재하도록 정의 → “이미 역방향 차단이 있는지” 검사
2. Lock을 활용해 동시성 제어
    1. 비관적 락
    2. 낙관적 락
 
→ A와 B가 서로 차단하는 경우 충돌 가능성이 높으므로 **`비관적 락`** 사용
5. 정책적으로 먼저 들어온 요청만 성공 처리(먼저 commit된 요청만 성공 처리)

### ✅ 비관적 락 적용

- User행 잠그기(Block 행은 아직 생성 전이므로)
- 모든 트랜잭션이 같은 순서로 락을 잡을 수 있도록, block 로직에서 작은 ID → 큰 ID 순서로 잠그는 규칙 생성 → 교착 상태 방지
- 동시 차단 시 먼저 락 잡은 트랜잭션만 성공