### PR TITLE
[feat] #188 북마크 지정/해제 API, 특정 단어 세부내용 조회 API 에서 단어 저장 경로를 구분해서 저장 및 표현

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/recommend/api/RecommendController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/recommend/api/RecommendController.java
@@ -22,15 +22,16 @@ public class RecommendController {
     @GetMapping("/{diaryId}/recommended")
     public ResponseEntity<RecommendListRes> getRecommendList(
             @UserId Long userId,
-            @PathVariable @Validated @Min(1) Long diaryId
+            @PathVariable @Min(1) Long diaryId
     ){
         return ResponseEntity.ok(recommendService.getRecommendList(userId, diaryId));
     }
 
+    // 북마크 지정/해제 API
     @PatchMapping("/{phraseId}")
     public ResponseEntity<Void> bookMark(
             @UserId Long userId,
-            @PathVariable @Validated @Min(1) Long phraseId,
+            @PathVariable @Min(1) Long phraseId,
             @RequestBody @NotNull BookmarkReq bookmarkRequest
     ){
         return ResponseEntity.ok(recommendService.bookMark(userId, phraseId, bookmarkRequest.isBookmarked()));

--- a/hilingual-api/src/main/java/org/sopt/controller/recommend/exception/RecommendApiErrorCode.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/recommend/exception/RecommendApiErrorCode.java
@@ -1,0 +1,30 @@
+package org.sopt.controller.recommend.exception;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum RecommendApiErrorCode implements ErrorCode {
+    RECOMMEND_FORBIDDEN(HttpStatus.FORBIDDEN, 40300, "비공개 일기의 추천표현에는 접근 불가능합니다.")
+    ;
+
+    public final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus(){
+        return httpStatus;
+    }
+
+    @Override
+    public int getCode(){
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/recommend/exception/RecommendApiException.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/recommend/exception/RecommendApiException.java
@@ -1,0 +1,10 @@
+package org.sopt.controller.recommend.exception;
+
+import org.sopt.exception.base.HilingualBaseException;
+import org.sopt.exception.code.ErrorCode;
+
+public abstract class RecommendApiException extends HilingualBaseException {
+    protected RecommendApiException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/recommend/exception/RecommendForbiddenException.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/recommend/exception/RecommendForbiddenException.java
@@ -1,0 +1,15 @@
+package org.sopt.controller.recommend.exception;
+
+import org.sopt.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class RecommendForbiddenException extends RecommendApiException{
+    public RecommendForbiddenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.FORBIDDEN;
+    }
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/recommend/service/RecommendService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/recommend/service/RecommendService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.controller.recommend.dto.RecommendListRes;
 import org.sopt.controller.recommend.exception.RecommendApiErrorCode;
 import org.sopt.controller.recommend.exception.RecommendForbiddenException;
+import org.sopt.diary.domain.Diary;
 import org.sopt.diary.facade.DiaryFacade;
 import org.sopt.recommend.domain.Recommend;
 import org.sopt.recommend.facade.RecommendFacade;
@@ -55,19 +56,23 @@ public class RecommendService {
 
     @Transactional
     public Void bookMark(final long userId, final long phraseId, final boolean isBookmarked) {
-        Recommend recommend = recommendFacade.findById(phraseId);
-        boolean mine = recommend.getDiary().getUser().getId().equals(userId);
-        boolean publicDiary = Boolean.TRUE.equals(recommend.getDiary().getIsPublic());
-        User user = userFacade.getUserById(userId);
 
-        if (isBookmarked) {
-            if (!mine && !publicDiary) {
-                throw new RecommendForbiddenException(RecommendApiErrorCode.RECOMMEND_FORBIDDEN);
-            }
-            vocaSaver.saveIfNotExists(user, recommend);
-        } else {
-            vocaRemover.delete(user, recommend);
+        if (!isBookmarked) {
+            vocaRemover.delete(userId, phraseId);
+            return null;
         }
+
+        Recommend recommend = recommendFacade.findById(phraseId);
+        Diary diary = recommend.getDiary();
+        boolean mine = (diary != null) && userId == diary.getUser().getId();
+        boolean publicDiary = (diary == null) || Boolean.TRUE.equals(diary.getIsPublic());
+
+        if (!mine && !publicDiary) {
+            throw new RecommendForbiddenException(RecommendApiErrorCode.RECOMMEND_FORBIDDEN);
+        }
+
+        User user = userFacade.getUserById(userId);
+        vocaSaver.saveIfNotExists(user, recommend);
         return null;
     }
 

--- a/hilingual-api/src/main/java/org/sopt/controller/recommend/service/RecommendService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/recommend/service/RecommendService.java
@@ -2,12 +2,13 @@ package org.sopt.controller.recommend.service;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.controller.recommend.dto.RecommendListRes;
+import org.sopt.controller.recommend.exception.RecommendApiErrorCode;
+import org.sopt.controller.recommend.exception.RecommendForbiddenException;
 import org.sopt.diary.facade.DiaryFacade;
 import org.sopt.recommend.domain.Recommend;
 import org.sopt.recommend.facade.RecommendFacade;
 import org.sopt.user.domain.User;
 import org.sopt.user.facade.UserFacade;
-import org.sopt.voca.domain.Voca;
 import org.sopt.voca.facade.VocaRemover;
 import org.sopt.voca.facade.VocaSaver;
 import org.springframework.stereotype.Service;
@@ -53,14 +54,19 @@ public class RecommendService {
     }
 
     @Transactional(readOnly = false)
-    public Void bookMark(final long userId, final long phraseId, final boolean isBookMarked){
+    public Void bookMark(final long userId, final long phraseId, final boolean isBookmarked){
         Recommend recommend = recommendFacade.findById(phraseId);
-        User user = userFacade.getUserById(userId);
-        recommend.updateMarkStatus(isBookMarked);
 
-        if (isBookMarked) {
-            Voca voca = new Voca(user, recommend);
-            vocaSaver.saveIfNotExists(voca);
+        // 내가 쓴 일기 or 피드에 공개된 일기만 허용
+        if (!recommend.getDiary().getUser().getId().equals(userId)
+                && Boolean.FALSE.equals(recommend.getDiary().getIsPublic())) {
+            throw new RecommendForbiddenException(RecommendApiErrorCode.RECOMMEND_FORBIDDEN);
+        }
+        User user = userFacade.getUserById(userId);
+        recommend.updateMarkStatus(isBookmarked);
+
+        if (isBookmarked) {
+            vocaSaver.saveIfNotExists(user, recommend);
         } else {
             vocaRemover.delete(user, recommend);
         }

--- a/hilingual-api/src/main/java/org/sopt/controller/recommend/service/RecommendService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/recommend/service/RecommendService.java
@@ -54,23 +54,20 @@ public class RecommendService {
     }
 
     @Transactional
-    public Void bookMark(final long userId, final long phraseId, final boolean isBookmarked){
+    public Void bookMark(final long userId, final long phraseId, final boolean isBookmarked) {
         Recommend recommend = recommendFacade.findById(phraseId);
-
-        // 내가 쓴 일기 or 피드에 공개된 일기만 허용
-        if (!recommend.getDiary().getUser().getId().equals(userId)
-                && Boolean.FALSE.equals(recommend.getDiary().getIsPublic())) {
-            throw new RecommendForbiddenException(RecommendApiErrorCode.RECOMMEND_FORBIDDEN);
-        }
+        boolean mine = recommend.getDiary().getUser().getId().equals(userId);
+        boolean publicDiary = Boolean.TRUE.equals(recommend.getDiary().getIsPublic());
         User user = userFacade.getUserById(userId);
-        recommend.updateMarkStatus(isBookmarked);
 
         if (isBookmarked) {
+            if (!mine && !publicDiary) {
+                throw new RecommendForbiddenException(RecommendApiErrorCode.RECOMMEND_FORBIDDEN);
+            }
             vocaSaver.saveIfNotExists(user, recommend);
         } else {
             vocaRemover.delete(user, recommend);
         }
-
         return null;
     }
 

--- a/hilingual-api/src/main/java/org/sopt/controller/recommend/service/RecommendService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/recommend/service/RecommendService.java
@@ -53,7 +53,7 @@ public class RecommendService {
         return new RecommendListRes(phrases);
     }
 
-    @Transactional(readOnly = false)
+    @Transactional
     public Void bookMark(final long userId, final long phraseId, final boolean isBookmarked){
         Recommend recommend = recommendFacade.findById(phraseId);
 

--- a/hilingual-api/src/main/java/org/sopt/controller/voca/dto/res/VocaDetailResponse.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/voca/dto/res/VocaDetailResponse.java
@@ -1,8 +1,6 @@
 package org.sopt.controller.voca.dto.res;
 
-import org.sopt.recommend.domain.Recommend;
-
-import java.time.format.DateTimeFormatter;
+import org.sopt.voca.domain.Voca;
 import java.util.Arrays;
 import java.util.List;
 
@@ -11,23 +9,17 @@ public record VocaDetailResponse(
         String phrase,
         List<String> phraseType,
         String explanation,
-        String writtenDate,
+        String writtenFrom,
         Boolean isBookmarked
 ) {
-
-    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yy.MM.dd");
-
-    public static VocaDetailResponse from(final Recommend recommend) {
+    public static VocaDetailResponse from(final Voca v) {
         return new VocaDetailResponse(
-                recommend.getId(),
-                recommend.getPhrase(),
-                parsePhraseTypes(recommend.getPhraseType()),
-                recommend.getExplanation(),
-                recommend
-                        .getDiary()
-                        .getWrittenDate()
-                        .format(FORMATTER),
-                recommend.getIsBookmarked()
+                v.getRecommendId(),
+                v.getPhrase(),
+                parsePhraseTypes(v.getPhraseType()),
+                v.getExplanation(),
+                v.getWrittenFrom(),
+                true
         );
     }
 

--- a/hilingual-api/src/main/java/org/sopt/controller/voca/dto/res/VocaSearchListResponse.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/voca/dto/res/VocaSearchListResponse.java
@@ -24,10 +24,10 @@ public record VocaSearchListResponse(
     ) {
         public static Item from(final Voca voca) {
             return new Item(
-                    voca.getRecommend().getId(),
-                    voca.getRecommend().getPhrase(),
-                    parsePhraseTypes(voca.getRecommend().getPhraseType()),
-                    voca.getRecommend().getIsBookmarked()
+                    voca.getRecommendId(),
+                    voca.getPhrase(),
+                    parsePhraseTypes(voca.getPhraseType()),
+                    Boolean.TRUE
             );
         }
 

--- a/hilingual-api/src/main/java/org/sopt/controller/voca/service/VocaService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/voca/service/VocaService.java
@@ -4,9 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.controller.voca.dto.res.VocaDetailResponse;
 import org.sopt.voca.dto.VocaListRes;
 import org.sopt.controller.voca.dto.res.VocaSearchListResponse;
-import org.sopt.recommend.domain.Recommend;
 import org.sopt.recommend.facade.RecommendFacade;
 import org.sopt.voca.domain.Voca;
+import org.sopt.voca.facade.VocaFacade;
 import org.sopt.voca.facade.VocaRetriever;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +19,7 @@ public class VocaService {
 
     private final VocaRetriever vocaRetriever;
     private final RecommendFacade recommendFacade;
+    private final VocaFacade vocaFacade;
 
 
     // 단어장 목록 조회
@@ -32,10 +33,10 @@ public class VocaService {
         return VocaSearchListResponse.from(vocas);
     }
 
-    //특정 단어 세부 조회
+    // 특정 단어 세부 조회
     public VocaDetailResponse getVocaDetails(final Long userId, final Long phraseId) {
-        final Recommend recommend = recommendFacade.findByUserIdAndPhraseId(userId, phraseId);
-        return VocaDetailResponse.from(recommend);
+        final Voca voca = vocaFacade.findDetailByUserIdAndPhraseId(userId, phraseId);
+        return VocaDetailResponse.from(voca);
     }
 
 }

--- a/hilingual-domain/src/main/java/org/sopt/recommend/domain/Recommend.java
+++ b/hilingual-domain/src/main/java/org/sopt/recommend/domain/Recommend.java
@@ -44,8 +44,4 @@ public class Recommend extends BaseTimeEntity {
     public static Recommend create(Diary diary, String phrase, String phraseType, String explanation, String reason) {
         return new Recommend(null, phrase, phraseType, explanation, false, reason, diary);
     }
-
-    public void updateMarkStatus(boolean isBookmarked) {
-        this.isBookmarked = isBookmarked;
-    }
 }

--- a/hilingual-domain/src/main/java/org/sopt/voca/domain/Voca.java
+++ b/hilingual-domain/src/main/java/org/sopt/voca/domain/Voca.java
@@ -11,8 +11,18 @@ import org.sopt.user.domain.User;
 import org.sopt.voca.type.SavedRoot;
 import org.sopt.voca.type.SavedRootConverter;
 
+import static org.sopt.voca.domain.VocaTableConstants.*;
+
 @Entity
-@Table(name = VocaTableConstants.TABLE_VOCA)
+@Table(
+        name = TABLE_VOCA,
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = UK_VOCA_USER_RECOMMEND,
+                        columnNames = { COLUMN_USER_ID, COLUMN_RECOMMEND_ID }
+                )
+        }
+)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -20,23 +30,27 @@ public class Voca extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = VocaTableConstants.COLUMN_ID)
+    @Column(name = COLUMN_ID)
     private Long id;
 
     @Convert(converter = SavedRootConverter.class)
-    @Column(name = VocaTableConstants.COLUMN_SAVED_ROOT, nullable = false)
+    @Column(name = COLUMN_SAVED_ROOT, nullable = false)
     private SavedRoot savedRoot;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = VocaTableConstants.COLUMN_USER_ID, nullable = false)
+    @JoinColumn(name = COLUMN_USER_ID, nullable = false)
     private User user;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = VocaTableConstants.COLUMN_RECOMMEND_ID, nullable = false, unique = true)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = COLUMN_RECOMMEND_ID, nullable = false)
     private Recommend recommend;
 
-    public Voca(User user, Recommend recommend) {
-        this.user = user;
-        this.recommend = recommend;
+    public static Voca fromMyDiary(User user, Recommend recommend) {
+        return new Voca(null, SavedRoot.MY, user, recommend);
     }
+
+    public static Voca fromFeed(User user, Recommend recommend) {
+        return new Voca(null, SavedRoot.FEED, user, recommend);
+    }
+
 }

--- a/hilingual-domain/src/main/java/org/sopt/voca/domain/Voca.java
+++ b/hilingual-domain/src/main/java/org/sopt/voca/domain/Voca.java
@@ -41,16 +41,40 @@ public class Voca extends BaseTimeEntity {
     @JoinColumn(name = COLUMN_USER_ID, nullable = false)
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = COLUMN_RECOMMEND_ID, nullable = false)
-    private Recommend recommend;
+    @Column(name = COLUMN_RECOMMEND_ID, nullable = false)
+    private Long recommendId;
 
-    public static Voca fromMyDiary(User user, Recommend recommend) {
-        return new Voca(null, SavedRoot.MY, user, recommend);
+    @Column(name = COLUMN_PHRASE, nullable = false)
+    private String phrase;
+
+    @Column(name = COLUMN_PHRASE_TYPE, nullable = false)
+    private String phraseType;
+
+    @Column(name = COLUMN_EXPLANATION, nullable = false)
+    private String explanation;
+
+    @Column(name = COLUMN_WRITTEN_FROM, nullable = false)
+    private String writtenFrom;
+
+    public static Voca fromMyDiary(User user, Recommend recommend, String writtenFrom) {
+        return new Voca(
+                null, SavedRoot.MY, user,
+                recommend.getId(),
+                recommend.getPhrase(),
+                recommend.getPhraseType(),
+                recommend.getExplanation(),
+                writtenFrom
+        );
     }
 
-    public static Voca fromFeed(User user, Recommend recommend) {
-        return new Voca(null, SavedRoot.FEED, user, recommend);
+    public static Voca fromFeed(User user, Recommend recommend, String writtenFrom) {
+        return new Voca(
+                null, SavedRoot.FEED, user,
+                recommend.getId(),
+                recommend.getPhrase(),
+                recommend.getPhraseType(),
+                recommend.getExplanation(),
+                writtenFrom
+        );
     }
-
 }

--- a/hilingual-domain/src/main/java/org/sopt/voca/domain/VocaTableConstants.java
+++ b/hilingual-domain/src/main/java/org/sopt/voca/domain/VocaTableConstants.java
@@ -2,9 +2,17 @@ package org.sopt.voca.domain;
 
 public class VocaTableConstants {
     public static final String TABLE_VOCA = "voca";
+
+    // constraints
     public static final String UK_VOCA_USER_RECOMMEND = "uk_voca_user_recommend";
+
+    // columns
     public static final String COLUMN_ID = "id";
     public static final String COLUMN_USER_ID = "user_id";
     public static final String COLUMN_RECOMMEND_ID = "recommend_id";
     public static final String COLUMN_SAVED_ROOT = "saved_root";
+    public static final String COLUMN_PHRASE = "phrase";
+    public static final String COLUMN_PHRASE_TYPE = "phrase_type";
+    public static final String COLUMN_EXPLANATION = "explanation";
+    public static final String COLUMN_WRITTEN_FROM = "written_from";
 }

--- a/hilingual-domain/src/main/java/org/sopt/voca/domain/VocaTableConstants.java
+++ b/hilingual-domain/src/main/java/org/sopt/voca/domain/VocaTableConstants.java
@@ -2,6 +2,7 @@ package org.sopt.voca.domain;
 
 public class VocaTableConstants {
     public static final String TABLE_VOCA = "voca";
+    public static final String UK_VOCA_USER_RECOMMEND = "uk_voca_user_recommend";
     public static final String COLUMN_ID = "id";
     public static final String COLUMN_USER_ID = "user_id";
     public static final String COLUMN_RECOMMEND_ID = "recommend_id";

--- a/hilingual-domain/src/main/java/org/sopt/voca/dto/VocaItemRes.java
+++ b/hilingual-domain/src/main/java/org/sopt/voca/dto/VocaItemRes.java
@@ -13,10 +13,10 @@ public record VocaItemRes(
 ) {
     public static VocaItemRes from(final Voca voca) {
         return new VocaItemRes(
-                voca.getRecommend().getId(),
-                voca.getRecommend().getPhrase(),
-                parsePhraseTypes(voca.getRecommend().getPhraseType()),
-                voca.getRecommend().getIsBookmarked()
+                voca.getRecommendId(),
+                voca.getPhrase(),
+                parsePhraseTypes(voca.getPhraseType()),
+                Boolean.TRUE
         );
     }
 

--- a/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaFacade.java
@@ -1,0 +1,17 @@
+package org.sopt.voca.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.voca.domain.Voca;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class VocaFacade {
+
+    private final VocaRetriever vocaRetriever;
+
+    public Voca findDetailByUserIdAndPhraseId(Long userId, Long phraseId){
+        return vocaRetriever.findDetailByUserIdAndPhraseId(userId, phraseId);
+    }
+
+}

--- a/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaRemover.java
+++ b/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaRemover.java
@@ -1,8 +1,6 @@
 package org.sopt.voca.facade;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.recommend.domain.Recommend;
-import org.sopt.user.domain.User;
 import org.sopt.voca.repository.VocaRepository;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,7 +12,7 @@ public class VocaRemover {
     private final VocaRepository vocaRepository;
 
     @Transactional
-    public void delete(final User user, final Recommend recommend) {
-        vocaRepository.deleteByUserAndRecommend(user, recommend);
+    public void delete(final long userId, final long recommendId) {
+        vocaRepository.deleteByUserIdAndRecommendId(userId, recommendId);
     }
 }

--- a/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaRetriever.java
@@ -3,6 +3,8 @@ package org.sopt.voca.facade;
 import lombok.RequiredArgsConstructor;
 import org.sopt.voca.domain.Voca;
 import org.sopt.voca.dto.VocaListRes;
+import org.sopt.voca.exception.VocaCoreErrorCode;
+import org.sopt.voca.exception.VocaNotFoundException;
 import org.sopt.voca.repository.VocaRepository;
 import org.springframework.stereotype.Component;
 
@@ -30,4 +32,8 @@ public class VocaRetriever {
         return vocaRepository.findAllByUserIdAndPhraseStartsWith(userId, keyword);
     }
 
+    public Voca findDetailByUserIdAndPhraseId(final Long userId, final Long phraseId) {
+        return vocaRepository.findDetailByUserIdAndPhraseId(userId, phraseId)
+                .orElseThrow(() -> new VocaNotFoundException(VocaCoreErrorCode.VOCA_NOT_FOUND));
+    }
 }

--- a/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaSaver.java
+++ b/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaSaver.java
@@ -10,6 +10,8 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.format.DateTimeFormatter;
+
 @Component
 @RequiredArgsConstructor
 public class VocaSaver {
@@ -18,10 +20,16 @@ public class VocaSaver {
 
     @Transactional
     public void saveIfNotExists(final User user, final Recommend recommend) {
-        if (vocaRepository.existsByUserAndRecommend(user, recommend)) return;
+        if (vocaRepository.existsByUserIdAndRecommendId(user.getId(), recommend.getId())) return;
 
         final boolean mine = recommend.getDiary().getUser().getId().equals(user.getId());
-        final Voca voca = mine ? Voca.fromMyDiary(user, recommend) : Voca.fromFeed(user, recommend);
+        final String writtenFrom = mine
+                ? recommend.getDiary().getWrittenDate().format(DateTimeFormatter.ofPattern("yy.MM.dd")) + " 일기에서 저장됨"
+                : "피드에서 저장됨";
+
+        final Voca voca = mine
+                ? Voca.fromMyDiary(user, recommend, writtenFrom)
+                : Voca.fromFeed(user, recommend, writtenFrom);
 
         try {
             vocaRepository.save(voca);

--- a/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaSaver.java
+++ b/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaSaver.java
@@ -4,7 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.recommend.domain.Recommend;
 import org.sopt.user.domain.User;
 import org.sopt.voca.domain.Voca;
+import org.sopt.voca.domain.VocaTableConstants;
 import org.sopt.voca.repository.VocaRepository;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,10 +20,20 @@ public class VocaSaver {
     public void saveIfNotExists(final User user, final Recommend recommend) {
         if (vocaRepository.existsByUserAndRecommend(user, recommend)) return;
 
-        boolean mine = recommend.getDiary().getUser().getId().equals(user.getId());
-        Voca voca = mine ? Voca.fromMyDiary(user, recommend)
-                : Voca.fromFeed(user, recommend);
+        final boolean mine = recommend.getDiary().getUser().getId().equals(user.getId());
+        final Voca voca = mine ? Voca.fromMyDiary(user, recommend) : Voca.fromFeed(user, recommend);
 
-        vocaRepository.save(voca);
+        try {
+            vocaRepository.save(voca);
+        } catch (DataIntegrityViolationException e) {
+            if (isUniqueViolation(e, VocaTableConstants.UK_VOCA_USER_RECOMMEND)) return;
+            throw e;
+        }
+    }
+
+    private boolean isUniqueViolation(DataIntegrityViolationException e, String constraintName) {
+        Throwable cause = e.getMostSpecificCause();
+        String msg = (cause != null ? cause.getMessage() : null);
+        return msg != null && msg.contains(constraintName);
     }
 }

--- a/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaSaver.java
+++ b/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaSaver.java
@@ -1,6 +1,8 @@
 package org.sopt.voca.facade;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.recommend.domain.Recommend;
+import org.sopt.user.domain.User;
 import org.sopt.voca.domain.Voca;
 import org.sopt.voca.repository.VocaRepository;
 import org.springframework.stereotype.Component;
@@ -13,14 +15,13 @@ public class VocaSaver {
     private final VocaRepository vocaRepository;
 
     @Transactional
-    public void saveIfNotExists(final Voca voca) {
-        boolean exists = vocaRepository.existsByUserAndRecommend(
-                voca.getUser(),
-                voca.getRecommend()
-        );
+    public void saveIfNotExists(final User user, final Recommend recommend) {
+        if (vocaRepository.existsByUserAndRecommend(user, recommend)) return;
 
-        if (!exists) {
-            vocaRepository.save(voca);
-        }
+        boolean mine = recommend.getDiary().getUser().getId().equals(user.getId());
+        Voca voca = mine ? Voca.fromMyDiary(user, recommend)
+                : Voca.fromFeed(user, recommend);
+
+        vocaRepository.save(voca);
     }
 }

--- a/hilingual-domain/src/main/java/org/sopt/voca/repository/VocaRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/voca/repository/VocaRepository.java
@@ -1,50 +1,60 @@
 package org.sopt.voca.repository;
 
-import org.sopt.recommend.domain.Recommend;
-import org.sopt.user.domain.User;
 import org.sopt.voca.domain.Voca;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface VocaRepository extends JpaRepository<Voca, Long> {
 
-    void deleteByUserAndRecommend(User user, Recommend recommend);
+    // 존재 여부 (user.id + recommendId)
+    boolean existsByUserIdAndRecommendId(Long userId, Long recommendId);
 
-    boolean existsByUserAndRecommend(User user, Recommend recommend);
+    // 북마크 해제
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        delete from Voca v
+         where v.user.id = :userId
+           and v.recommendId = :recommendId
+    """)
+    int deleteByUserIdAndRecommendId(@Param("userId") long userId,
+                                     @Param("recommendId") long recommendId);
 
-
-    // AZ순 정렬 (Recommend.phrase 기반)
+    // A~Z 정렬
     @Query("""
         SELECT v FROM Voca v
-        JOIN FETCH v.recommend r
         WHERE v.user.id = :userId
-        ORDER BY LOWER(r.phrase)
+        ORDER BY LOWER(v.phrase)
     """)
     List<Voca> findAllByUserIdOrderByPhraseAsc(@Param("userId") Long userId);
 
     // 최신순 정렬 (Voca.createdAt 기반)
     @Query("""
         SELECT v FROM Voca v
-        JOIN FETCH v.recommend r
         WHERE v.user.id = :userId
         ORDER BY v.createdAt DESC
     """)
     List<Voca> findAllByUserIdOrderByCreatedAtDesc(@Param("userId") Long userId);
 
+    // 검색 (Prefix 기반)
     @Query("""
-    SELECT v FROM Voca v
-    JOIN FETCH v.recommend r
-    WHERE v.user.id = :userId
-      AND LOWER(r.phrase) LIKE LOWER(CONCAT(:keyword, '%'))
-    ORDER BY LOWER(SUBSTRING(r.phrase, LENGTH(:keyword) + 1))
-""")
-    List<Voca> findAllByUserIdAndPhraseStartsWith(
-            @Param("userId") Long userId,
-            @Param("keyword") String keyword
-    );
+        SELECT v FROM Voca v
+        WHERE v.user.id = :userId
+          AND LOWER(v.phrase) LIKE LOWER(CONCAT(:keyword, '%'))
+        ORDER BY LOWER(SUBSTRING(v.phrase, LENGTH(:keyword) + 1))
+    """)
+    List<Voca> findAllByUserIdAndPhraseStartsWith(@Param("userId") Long userId,
+                                                  @Param("keyword") String keyword);
 
+    // Voca 상세
+    @Query("""
+        SELECT v FROM Voca v
+        WHERE v.user.id = :userId AND v.recommendId = :phraseId
+    """)
+    Optional<Voca> findDetailByUserIdAndPhraseId(@Param("userId") Long userId,
+                                                 @Param("phraseId") Long phraseId);
 }
-


### PR DESCRIPTION
## **Related issue 🛠**
- closed #188  
- closed #186 

&nbsp;

## **Work Description ✏️**

### Voca 엔티티 변경
- 기존 `Recommend.isBookmarked` 방식 대신 `Voca` 엔티티를 통해 북마크 상태 관리  
- `Voca` 엔티티에 `SavedRoot(MY, FEED)` 추가 → 저장 경로(내 일기 / 피드) 구분  
- UniqueConstraint 적용 : 한 유저는 하나의 recommend에 대해 단 1개만 저장 가능(연타/중복 방지. 클라 state 변경 타이밍과 무관하게 항상 최종 상태 보장)
- **관계 매핑 변경**  
  - 기존 `Voca → Recommend` 관계: `@OneToOne`  
  - 변경 후: `@ManyToOne` (여러 유저가 동일한 Recommend를 북마크할 수 있도록)  
  - 이제 삭제/비공개 된 일기여도 voca는 존재해야하므로 Voca는 Recommend 엔티티를 참조하지 않고 recommendId(FK 값)만 저장하여 의존 최소화
  - recommendId, phrase, phraseType, explanation 스냡샷으로 보관!

### 로직
- 권한
  - 지정(true): “내 일기”이거나 “공개 일기”인 경우에만 허용 -> 아니면 RecommendForbiddenException 발생
  - 해제(false): 공개 여부와 무관, 항상 가능
- 저장 경로 표현
  - 내 일기의 추천 표현 → `SavedRoot.MY` 로 저장  
  - 피드에서 저장한 추천 표현 → `SavedRoot.FEED` 로 저장  

### bookMark 서비스 로직 수정
- 내 일기 **또는 공개된 일기**에 대해서만 북마크 허용  
- 북마크 해제는 공개된 일기의 여부가 필요없음. 언제든 가능.
- 북마크 시 → `Voca` 저장  
- 해제 시 → 해당 `Voca` 삭제  

### Voca 엔티티 변경에 따라 VocaRepository 메서드들 일괄 수정


&nbsp;

## **북마크 지정/해제 API Screenshot 📸**

> recommend 의 id `1~5` → 테스트 기준 **“내 일기”**  
> recommend 의 id `6~10` → 테스트 기준 **“다른 사람의 일기”**

| 시나리오 | 결과 |
| --- | --- |
| 내 일기에서 저장 → `SavedRoot.MY` 로 저장 | <img width="1952" height="350" alt="image" src="https://github.com/user-attachments/assets/a1a0113e-7764-4b6b-b9e9-4430180f0fc0" /> |
| 비공개 일기의 추천 표현 접근 | <img width="2048" height="874" alt="image" src="https://github.com/user-attachments/assets/6b6d37ce-3328-4631-b378-72633f34e3e5" /> |
| 피드에서 저장 → `SavedRoot.FEED` 로 저장 | <img width="1958" height="368" alt="image" src="https://github.com/user-attachments/assets/0937596c-bd43-401c-ac34-8175b3a08c76" /> |

## **특정 단어 세부내용 조회 API Screenshot 📸**
| 시나리오 | 결과 |
| --- | --- |
| 내 일기에서 저장 | <img width="2048" height="1335" alt="image" src="https://github.com/user-attachments/assets/60865e6f-f460-4a1c-aa53-8f3b13718743" />
| 피드에서 저장 | <img width="2048" height="1330" alt="image" src="https://github.com/user-attachments/assets/f9ce5a95-7f38-481c-9097-edc6c8753701" />
| 피드에서 저장한 일기가 비공개된 상태에서(diaryId=2) | <img width="489" height="213" alt="image" src="https://github.com/user-attachments/assets/1f808f04-ec35-4f61-b386-6c91a4018927" />
| 세부내용 조회하니까 "피드에서 저장됨"으로 표현. 이는 비공개/삭제 일기 모두 동일 | <img width="941" height="758" alt="image" src="https://github.com/user-attachments/assets/515b3be9-fa00-46e3-b67c-62d3b6f7e7ce" />

&nbsp;

## Uncompleted Tasks 😅
- @HAJIEUN02 현재 아마도 "단어장 목록조회"에서는 voca 테이블의 voca id(PK)를 내려주고 있을 겁니다. 이제는 그냥 voca테이블이 필드로 가지고있는 recommend id를 내려줘야 할 것 같아요! 
- 해당 PR과 관련된 아이들만 Facade에 만들어주었습니다. 단어장 목록 조회나 검색 등등.. 은 Service에서 Facade 통해서 호출하지 않고 있을거라 해당 부분 체크 및 구현하실때 함께 리팩 진행해주시면 될 것 같아요!
- 해당 API랑 "특정 단어 세부내용 조회 API" 같이 묶어서 했어야 했는데.. PR 타임라인이 조금 꼬였습니다. 해당 PR에서 "북마크 지정/해제 API"와 "특정 단어 세부내용 조회 API" 둘 다 작업했다고 이해하시면 됩니다!!

## **To Reviewers 📢**
- 이제 북마크 여부는 Recommend가 아닌 Voca를 통해 관리
- 저장 경로(`MY`, `FEED`)가 구분되었습니다.
  - 내 일기에서 저장 → 일기 작성일 표시  
  - 피드에서 저장 → "피드에서 저장됨" 표시  