### PR TITLE
[refac] #168  도메인 연결에 따른 nginx 변경 및 배포 파이프라인 대공사

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -39,7 +39,7 @@ jobs:
           target:      "/home/ubuntu/nginx/"
           strip_components: 1
 
-      - name: 🔧 Start/Reload Nginx on Nginx EC2
+      - name: 🔧 Ensure Nginx container is up (DEV)
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ env.NGINX_HOST }}
@@ -52,51 +52,10 @@ jobs:
           script: |
             set -e
             cd ~/nginx
-
-            # 값 준비
-            TARGET_UPSTREAM="${{ env.APP_HOST }}:8081"
-            PROJECT="hilingual"
-            SERVICE="nginx"
-
-            # Docker 데몬 보장
             sudo systemctl start docker
             sudo systemctl enable docker >/dev/null 2>&1 || true
-
-            # sudo가 env를 보존하도록
-            C="sudo --preserve-env=TARGET_UPSTREAM docker compose -p ${PROJECT}"
-
-            # 컨테이너가 이미 떠 있으면 무중단 reload
-            cid=$($C ps -q ${SERVICE} || true)
-            if [ -n "$cid" ] && sudo docker ps -q --no-trunc | grep -q "$cid"; then
-              sudo docker exec -e TARGET_UPSTREAM="$TARGET_UPSTREAM" "$cid" \
-                /bin/sh -lc "envsubst '\$TARGET_UPSTREAM' < /etc/nginx/nginx.template.conf > /etc/nginx/conf.d/default.conf && nginx -t && nginx -s reload"
-              exit 0
-            fi
-
-            # 없으면 최초 기동 (호스트 nginx 충돌 방지)
-            sudo systemctl stop nginx 2>/dev/null || true
-            $C up -d --remove-orphans ${SERVICE}
-
-            # 컨테이너 기동 대기: 라벨로 안정적으로 조회
-            i=0
-            cid=""
-            while [ $i -lt 30 ]; do
-              cid=$(sudo docker ps -q \
-                -f "label=com.docker.compose.project=${PROJECT}" \
-                -f "label=com.docker.compose.service=${SERVICE}")
-              [ -n "$cid" ] && break
-              i=$((i+1))
-              sleep 1
-            done
-            if [ -z "$cid" ]; then
-              echo "nginx container not found after up; compose ps follows:"
-              $C ps || true
-              exit 1
-            fi
-
-            # 템플릿 치환 + 검증 + 리로드
-            sudo docker exec -e TARGET_UPSTREAM="$TARGET_UPSTREAM" "$cid" \
-              /bin/sh -lc "envsubst '\$TARGET_UPSTREAM' < /etc/nginx/nginx.template.conf > /etc/nginx/conf.d/default.conf && nginx -t && nginx -s reload"
+            sudo docker compose -p hilingual up -d --remove-orphans nginx
+            
       
 
       - name: 📦 Copy JAR to Target
