### PR TITLE
[feat] #178 S3 이미지 삭제로직 구현 및 "일기 삭제하기 API" 수정, prefix 경로 변경

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/diary/service/DiaryService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/diary/service/DiaryService.java
@@ -1,6 +1,7 @@
 package org.sopt.controller.diary.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.aws.s3.service.S3Service;
 import org.sopt.controller.diary.dto.CreateDiaryReq;
 import org.sopt.diaryfeedback.diff.dto.DiaryDetailsRes;
@@ -25,6 +26,7 @@ import java.util.List;
 import java.util.Locale;
 
 @Service
+@Slf4j
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class DiaryService {
@@ -102,7 +104,15 @@ public class DiaryService {
     }
 
     @Transactional
-    public void removeDairy(final Long userId, final Long diary){
-        diaryFacade.deleteDiary(userId, diary);
-    };
+    public void removeDairy(final Long userId, final Long diaryId) {
+        diaryFacade.validateDiaryOwnership(userId, diaryId);
+        Diary diary = diaryFacade.getDiaryById(diaryId);
+
+        String imageKey = diary.getImageUrl();
+        if (imageKey != null && !imageKey.isBlank()) {
+            s3Service.deleteObject(imageKey);
+        }
+
+        diaryFacade.deleteDiary(userId, diaryId);
+    }
 }

--- a/hilingual-domain/src/main/java/org/sopt/diary/facade/DiaryFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/diary/facade/DiaryFacade.java
@@ -40,6 +40,7 @@ public class DiaryFacade {
         return diaryRetriever.findById(diaryId);
     }
 
+    @Transactional
     public void deleteDiary(final long userId, final long diaryId) {
         diaryRemover.deleteDiary(userId,diaryId);
     }

--- a/hilingual-domain/src/main/java/org/sopt/usercalendar/domain/UserCalendar.java
+++ b/hilingual-domain/src/main/java/org/sopt/usercalendar/domain/UserCalendar.java
@@ -29,7 +29,7 @@ public class UserCalendar extends BaseTimeEntity {
   
     @Enumerated(EnumType.STRING)
     @Column(name = UserCalendarTableConstants.COLUMN_STATUS, nullable = false, length = 16)
-    private WriteStatus status;
+    private WriteStatus status = WriteStatus.NONE;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = UserCalendarTableConstants.COLUMN_USER_ID, nullable = false)

--- a/hilingual-external/src/main/java/org/sopt/aws/s3/exception/S3ErrorCode.java
+++ b/hilingual-external/src/main/java/org/sopt/aws/s3/exception/S3ErrorCode.java
@@ -19,6 +19,9 @@ public enum S3ErrorCode implements ErrorCode {
     // 403
     S3_ACCESS_DENIED(HttpStatus.FORBIDDEN, 40302, "S3 접근이 거부되었습니다."),
 
+    // 404
+    S3_BUCKET_NOT_FOUND(HttpStatus.NOT_FOUND, 40405, "S3 버킷이 존재하지 않습니다."),
+
     // 500
     PRESIGN_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 50005, "Presigned URL 생성에 실패했습니다."),
     S3_COPY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 50006, "S3 객체 복사에 실패했습니다."),

--- a/hilingual-external/src/main/java/org/sopt/aws/s3/service/S3Constants.java
+++ b/hilingual-external/src/main/java/org/sopt/aws/s3/service/S3Constants.java
@@ -1,0 +1,7 @@
+package org.sopt.aws.s3.service;
+
+public class S3Constants {
+    public static final String NO_SUCH_KEY = "NoSuchKey";
+    public static final String NO_SUCH_VERSION = "NoSuchVersion";
+    public static final String NO_SUCH_BUCKET = "NoSuchBucket";
+}

--- a/hilingual-external/src/main/java/org/sopt/aws/s3/service/S3Service.java
+++ b/hilingual-external/src/main/java/org/sopt/aws/s3/service/S3Service.java
@@ -1,12 +1,12 @@
 package org.sopt.aws.s3.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.aws.config.AWSProperties;
 import org.sopt.aws.s3.dto.PreSignedUrlRes;
 import org.sopt.aws.s3.dto.Purpose;
 import org.sopt.aws.s3.exception.S3BaseException;
 import org.sopt.aws.s3.exception.S3ErrorCode;
