### PR TITLE
[feat] #151 차단한 계정 목록 조회 API 구현

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/block/api/BlockController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/block/api/BlockController.java
@@ -2,7 +2,7 @@ package org.sopt.controller.block.api;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
-import org.sopt.controller.block.dto.BlockedUserProfileDtoRes;
+import org.sopt.controller.userprofile.dto.UserProfileSummaryDtoRes;
 import org.sopt.controller.block.service.BlockService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -36,7 +36,7 @@ public class BlockController {
     }
 
     @GetMapping("/mypage/blocks")
-    public ResponseEntity<List<BlockedUserProfileDtoRes>> getBlockedUserList(){
+    public ResponseEntity<List<UserProfileSummaryDtoRes>> getBlockedUserList(){
         Long userId = 1L;
         // TODO Long userId = UserAuthenticationUtils.getCurrentUserId();
         return ResponseEntity.ok(blockService.getBlockedUserList(userId));

--- a/hilingual-api/src/main/java/org/sopt/controller/block/api/BlockController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/block/api/BlockController.java
@@ -2,9 +2,12 @@ package org.sopt.controller.block.api;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import org.sopt.controller.block.dto.BlockedUserProfileDtoRes;
 import org.sopt.controller.block.service.BlockService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,5 +33,12 @@ public class BlockController {
         Long blockerId = 1L;
         // TODO Long blockerId = UserAuthenticationUtils.getCurrentUserId();
         return ResponseEntity.ok(blockService.unblockUser(blockerId, unblockedId));
+    }
+
+    @GetMapping("/mypage/blocks")
+    public ResponseEntity<List<BlockedUserProfileDtoRes>> getBlockedUserList(){
+        Long userId = 1L;
+        // TODO Long userId = UserAuthenticationUtils.getCurrentUserId();
+        return ResponseEntity.ok(blockService.getBlockedUserList(userId));
     }
 }

--- a/hilingual-api/src/main/java/org/sopt/controller/block/dto/BlockedUserProfileDtoRes.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/block/dto/BlockedUserProfileDtoRes.java
@@ -1,0 +1,17 @@
+package org.sopt.controller.block.dto;
+
+import org.sopt.userprofile.domain.UserProfile;
+
+public record BlockedUserProfileDtoRes(
+        Long userId,
+        String profileImg,
+        String nickname
+){
+    public static BlockedUserProfileDtoRes from(UserProfile profile) {
+        return new BlockedUserProfileDtoRes(
+                profile.getUser().getId(),
+                profile.getProfileImg(),
+                profile.getNickname()
+        );
+    }
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/block/service/BlockService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/block/service/BlockService.java
@@ -2,14 +2,16 @@ package org.sopt.controller.block.service;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.block.facade.BlockFacade;
+import org.sopt.controller.block.dto.BlockedUserProfileDtoRes;
 import org.sopt.controller.block.exception.BlockApiErrorCode;
 import org.sopt.controller.block.exception.CannotSelfBlockException;
 import org.sopt.controller.block.exception.CannotSelfUnblockException;
-import org.sopt.jwt.auth.util.UserAuthenticationUtils;
 import org.sopt.user.domain.User;
 import org.sopt.user.facade.UserFacade;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -49,5 +51,15 @@ public class BlockService {
 
         blockFacade.unblock(blocker, unblocked);
         return null;
+    }
+
+    public List<BlockedUserProfileDtoRes> getBlockedUserList(Long userId) {
+        // 유저 존재 여부 확인(없을 시 UserRetriever에서 not found 예외 처리)
+        userFacade.getUserById(userId);
+
+        return blockFacade.getBlockedUserProfiles(userId)
+                .stream()
+                .map(BlockedUserProfileDtoRes::from)
+                .toList();
     }
 }

--- a/hilingual-api/src/main/java/org/sopt/controller/block/service/BlockService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/block/service/BlockService.java
@@ -2,12 +2,13 @@ package org.sopt.controller.block.service;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.block.facade.BlockFacade;
-import org.sopt.controller.block.dto.BlockedUserProfileDtoRes;
+import org.sopt.controller.userprofile.dto.UserProfileSummaryDtoRes;
 import org.sopt.controller.block.exception.BlockApiErrorCode;
 import org.sopt.controller.block.exception.CannotSelfBlockException;
 import org.sopt.controller.block.exception.CannotSelfUnblockException;
 import org.sopt.user.domain.User;
 import org.sopt.user.facade.UserFacade;
+import org.sopt.userprofile.facade.UserProfileFacade;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +20,7 @@ public class BlockService {
 
     private final UserFacade userFacade;
     private final BlockFacade blockFacade;
+    private final UserProfileFacade userProfileFacade;
 
     @Transactional
     public Void blockUser(Long blockerId, Long blockedId) {
@@ -53,13 +55,15 @@ public class BlockService {
         return null;
     }
 
-    public List<BlockedUserProfileDtoRes> getBlockedUserList(Long userId) {
+    public List<UserProfileSummaryDtoRes> getBlockedUserList(Long userId) {
         // 유저 존재 여부 확인(없을 시 UserRetriever에서 not found 예외 처리)
         userFacade.getUserById(userId);
 
-        return blockFacade.getBlockedUserProfiles(userId)
+        List<Long> blockedUserId = blockFacade.getBlockedUserId(userId);
+
+        return userProfileFacade.getProfilesByUserIds(blockedUserId)
                 .stream()
-                .map(BlockedUserProfileDtoRes::from)
+                .map(UserProfileSummaryDtoRes::from)
                 .toList();
     }
 }

--- a/hilingual-api/src/main/java/org/sopt/controller/userprofile/dto/UserProfileSummaryDtoRes.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/userprofile/dto/UserProfileSummaryDtoRes.java
@@ -1,14 +1,14 @@
-package org.sopt.controller.block.dto;
+package org.sopt.controller.userprofile.dto;
 
 import org.sopt.userprofile.domain.UserProfile;
 
-public record BlockedUserProfileDtoRes(
+public record UserProfileSummaryDtoRes(
         Long userId,
         String profileImg,
         String nickname
 ){
-    public static BlockedUserProfileDtoRes from(UserProfile profile) {
-        return new BlockedUserProfileDtoRes(
+    public static UserProfileSummaryDtoRes from(UserProfile profile) {
+        return new UserProfileSummaryDtoRes(
                 profile.getUser().getId(),
                 profile.getProfileImg(),
                 profile.getNickname()

--- a/hilingual-domain/src/main/java/org/sopt/block/domain/Block.java
+++ b/hilingual-domain/src/main/java/org/sopt/block/domain/Block.java
@@ -27,7 +27,7 @@ public class Block {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = BlockTableConstants.COLUMN_BLOCK_ID)
-    private Long blockId;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = BlockTableConstants.COLUMN_BLOCKER_ID, nullable = false)

--- a/hilingual-domain/src/main/java/org/sopt/block/domain/BlockTableConstants.java
+++ b/hilingual-domain/src/main/java/org/sopt/block/domain/BlockTableConstants.java
@@ -2,7 +2,7 @@ package org.sopt.block.domain;
 
 public class BlockTableConstants {
     public static final String TABLE_BLOCK = "Block";
-    public static final String COLUMN_BLOCK_ID = "block_id";
+    public static final String COLUMN_BLOCK_ID = "id";
     public static final String COLUMN_BLOCKER_ID = "blocker_id";
     public static final String COLUMN_BLOCKED_ID = "blocked_id";
 }

--- a/hilingual-domain/src/main/java/org/sopt/block/facade/BlockFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/block/facade/BlockFacade.java
@@ -6,9 +6,13 @@ import org.sopt.block.exception.AlreadyBlockedUserException;
 import org.sopt.block.exception.BlockCoreErrorCode;
 import org.sopt.block.exception.BlockedNotFoundException;
 import org.sopt.block.exception.UnblockableUserException;
+import org.sopt.block.repository.BlockRepository;
 import org.sopt.user.domain.User;
+import org.sopt.userprofile.domain.UserProfile;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -16,6 +20,7 @@ public class BlockFacade {
 
     private final BlockRetriever blockRetriever;
     private final BlockSaver blockSaver;
+    private final BlockRepository blockRepository;
 
     @Transactional
     public void block(User blocker, User blocked) {
@@ -38,5 +43,13 @@ public class BlockFacade {
                 .orElseThrow(() -> new BlockedNotFoundException(BlockCoreErrorCode.BLOCKED_NOT_FOUND));
 
         blockSaver.delete(relation);
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserProfile> getBlockedUserProfiles(Long blockerId) {
+        List<User> blockedUsers = blockRetriever.findBlockedUsers(blockerId);
+        return blockedUsers.stream()
+                .map(User::getUserProfile)
+                .toList();
     }
 }

--- a/hilingual-domain/src/main/java/org/sopt/block/facade/BlockFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/block/facade/BlockFacade.java
@@ -20,7 +20,6 @@ public class BlockFacade {
 
     private final BlockRetriever blockRetriever;
     private final BlockSaver blockSaver;
-    private final BlockRepository blockRepository;
 
     @Transactional
     public void block(User blocker, User blocked) {
@@ -46,10 +45,7 @@ public class BlockFacade {
     }
 
     @Transactional(readOnly = true)
-    public List<UserProfile> getBlockedUserProfiles(Long blockerId) {
-        List<User> blockedUsers = blockRetriever.findBlockedUsers(blockerId);
-        return blockedUsers.stream()
-                .map(User::getUserProfile)
-                .toList();
+    public List<Long> getBlockedUserId(Long blockerId) {
+        return blockRetriever.findBlockedUserId(blockerId);
     }
 }

--- a/hilingual-domain/src/main/java/org/sopt/block/facade/BlockRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/block/facade/BlockRetriever.java
@@ -27,7 +27,7 @@ public class BlockRetriever {
         return blockRepository.findByBlockerAndBlocked(blocker, blocked);
     }
 
-    public List<User> findBlockedUsers(Long blockerId) {
+    public List<Long> findBlockedUserId(Long blockerId) {
         return blockRepository.findBlockedUsers(blockerId);
     }
 }

--- a/hilingual-domain/src/main/java/org/sopt/block/facade/BlockRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/block/facade/BlockRetriever.java
@@ -6,6 +6,7 @@ import org.sopt.block.repository.BlockRepository;
 import org.sopt.user.domain.User;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Optional;
 
 @Component
@@ -24,5 +25,9 @@ public class BlockRetriever {
 
     public Optional<Block> findRelation(User blocker, User blocked) {
         return blockRepository.findByBlockerAndBlocked(blocker, blocked);
+    }
+
+    public List<User> findBlockedUsers(Long blockerId) {
+        return blockRepository.findBlockedUsers(blockerId);
     }
 }

--- a/hilingual-domain/src/main/java/org/sopt/block/repository/BlockRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/block/repository/BlockRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BlockRepository extends JpaRepository<Block, Long> {
@@ -32,5 +33,8 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
            """)
     Optional<Block> findByBlockerAndBlocked(@Param("blocker") User blocker,
                                             @Param("blocked") User blocked);
+
+    @Query("SELECT b.blocked FROM Block b WHERE b.blocker.id = :blockerId")
+    List<User> findBlockedUsers(@Param("blockerId") Long blockerId);
 
 }

--- a/hilingual-domain/src/main/java/org/sopt/block/repository/BlockRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/block/repository/BlockRepository.java
@@ -34,7 +34,7 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
     Optional<Block> findByBlockerAndBlocked(@Param("blocker") User blocker,
                                             @Param("blocked") User blocked);
 
-    @Query("SELECT b.blocked FROM Block b WHERE b.blocker.id = :blockerId")
-    List<User> findBlockedUsers(@Param("blockerId") Long blockerId);
+    @Query("SELECT b.blocked.id FROM Block b WHERE b.blocker.id = :blockerId")
+    List<Long> findBlockedUsers(@Param("blockerId") Long blockerId);
 
 }

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileFacade.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.userprofile.domain.UserProfile;
 import org.sopt.userprofile.dto.UserProfileRes;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -34,6 +35,11 @@ public class UserProfileFacade {
 
     public List<UserProfile> findAll() {
         return userProfileRetriever.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserProfile> getProfilesByUserIds(List<Long> userIds) {
+        return userProfileRetriever.findByUserIds(userIds);
     }
 
     /**

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileRetriever.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 public class UserProfileRetriever {
 
     private final UserProfileRepository userProfileRepository;
-    private final DiaryRepository diaryRepository;
 
 
     public UserProfile findByUserId(final Long userId) {
@@ -39,5 +38,7 @@ public class UserProfileRetriever {
         return UserProfileRes.from(profile);
     }
 
-
+    public List<UserProfile> findByUserIds(List<Long> userIds) {
+        return userProfileRepository.findByUserIds(userIds);
+    }
 }

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/repository/UserProfileRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/repository/UserProfileRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserProfileRepository extends JpaRepository<UserProfile, Long> {
@@ -19,5 +20,12 @@ public interface UserProfileRepository extends JpaRepository<UserProfile, Long> 
     Optional<UserProfile> findByUserId(@Param("userId") Long userId);
 
     Optional<UserProfile> findByUser(User user);
+
+    @Query("""
+           SELECT up
+           FROM UserProfile up
+           WHERE up.user.id IN :userIds
+           """)
+    List<UserProfile> findByUserIds(@Param("userIds") List<Long> userIds);
 }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #151 

## Work Description ✏️
- 차단한 계정 목록 조회 API 구현

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 차단 계정 목록 조회 구현 성공(200) | <img width="539" height="632" alt="image" src="https://github.com/user-attachments/assets/8fee37fc-d29e-492d-823e-7b32a9ea9f32" /> |
| 차단 계정 없을 때(200) | <img width="376" height="495" alt="image" src="https://github.com/user-attachments/assets/d9197df6-b724-4dce-b6d7-2b7e8faa1751" /> |

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢

> ### BlcokedUserProfileDto는 block 도메인에 위치해야 하는가, userprofile 도메인에 위치해야 하는가?
Block에서 blocker_id에 대한 blocked_id를 조회하고, 그 blocked_id에 해당하는 UserProfile을 조회해서 내려줌. 

---

- **Block 도메인** → 차단 관계 자체만 관리 (blocker, blocked 관계)
- **UserProfile 도메인** → 사용자 정보 표현 (DTO 포함)
- **BlockedUserProfileDto** → 사실상 "UserProfile의 요약 정보"를 담는 역할이므로 **UserProfile 모듈에 두는 것이 더 적절**

⇒ **BlockService는 blockedUserIds만 모아서 UserProfileFacade에 전달** → **UserProfileFacade가 BlockedUserProfileDto리스트로 변환** → Controller에서 응답
⇒ BlockedUserProfileDto를 userprofile > dto 패키지로 이동 및 UserProfileSummaryDto로 네이밍 변경 : 재활용 가능