### PR TITLE
[feat] #186 "특정 단어 세부내용 조회 API"에서 단어 저장 경로를 구분해서 표현

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/voca/api/VocaController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/voca/api/VocaController.java
@@ -41,7 +41,7 @@ public class VocaController {
         return ResponseEntity.ok(vocaService.searchVocaList(userId, trimmedKeyword));
     }
 
-    // 특정 단어 세부 조회
+    // 특정 단어 세부내용 조회 API
     @GetMapping("/{phraseId}")
     public ResponseEntity<VocaDetailResponse> getVocaDetails(
             @UserId Long userId,

--- a/hilingual-api/src/main/java/org/sopt/controller/voca/dto/res/VocaDetailResponse.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/voca/dto/res/VocaDetailResponse.java
@@ -1,6 +1,8 @@
 package org.sopt.controller.voca.dto.res;
 
 import org.sopt.recommend.domain.Recommend;
+import org.sopt.voca.domain.Voca;
+import org.sopt.voca.type.SavedRoot;
 
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
@@ -11,30 +13,31 @@ public record VocaDetailResponse(
         String phrase,
         List<String> phraseType,
         String explanation,
-        String writtenDate,
+        String writtenFrom,
         Boolean isBookmarked
 ) {
-
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yy.MM.dd");
+    private static final String FROM_FEED = "피드에서 저장됨";
 
-    public static VocaDetailResponse from(final Recommend recommend) {
+    public static VocaDetailResponse from(final Voca voca) {
+        Recommend r = voca.getRecommend();
+
+        String writtenFrom = (voca.getSavedRoot() == SavedRoot.MY)
+                ? r.getDiary().getWrittenDate().format(FORMATTER) + " 일기에서 저장됨"
+                : FROM_FEED;
+
         return new VocaDetailResponse(
-                recommend.getId(),
-                recommend.getPhrase(),
-                parsePhraseTypes(recommend.getPhraseType()),
-                recommend.getExplanation(),
-                recommend
-                        .getDiary()
-                        .getWrittenDate()
-                        .format(FORMATTER),
-                recommend.getIsBookmarked()
+                r.getId(),
+                r.getPhrase(),
+                parsePhraseTypes(r.getPhraseType()),
+                r.getExplanation(),
+                writtenFrom,
+                true
         );
     }
 
     private static List<String> parsePhraseTypes(String phraseTypeRaw) {
-        if (phraseTypeRaw == null || phraseTypeRaw.isBlank()) {
-            return List.of();
-        }
+        if (phraseTypeRaw == null || phraseTypeRaw.isBlank()) return List.of();
         return Arrays.stream(phraseTypeRaw.split(","))
                 .map(String::trim)
                 .filter(s -> !s.isEmpty())

--- a/hilingual-api/src/main/java/org/sopt/controller/voca/service/VocaService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/voca/service/VocaService.java
@@ -6,7 +6,6 @@ import org.sopt.voca.dto.VocaListRes;
 import org.sopt.controller.voca.dto.res.VocaSearchListResponse;
 import org.sopt.voca.domain.Voca;
 import org.sopt.voca.facade.VocaFacade;
-import org.sopt.voca.facade.VocaRetriever;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
@@ -16,18 +15,16 @@ import java.util.List;
 @RequiredArgsConstructor
 public class VocaService {
 
-    private final VocaRetriever vocaRetriever;
     private final VocaFacade vocaFacade;
-
 
     // 단어장 목록 조회
     public VocaListRes getVocaList(final Long userId, final int sort) {
-        return vocaRetriever.findGroupedVoca(userId, sort);
+        return vocaFacade.findGroupedVoca(userId, sort);
     }
 
     // 단어장 검색
     public VocaSearchListResponse searchVocaList(final Long userId, final String keyword) {
-        final List<Voca> vocas = vocaRetriever.findStartsWithVoca(userId, keyword);
+        final List<Voca> vocas = vocaFacade.findStartsWithVoca(userId, keyword);
         return VocaSearchListResponse.from(vocas);
     }
 

--- a/hilingual-api/src/main/java/org/sopt/controller/voca/service/VocaService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/voca/service/VocaService.java
@@ -4,9 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.controller.voca.dto.res.VocaDetailResponse;
 import org.sopt.voca.dto.VocaListRes;
 import org.sopt.controller.voca.dto.res.VocaSearchListResponse;
-import org.sopt.recommend.domain.Recommend;
-import org.sopt.recommend.facade.RecommendFacade;
 import org.sopt.voca.domain.Voca;
+import org.sopt.voca.facade.VocaFacade;
 import org.sopt.voca.facade.VocaRetriever;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,7 +17,7 @@ import java.util.List;
 public class VocaService {
 
     private final VocaRetriever vocaRetriever;
-    private final RecommendFacade recommendFacade;
+    private final VocaFacade vocaFacade;
 
 
     // 단어장 목록 조회
@@ -34,8 +33,8 @@ public class VocaService {
 
     //특정 단어 세부 조회
     public VocaDetailResponse getVocaDetails(final Long userId, final Long phraseId) {
-        final Recommend recommend = recommendFacade.findByUserIdAndPhraseId(userId, phraseId);
-        return VocaDetailResponse.from(recommend);
+        final Voca voca = vocaFacade.findDetailByUserIdAndPhraseId(userId, phraseId);
+        return VocaDetailResponse.from(voca);
     }
 
 }

--- a/hilingual-domain/src/main/java/org/sopt/recommend/facade/RecommendFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/recommend/facade/RecommendFacade.java
@@ -25,8 +25,4 @@ public class RecommendFacade {
         return recommendRetriever.findById(phraseId);
     }
 
-    public Recommend findByUserIdAndPhraseId(final Long userId, final Long phraseId) {
-        return recommendRetriever.findByUserIdAndPhraseId(userId, phraseId);
-    }
-
 }

--- a/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaFacade.java
@@ -2,7 +2,10 @@ package org.sopt.voca.facade;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.voca.domain.Voca;
+import org.sopt.voca.dto.VocaListRes;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -11,6 +14,14 @@ public class VocaFacade {
     private final VocaRetriever vocaRetriever;
     private final VocaRemover vocaRemover;
     private final VocaSaver vocaSaver;
+
+    public VocaListRes findGroupedVoca(final Long userId, final int sort) {
+        return vocaRetriever.findGroupedVoca(userId, sort);
+    }
+
+    public List<Voca> findStartsWithVoca(final Long userId, final String keyword) {
+        return vocaRetriever.findStartsWithVoca(userId, keyword);
+    }
 
     public Voca findDetailByUserIdAndPhraseId(final Long userId, final Long phraseId){
         return vocaRetriever.findDetailByUserIdAndPhraseId(userId, phraseId);

--- a/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaFacade.java
@@ -1,0 +1,18 @@
+package org.sopt.voca.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.voca.domain.Voca;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class VocaFacade {
+
+    private final VocaRetriever vocaRetriever;
+    private final VocaRemover vocaRemover;
+    private final VocaSaver vocaSaver;
+
+    public Voca findDetailByUserIdAndPhraseId(final Long userId, final Long phraseId){
+        return vocaRetriever.findDetailByUserIdAndPhraseId(userId, phraseId);
+    }
+}

--- a/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaRetriever.java
@@ -3,6 +3,8 @@ package org.sopt.voca.facade;
 import lombok.RequiredArgsConstructor;
 import org.sopt.voca.domain.Voca;
 import org.sopt.voca.dto.VocaListRes;
+import org.sopt.voca.exception.VocaCoreErrorCode;
+import org.sopt.voca.exception.VocaNotFoundException;
 import org.sopt.voca.repository.VocaRepository;
 import org.springframework.stereotype.Component;
 
@@ -28,6 +30,11 @@ public class VocaRetriever {
     // TODO : 검색 한글 예외처리 추가 (단어장 사용 시)
     public List<Voca> findStartsWithVoca(final Long userId, final String keyword) {
         return vocaRepository.findAllByUserIdAndPhraseStartsWith(userId, keyword);
+    }
+
+    public Voca findDetailByUserIdAndPhraseId(final Long userId, final Long phraseId){
+        return vocaRepository.findDetailByUserIdAndPhraseId(userId, phraseId)
+                .orElseThrow(() -> new VocaNotFoundException(VocaCoreErrorCode.VOCA_NOT_FOUND));
     }
 
 }

--- a/hilingual-domain/src/main/java/org/sopt/voca/repository/VocaRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/voca/repository/VocaRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface VocaRepository extends JpaRepository<Voca, Long> {
 
@@ -45,6 +46,17 @@ public interface VocaRepository extends JpaRepository<Voca, Long> {
             @Param("userId") Long userId,
             @Param("keyword") String keyword
     );
+
+    // 특정 단어 상세 조회
+    @Query("""
+        SELECT v
+        FROM Voca v
+        JOIN FETCH v.recommend r
+        JOIN FETCH r.diary d
+        WHERE v.user.id = :userId AND r.id = :phraseId
+    """)
+    Optional<Voca> findDetailByUserIdAndPhraseId(@Param("userId") Long userId,
+                                                 @Param("phraseId") Long phraseId);
 
 }
 


### PR DESCRIPTION
## Related issue 🛠

## Work Description ✏️
- "특정 단어 세부내용 조회 API" 기능 스펙
  - 단어 저장 경로(SavedRoot)에 따라 `writtenFrom` 값 구분
    - 내 일기에서 저장 → `"yy.MM.dd (일기 작성일)에서 저장됨"`
    - 피드에서 저장 → `"피드에서 저장됨"`
  - 삭제된 일기, 비공개 일기, 탈퇴한 회원의 일기 → 모두 `"피드에서 저장됨"`으로 유지
- `VocaRepository.findDetailByUserIdAndPhraseId` 쿼리 추가  
  → Recommend, Diary까지 함께 조회하여 저장 경로 판별 가능
- `VocaDetailResponse` DTO 수정  
  → `writtenDate` → `writtenFrom` 으로 변경 

## Screenshot 📸
| 설명 | 응답 예시 |
| --- | --- |
| 내 일기에서 저장 | <img width="2048" height="1335" alt="image" src="https://github.com/user-attachments/assets/60865e6f-f460-4a1c-aa53-8f3b13718743" />
| 피드에서 저장 | <img width="2048" height="1330" alt="image" src="https://github.com/user-attachments/assets/f9ce5a95-7f38-481c-9097-edc6c8753701" />
| 피드에서 저장한 일기가 비공개된 상태에서(diaryId=2) | <img width="489" height="213" alt="image" src="https://github.com/user-attachments/assets/1f808f04-ec35-4f61-b386-6c91a4018927" />
| 세부내용 조회하니까 "피드에서 저장됨"으로 표현. 이는 비공개/삭제 일기 모두 동일 | <img width="941" height="758" alt="image" src="https://github.com/user-attachments/assets/515b3be9-fa00-46e3-b67c-62d3b6f7e7ce" />

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
- 이제 단어 상세조회 응답에서 저장 경로가 명확히 구분됩니다.  
- 프론트에서도 `writtenFrom` 값만 그대로 노출하면 되도록 했습니다.