@@ -150,11 +109,12 @@ jobs:
             ssh-keyscan -H ${{ env.NGINX_HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
       
 
-      - name: 🔐 Deploy via Bastion    # ⑥ Bastion 경유 SSH 배포
+      - name: 🔐 Deploy via Bastion(DEV)    # ⑥ Bastion 경유 SSH 배포
         uses: appleboy/ssh-action@v1.0.3
         env:
           APP_HOST:   ${{ env.APP_HOST }}        # deploy.sh 에 전달될 변수
           NGINX_HOST: ${{ env.NGINX_HOST }}
+          UPSTREAM_ENV: dev
         with:
           host:          ${{ env.APP_HOST }}  #  dev App EC2
           username:      ubuntu
@@ -163,7 +123,7 @@ jobs:
           proxy_username: ubuntu
           proxy_key:     ${{ secrets.SSH_KEY }}
           script_stop:   true                       # 서버 오류 시 Job Fail.
-          envs: APP_HOST,NGINX_HOST
+          envs: APP_HOST,NGINX_HOST,UPSTREAM_ENV
           script: |
             set -e
             mkdir -p /home/ubuntu/artifacts
@@ -179,7 +139,7 @@ jobs:
             mv /home/ubuntu/artifacts/*.jar build/libs/
             
             chmod +x deploy.sh
-            ./deploy.sh
+            UPSTREAM_ENV=${UPSTREAM_ENV} APP_HOST=${APP_HOST} NGINX_HOST=${NGINX_HOST} ./deploy.sh
 
       - name: 📢 Discord notify
         if: always()

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -43,7 +43,7 @@ jobs:
           target:      "/home/ubuntu/nginx/"
           strip_components: 1
 
-      - name: 🔧 Start/Reload Nginx on Nginx EC2
+      - name: 🔧 Ensure Nginx container is up (PROD)
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ env.NGINX_HOST }}
@@ -56,51 +56,10 @@ jobs:
           script: |
             set -e
             cd ~/nginx
-
-            # 값 준비
-            TARGET_UPSTREAM="${{ env.APP_HOST }}:8081"
-            PROJECT="hilingual"
-            SERVICE="nginx"
-
-            # Docker 데몬 보장
             sudo systemctl start docker
             sudo systemctl enable docker >/dev/null 2>&1 || true
-
-            # sudo가 env를 보존하도록
-            C="sudo --preserve-env=TARGET_UPSTREAM docker compose -p ${PROJECT}"
-
-            # 컨테이너가 이미 떠 있으면 무중단 reload
-            cid=$($C ps -q ${SERVICE} || true)
-            if [ -n "$cid" ] && sudo docker ps -q --no-trunc | grep -q "$cid"; then
-              sudo docker exec -e TARGET_UPSTREAM="$TARGET_UPSTREAM" "$cid" \
-                /bin/sh -lc "envsubst '\$TARGET_UPSTREAM' < /etc/nginx/nginx.template.conf > /etc/nginx/conf.d/default.conf && nginx -t && nginx -s reload"
-              exit 0
-            fi
-
-            # 없으면 최초 기동 (호스트 nginx 충돌 방지)
-            sudo systemctl stop nginx 2>/dev/null || true
-            $C up -d --remove-orphans ${SERVICE}
-
-            # 컨테이너 기동 대기: 라벨로 안정적으로 조회
-            i=0
-            cid=""
-            while [ $i -lt 30 ]; do
-              cid=$(sudo docker ps -q \
-                -f "label=com.docker.compose.project=${PROJECT}" \
-                -f "label=com.docker.compose.service=${SERVICE}")
-              [ -n "$cid" ] && break
-              i=$((i+1))
-              sleep 1
-            done
-            if [ -z "$cid" ]; then
-              echo "nginx container not found after up; compose ps follows:"
-              $C ps || true
-              exit 1
-            fi
-
-            # 템플릿 치환 + 검증 + 리로드
-            sudo docker exec -e TARGET_UPSTREAM="$TARGET_UPSTREAM" "$cid" \
-              /bin/sh -lc "envsubst '\$TARGET_UPSTREAM' < /etc/nginx/nginx.template.conf > /etc/nginx/conf.d/default.conf && nginx -t && nginx -s reload"
+            sudo docker compose -p hilingual up -d --remove-orphans nginx
+            
 
       - name: 📦 Copy JAR to Target   # 러너 → Target 전송
         uses: appleboy/scp-action@v0.1.6
@@ -154,11 +113,12 @@ jobs:
             ssh-keyscan -H ${{ env.NGINX_HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
       
 
-      - name: 🔐 Deploy via Bastion    # deploy.sh 실행
+      - name: 🔐 Deploy via Bastion (PROD)   # deploy.sh 실행
         uses: appleboy/ssh-action@v1.0.3
         env:
           APP_HOST:   ${{ env.APP_HOST }}
           NGINX_HOST: ${{ env.NGINX_HOST }}
+          UPSTREAM_ENV: prod
         with:
           host:           ${{ env.APP_HOST }}    # prod App EC2
           username:       ubuntu
@@ -167,7 +127,7 @@ jobs:
           proxy_username: ubuntu
           proxy_key:      ${{ secrets.SSH_KEY }}
           script_stop:    true
-          envs: APP_HOST,NGINX_HOST
+          envs: APP_HOST,NGINX_HOST,UPSTREAM_ENV
           script: |
             set -e
             mkdir -p /home/ubuntu/artifacts
@@ -183,7 +143,7 @@ jobs:
             mv /home/ubuntu/artifacts/*.jar build/libs/
             
             chmod +x deploy.sh
-            ./deploy.sh
+            UPSTREAM_ENV=${UPSTREAM_ENV} APP_HOST=${APP_HOST} NGINX_HOST=${NGINX_HOST} ./deploy.sh
 
       - name: 📢 Discord notify
         if: always()

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,57 +1,77 @@
 #!/bin/bash
-set -e                                  # 명령 실패 시 즉시 종료
+set -e  # 명령 실패 시 즉시 종료
 
-## 테스트용 주석 변경!!! ##
-######## 0) 지금 어떤 색 컨테이너가 떠 있는지 확인 ############
-#  └─ 둘 다 없으면 “첫 배포” 라고 간주
+############################################
+# 입력 환경변수
+# - APP_HOST:   App EC2 Private IP
+# - NGINX_HOST: Nginx EC2 Private IP
+# - UPSTREAM_ENV: dev | prod  (배포 대상 도메인 그룹)
+############################################
+
+UPSTREAM_ENV="${UPSTREAM_ENV:-}"
+SSH_KEY=~/.ssh/hilingual_actions
+SSH_HOST="ubuntu@${NGINX_HOST}"
+SSH="ssh -i ${SSH_KEY} -o IdentitiesOnly=yes -o StrictHostKeyChecking=no ${SSH_HOST}"
+
+######## 0) 현재 떠 있는 색 확인 ########
 if  docker ps --format '{{.Names}}' | grep -q hilingual-blue ; then
   CURRENT="blue"
 elif docker ps --format '{{.Names}}' | grep -q hilingual-green ; then
   CURRENT="green"
 else
-  CURRENT=""                            # ← 첫 배포
+  CURRENT=""  # 첫 배포
 fi
 
-# 이번에 띄울 색·포트 결정
+######## 새로 띄울 색/포트 결정 ########
 if [ "$CURRENT" = "blue" ]; then
   NEW="green"; PORT_NEW=8082
   OLD="blue" ; PORT_OLD=8081
-else                                    # green 이거나 첫 배포
+else
   NEW="blue" ; PORT_NEW=8081
   OLD="green"; PORT_OLD=8082
 fi
 
-######## 1) 새 컨테이너 기동 ##################################
+echo "[INFO] CURRENT=$CURRENT NEW=$NEW PORT_NEW=$PORT_NEW"
+
+######## 1) 새 컨테이너 기동 ########
 docker compose up -d spring-${NEW}
 
-######## 2) 헬스체크 (최대 100 초) ###############################
+######## 2) 헬스체크 (최대 100초) ########
 SUCCESS=0
 for i in {1..20}; do
   if curl -fs "http://localhost:${PORT_NEW}/actuator/health" 2>/dev/null | grep -q '"status":"UP"'; then
     SUCCESS=1
     break
   fi
-  echo "  …${i}/20"
+  echo "  …health ${i}/20"
   sleep 5
 done
-[ "$SUCCESS" -eq 1 ] || { echo "Health FAIL"; ROLLBACK=1; }
 
-######## 3) Nginx EC2 upstream 전환(또는 롤백) #################
-# 첫 배포 + ssh 키 미배치 상황을 고려해 “없으면 건너뜀”
-SSH_KEY=~/.ssh/hilingual_actions
-SSH_HOST="ubuntu@${NGINX_HOST}"
-SSH="ssh -i ${SSH_KEY} -o IdentitiesOnly=yes -o StrictHostKeyChecking=no ${SSH_HOST}"
+if [ "$SUCCESS" -ne 1 ]; then
+  echo "[ERROR] Health check failed on :${PORT_NEW}"
+  ROLLBACK=1
+fi
 
+############################################
+# Nginx 스위치 함수
+# - TARGET: "APP_HOST:PORT" (예: 10.0.2.177:8082)
+# - UPSTREAM_ENV에 따라 dev/prod inc 파일을 함께 갱신
+############################################
 switch_upstream () {
-  local TARGET="$1"
+  local TARGET="$1"  # 예: "10.0.2.177:8082"
+
   if [ -f "${SSH_KEY}" ]; then
     $SSH bash -lc "
       set -e
-      C='sudo --preserve-env=TARGET_UPSTREAM docker compose -p hilingual -f /home/ubuntu/nginx/docker-compose.yml'
-      # Nginx 컨테이너 보장
+      cd /home/ubuntu/nginx
+
+      # Docker compose 준비 (nginx 서비스 보장)
+      C='sudo docker compose -p hilingual -f /home/ubuntu/nginx/docker-compose.yml'
+      sudo systemctl start docker
+      sudo systemctl enable docker >/dev/null 2>&1 || true
       \$C up -d --remove-orphans nginx
 
-      # 컨테이너 CID를 라벨로 안정적으로 조회
+      # nginx 컨테이너 CID 조회(라벨 기준, 안정적)
       i=0; cid=''
       while [ \$i -lt 30 ]; do
         cid=\$(sudo docker ps -q \
@@ -62,7 +82,17 @@ switch_upstream () {
       done
       [ -n \"\$cid\" ] || { echo 'nginx container not found'; exit 1; }
 
-      # 컨테이너 내부에서 envsubst + 검증 + 리로드
+      # (A) 환경 inc 파일 갱신: 실제 전환된 포트를 반영(printf로 안전하게)
+      if [ '${UPSTREAM_ENV}' = 'dev' ]; then
+        sudo docker exec \"\$cid\" /bin/sh -lc \"printf 'set \\\$app_dev \\\"%s\\\";\\n' 'http://${TARGET}' > /etc/nginx/conf.d/dev.inc\"
+      elif [ '${UPSTREAM_ENV}' = 'prod' ]; then
+        sudo docker exec \"\$cid\" /bin/sh -lc \"printf 'set \\\$app_prod \\\"%s\\\";\\n' 'http://${TARGET}' > /etc/nginx/conf.d/prod.inc\"
+      else
+        echo '[WARN] UPSTREAM_ENV not set (dev|prod). inc 파일 갱신 생략'
+      fi
+
+      # (B) 템플릿 치환 + 검증 + 리로드
+      #     여기서 TARGET_UPSTREAM은 fallback 용도로만 사용(템플릿 map 구조와 함께 동작)
       sudo docker exec -e TARGET_UPSTREAM='${TARGET}' \"\$cid\" \
         /bin/sh -lc \"envsubst '\\\$TARGET_UPSTREAM' < /etc/nginx/nginx.template.conf > /etc/nginx/conf.d/default.conf && nginx -t && nginx -s reload\"
     "
@@ -71,16 +101,17 @@ switch_upstream () {
   fi
 }
 
+######## 3) 스위치 or 롤백 ########
 if [ -z "$ROLLBACK" ]; then
-  echo "[NGINX] switch → ${NEW}"
+  echo "[NGINX] switch → ${NEW} (${APP_HOST}:${PORT_NEW})"
   switch_upstream "${APP_HOST}:${PORT_NEW}"
 
-  # 첫 배포가 아니면 이전 색 컨테이너 종료
-  if [ -n "$CURRENT" ] ; then
+  # 이전 색 종료(첫 배포가 아니면)
+  if [ -n "$CURRENT" ]; then
     docker compose stop spring-${OLD}
   fi
 else
-  echo "[NGINX] rollback → ${OLD}"
+  echo "[NGINX] rollback → ${OLD} (${APP_HOST}:${PORT_OLD})"
   switch_upstream "${APP_HOST}:${PORT_OLD}"
-  exit 1                                 # GitHub Actions job 을 실패로 종료
+  exit 1
 fi

--- a/nginx/conf.d/dev.inc
+++ b/nginx/conf.d/dev.inc
@@ -1,0 +1,2 @@
+# api-dev.hilingual.kr 업스트림 (deploy.sh가 자동 갱신)
+# 예시) set $app_dev "http://10.0.2.177:8082";

--- a/nginx/conf.d/prod.inc
+++ b/nginx/conf.d/prod.inc
@@ -1,0 +1,2 @@
+# api.hilingual.kr 업스트림 (deploy.sh가 자동 갱신)
+# 예시) set $app_prod "http://10.0.2.63:8081";

--- a/nginx/docker-compose.yml
+++ b/nginx/docker-compose.yml
@@ -1,11 +1,14 @@
 services:
   nginx:
-    image: nginx:latest
+    image: nginx:1.25-alpine
     container_name: hilingual-nginx
     ports: ["80:80"]
     volumes:
       # 템플릿만 컨테이너에 제공(읽기전용 권장)
       - ./nginx.template.conf:/etc/nginx/nginx.template.conf:ro
+      - ./conf.d/:/etc/nginx/conf.d/:rw
+    restart: unless-stopped
+
       # (선택) 스크립트는 자동 실행 안 되게 다른 경로로 마운트만 해둠
       # - ./start-nginx.sh:/opt/start-nginx.sh:ro
 

--- a/nginx/nginx.template.conf
+++ b/nginx/nginx.template.conf
@@ -1,32 +1,51 @@
+# ──(1) 기본 fallback: 레거시 호환 ─────────────────────────────────────
+# inc 파일이 비어 있거나 없더라도, 기존처럼 $TARGET_UPSTREAM을 사용
+set $app_prod "http://${TARGET_UPSTREAM}";
+set $app_prod "http://127.0.0.1:65535";  # prod 준비 전엔 502/503 유도
+
+# ──(2) 환경별 오버라이드: 있으면 덮어씀 ───────────────────────────────
+include /etc/nginx/conf.d/prod.inc;   # 예: set $app_prod http://10.0.2.63:8082;
+include /etc/nginx/conf.d/dev.inc;    # 예: set $app_dev  http://10.0.2.177:8081;
+
+# ──(3) Host → 업스트림 매핑 ──────────────────────────────────────────
+map $host $service_url {
+    default               $app_prod;   # 안전망
+    api.hilingual.kr      $app_prod;   # 운영
+    api-dev.hilingual.kr  $app_dev;    # 개발
+}
+
 server {
     listen 80;
 
-    # 애플리케이션 Blue/Green
+    # 애플리케이션 Blue/Green (도메인별 분기된 $service_url 사용)
     location / {
-        proxy_pass http://${TARGET_UPSTREAM};
+        proxy_pass $service_url;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+        proxy_send_timeout 60s;
     }
 
     # 헬스체크
-    location /healthz {
-        proxy_pass http://${TARGET_UPSTREAM}/actuator/health;
+    location = /healthz {
+        proxy_pass $service_url/actuator/health;
         proxy_set_header Host      $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_intercept_errors on;
     }
 
-    location = /grafana {
-        return 302 /grafana/;
-    }
 
+    location = /grafana { return 302 /grafana/; }
     rewrite ^/prometheus$ /prometheus/ permanent;
     rewrite ^/loki$ /loki/ permanent;
 
-    # Grafana (monitoring EC2: 10.0.2.54:3000)!
+    # Grafana (monitoring EC2: 10.0.2.54:3000)
     location /grafana/ {
-        proxy_pass http://10.0.2.54:3000/grafana/;   # nginx경유 IP:PORT
+        proxy_pass http://10.0.2.54:3000/grafana/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Related issue 🛠
- closed #168 

## Work Description ✏️
- **CI/CD 개선**
  - DEV/PROD 각각 별도 워크플로우 파일로 분리
  - `UPSTREAM_ENV`(`dev`/`prod`)에 따라 Blue/Green 전환 및 Nginx inc 파일 자동 갱신
- **Nginx 구성 개편**
  - `nginx/conf.d/dev.inc`, `nginx/conf.d/prod.inc` 도입
  - `nginx.template.conf`에 Host 기반 분기(`api-dev.hilingual.kr` vs `api.hilingual.kr`) 추가
  - Route53 레코드 설계 반영 (루트, www, api, api-dev, cdn)
- **Blue/Green 배포 스크립트 개선**
  - `deploy.sh`에서 dev/prod 별 inc 파일 동기화
- **추가**
  - `.github/workflows/dev-deploy.yml`, `.github/workflows/prod-deploy.yml` 완성본 반영
  - `nginx/docker-compose.yml` conf.d 마운트 추가
  - 최초 배포 환경에서도 에러 없이 동작하도록 가드 처리

## Uncompleted Tasks 😅
- HTTPS 인증서(Certbot) 적용은 후속 PR에서 진행 예정
- PROD 첫 배포는 아직 진행하지 않아서 혼선을 막기위해 DNS는 자동으로 502 뜨도록 설정

## To Reviewers 📢
- DEV/PROD 두 환경을 분리해서 모두 nginx에서 업스트림될 수 잇도록 하다보니 Nginx 설정과 CICD 워크플로우 수정사항이 많습니다