-import org.sopt.exception.code.GlobalErrorCode;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -31,6 +31,7 @@ import java.util.UUID;
 import static org.apache.logging.log4j.util.Strings.trimToNull;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class S3Service {
 
@@ -95,11 +96,11 @@ public class S3Service {
 
     private String buildTmpKey(Long userId, Purpose purpose, String ext) {
         return switch (purpose) {
-            case PROFILE_UPLOAD, PROFILE_UPDATE -> "users/%d/images/profile/tmp/%s.%s"
+            case PROFILE_UPLOAD, PROFILE_UPDATE -> "/tmp/users/%d/images/profile/%s.%s"
                     .formatted(userId, UUID.randomUUID(), ext);
             case DIARY_IMAGE -> {
                 String dateDir = LocalDate.now(clock).format(DATE_DIR);
-                yield "users/%d/images/diaries/tmp/%s/%s.%s"
+                yield "/tmp/users/%d/images/diaries/%s/%s.%s"
                         .formatted(userId, dateDir, UUID.randomUUID(), ext);
             }
         };
@@ -109,7 +110,7 @@ public class S3Service {
      * tmp 키를 최종 위치로 이동(finalKey 반환) 후 tmp 삭제
      */
     public String bindDiaryImage(Long userId, String tmpKey, LocalDate date) {
-        String expectedPrefix = prefix("users/%d/images/diaries/tmp/".formatted(userId));
+        String expectedPrefix = prefix("/tmp/users/%d/images/diaries".formatted(userId));
         validateTmpKeyOwnership(userId, tmpKey, expectedPrefix);
 
         String dateDir = date.toString();
@@ -179,5 +180,37 @@ public class S3Service {
                 ? cdn
                 : "http://" + (cdn.endsWith("/") ? cdn.substring(0, cdn.length() - 1) : cdn);
         return base + "/" + normKey;
+    }
+
+    /*
+     * S3 이미지 삭제
+     */
+    public void deleteObject(String key) {
+        String bucket = awsProperties.getBucketName();
+        String normKey = key.startsWith("/") ? key.substring(1) : key;
+        try {
+            s3Client.deleteObject(DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(normKey)
+                    .build());
+        } catch (S3Exception e) {
+            String code = e.awsErrorDetails() != null ? e.awsErrorDetails().errorCode() : null;
+            int status = e.statusCode();
+
+            log.warn("S3 delete failed bucket={}, key={}, status={}, code={}, requestId={}",
+                    bucket, normKey, status, code, e.requestId(), e);
+
+            if (S3Constants.NO_SUCH_KEY.equals(code) || S3Constants.NO_SUCH_VERSION.equals(code)) {
+                return;
+            }
+            if (S3Constants.NO_SUCH_BUCKET.equals(code)) {
+                throw new S3BaseException(S3ErrorCode.S3_BUCKET_NOT_FOUND);
+            }
+            throw new S3BaseException(S3ErrorCode.S3_DELETE_FAILED);
+
+        } catch (SdkException e) {
+            log.error("S3 SDK exception on delete bucket={}, key={}", bucket, normKey, e);
+            throw new S3BaseException(S3ErrorCode.S3_DELETE_FAILED);
+        }
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #178 

## Work Description ✏️
- **S3Service**
  - presigned URL 발급 및 tmp 경로 관리 로직 추가
  - prefix(dev/prod) 자동 부여 
  - S3 이미지 삭제(deleteObject) 로직 구현
- **Diary API**
  - 일기 삭제 시 S3 이미지 함께 삭제되도록 수정
  - imageKey 없는 경우 스킵, 존재 시 S3에서 삭제
- **Prefix 경로 구조**
  - S3 버킷 TTL설정을 위해 /tmp를 cdn/dev 바로 다음에 오도록 변경!
  - `/tmp/users/{id}/images/...` → `users/{id}/images/...` 로 바인딩 후 이동
  - dev/prod prefix 자동 적용

## Screenshot 📸
설명 | 사진
-- | --
presigend url 발급 |  <img width="2048" height="1117" alt="image" src="https://github.com/user-attachments/assets/039ae5f5-70ff-47da-a14d-386f7eaffe2f" />
발급한 uploadUrl로 직접 PUT 결과(/tmp) |  <img width="2048" height="702" alt="image" src="https://github.com/user-attachments/assets/b2fc79e7-9580-42ea-bd96-43a6a3b74b52" />
일기 피드백 요청 API 호출 (바인딩) |  <img width="2048" height="1128" alt="image" src="https://github.com/user-attachments/assets/5fe9a6cd-dbbc-45fe-8fd2-0e8bfced875d" />/tmp 경로 사라지고 진짜 경로에 업로드 |  
일기 삭제하기 API 호출 |  <img width="2048" height="682" alt="image" src="https://github.com/user-attachments/assets/cebad3db-7c6b-4fb4-babe-e7d0de4d4f0f" />
S3 버킷에서 지워짐 |  <img width="2048" height="1006" alt="image" src="https://github.com/user-attachments/assets/ad73e879-e516-4333-bddd-ed849ade9e01" />

<!-- notionvc: f1711f8d-a138-41af-86e4-ca003f3a78f8 -->

## Uncompleted Tasks 😅
- 책임이나 역할분리 이번 스프린트 끝나고 하겠습니다. 현재 S3 Service 가 길고 좀 무거움..!

## To Reviewers 📢
N/A