### PR TITLE
[feat] #191 유저의 현재 알림 설정 상태 확인 API && 알림 설정 ON/OFF API 구현

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/user/api/UserController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/api/UserController.java
@@ -2,16 +2,16 @@ package org.sopt.controller.user.api;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.sopt.controller.user.dto.NicknameAvailableRes;
+import org.sopt.alarmpreference.type.AlarmType;
+import org.sopt.controller.user.dto.NotiStatusRes;
 import org.sopt.controller.user.dto.NoticeDetailRes;
 import org.sopt.controller.user.dto.UserDefaultInfoRes;
+import org.sopt.controller.user.dto.HomeUserProfileRes;
 import org.sopt.controller.user.service.UserService;
-import org.sopt.dto.BaseResponseDto;
 import org.sopt.jwt.core.JwtTokenProvider;
 import org.sopt.jwt.auth.dto.ReissueTokensRes;
-import org.springframework.http.ResponseEntity;
 import org.sopt.jwt.annotation.UserId;
-import org.sopt.controller.user.dto.HomeUserProfileRes;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -30,9 +30,7 @@ public class UserController {
         return ResponseEntity.ok(userService.reissue(refreshToken));
     }
 
-    /*
-     * 홈
-     */
+    // 홈
     @GetMapping("/home/info")
     public ResponseEntity<HomeUserProfileRes> getUserProfile(
             @UserId Long userId
@@ -40,14 +38,30 @@ public class UserController {
         return ResponseEntity.ok(userService.getHomeUserInfo(userId));
     }
 
-    /*
-     * 마이페이지
-     */
+    // 마이페이지
     @GetMapping("/mypage/info")
     public ResponseEntity<UserDefaultInfoRes> getUserDefaultInfo(
             @UserId Long userId
     ) {
         return ResponseEntity.ok(userService.getUserDefaultInfo(userId));
+    }
+
+    // 유저의 현재 알림 설정 상태 확인 API
+    @GetMapping("/mypage/noti")
+    public ResponseEntity<NotiStatusRes> getUserNotiStatus(
+            @UserId Long userId
+    ){
+        return ResponseEntity.ok(userService.getUserNotiSatus(userId));
+    }
+
+    // 알림 설정 ON/OFF API
+    @PatchMapping("/mypage/noti")
+    public ResponseEntity<NotiStatusRes> toggleAlarmStatus(
+            @UserId Long userId,
+            @RequestParam String notiType
+    ) {
+        AlarmType type = AlarmType.from(notiType);
+        return ResponseEntity.ok(userService.toggleAlarmStatus(userId, String.valueOf(type)));
     }
 
     // 공지 사항 알림 상세보기 API

--- a/hilingual-api/src/main/java/org/sopt/controller/user/dto/NotiStatusRes.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/dto/NotiStatusRes.java
@@ -1,0 +1,7 @@
+package org.sopt.controller.user.dto;
+
+public record NotiStatusRes(
+        boolean marketing,
+        boolean feed
+) {
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/user/service/UserService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/service/UserService.java
@@ -1,6 +1,8 @@
 package org.sopt.controller.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.alarmpreference.facade.AlarmPreferenceFacade;
+import org.sopt.alarmpreference.type.AlarmType;
 import org.sopt.controller.token.TokenService;
 import org.sopt.controller.user.dto.NotiStatusRes;
 import org.sopt.controller.user.dto.UserDefaultInfoRes;
@@ -29,6 +31,7 @@ public class UserService {
     private final UserFacade userFacade;
     private final NoticeDeliveryFacade noticeDeliveryFacade;
     private final FeedAlarmFacade feedAlarmFacade;
+    private final AlarmPreferenceFacade alarmPreferenceFacade;
 
     public UserDefaultInfoRes getUserDefaultInfo(final long userId) {
         User user = userFacade.getUserById(userId);

--- a/hilingual-api/src/main/java/org/sopt/controller/user/service/UserService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/service/UserService.java
@@ -2,6 +2,7 @@ package org.sopt.controller.user.service;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.controller.token.TokenService;
+import org.sopt.controller.user.dto.NotiStatusRes;
 import org.sopt.controller.user.dto.UserDefaultInfoRes;
 import org.sopt.controller.user.exception.CannotLoadProviderException;
 import org.sopt.controller.user.exception.UserApiErrorCode;
@@ -10,15 +11,14 @@ import org.sopt.jwt.auth.dto.ReissueTokensRes;
 import org.sopt.user.domain.User;
 import org.sopt.controller.user.dto.HomeUserProfileRes;
 import org.sopt.user.facade.UserFacade;
-import org.sopt.userprofile.facade.UserProfileFacade;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.sopt.controller.user.dto.NoticeDetailRes;
 import org.sopt.noticedelivery.domain.NoticeDelivery;
 import org.sopt.noticedelivery.facade.NoticeDeliveryFacade;
 
-
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Service
 @Transactional(readOnly = true)
@@ -67,6 +67,21 @@ public class UserService {
                 throw new CannotLoadProviderException(UserApiErrorCode.PROVIDER_LOAD_ERROR);
         }
         return loginProviderInfo;
+    }
+
+    public NotiStatusRes getUserNotiSatus(final Long userId) {
+        Map<AlarmType, Boolean> map = alarmPreferenceFacade.getAlarmStatusMap(userId);
+
+        boolean marketing = Boolean.TRUE.equals(map.get(AlarmType.MARKETING));
+        boolean feed = Boolean.TRUE.equals(map.get(AlarmType.FEED));
+
+        return new NotiStatusRes(marketing, feed);
+    }
+
+    @Transactional
+    public NotiStatusRes toggleAlarmStatus(final Long userId, final String type) {
+        alarmPreferenceFacade.toggle(userId, AlarmType.from(type));
+        return getUserNotiSatus(userId);
     }
 
     @Transactional

--- a/hilingual-domain/src/main/java/org/sopt/alarmpreference/domain/AlarmPreference.java
+++ b/hilingual-domain/src/main/java/org/sopt/alarmpreference/domain/AlarmPreference.java
@@ -54,4 +54,8 @@ public class AlarmPreference {
         );
     }
 
+    public void toggle() {
+        this.isEnabled = !Boolean.TRUE.equals(this.isEnabled);
+    }
+
 }

--- a/hilingual-domain/src/main/java/org/sopt/alarmpreference/exception/AlarmPreferenceCoreErrorCode.java
+++ b/hilingual-domain/src/main/java/org/sopt/alarmpreference/exception/AlarmPreferenceCoreErrorCode.java
@@ -9,6 +9,9 @@ public enum AlarmPreferenceCoreErrorCode implements ErrorCode {
 
     // 400
     INVALID_ALARM_TYPE(HttpStatus.BAD_REQUEST, 40017, "올바르지 않은 알림 타입입니다."),
+
+    // 500
+    NOT_FOUND_ALARM_PREFERENCE_ROW(HttpStatus.INTERNAL_SERVER_ERROR, 50009, "AlarmPreference row가 존재하지 않습니다.");
     ;
 
     public final HttpStatus httpStatus;

--- a/hilingual-domain/src/main/java/org/sopt/alarmpreference/exception/NotFoundAlarmPreferenceRow.java
+++ b/hilingual-domain/src/main/java/org/sopt/alarmpreference/exception/NotFoundAlarmPreferenceRow.java
@@ -1,0 +1,15 @@
+package org.sopt.alarmpreference.exception;
+
+import org.sopt.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundAlarmPreferenceRow extends AlarmPreferenceCoreException{
+    public NotFoundAlarmPreferenceRow(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+}

--- a/hilingual-domain/src/main/java/org/sopt/alarmpreference/facade/AlarmPreferenceFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/alarmpreference/facade/AlarmPreferenceFacade.java
@@ -2,17 +2,30 @@ package org.sopt.alarmpreference.facade;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.alarmpreference.domain.AlarmPreference;
+import org.sopt.alarmpreference.type.AlarmType;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AlarmPreferenceFacade {
 
+    private final AlarmPreferenceRetriever alarmPreferenceRetriever;
+    private final AlarmPreferenceUpdater alarmPreferenceUpdater;
     private final AlarmPreferenceSaver alarmPreferenceSaver;
 
-    /*
-     * Saver
-     */
+    public Map<AlarmType, Boolean> getAlarmStatusMap(final long userId) {
+        return alarmPreferenceRetriever.getAlarmStatusMap(userId);
+    }
+
+    @Transactional
+    public void toggle(final long userId, final AlarmType type) {
+        alarmPreferenceUpdater.toggle(userId, type);
+    }
+
     public AlarmPreference save(AlarmPreference alarmPreference) {
         return alarmPreferenceSaver.save(alarmPreference);
     }

--- a/hilingual-domain/src/main/java/org/sopt/alarmpreference/facade/AlarmPreferenceRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/alarmpreference/facade/AlarmPreferenceRetriever.java
@@ -1,0 +1,33 @@
+package org.sopt.alarmpreference.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.alarmpreference.domain.AlarmPreference;
+import org.sopt.alarmpreference.exception.AlarmPreferenceCoreErrorCode;
+import org.sopt.alarmpreference.exception.NotFoundAlarmPreferenceRow;
+import org.sopt.alarmpreference.repository.AlarmPreferenceRepository;
+import org.sopt.alarmpreference.type.AlarmType;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.EnumMap;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AlarmPreferenceRetriever {
+
+    private final AlarmPreferenceRepository alarmPreferenceRepository;
+
+    public EnumMap<AlarmType, Boolean> getAlarmStatusMap(Long userId) {
+        List<AlarmPreference> prefs = alarmPreferenceRepository.findByUserId(userId);
+
+        if (prefs.isEmpty()) {
+            throw new NotFoundAlarmPreferenceRow(AlarmPreferenceCoreErrorCode.NOT_FOUND_ALARM_PREFERENCE_ROW);
+        }
+
+        EnumMap<AlarmType, Boolean> map = new EnumMap<>(AlarmType.class);
+        prefs.forEach(p -> map.put(p.getAlarmType(), Boolean.TRUE.equals(p.getIsEnabled())));
+        return map;
+    }
+}

--- a/hilingual-domain/src/main/java/org/sopt/alarmpreference/facade/AlarmPreferenceUpdater.java
+++ b/hilingual-domain/src/main/java/org/sopt/alarmpreference/facade/AlarmPreferenceUpdater.java
@@ -1,0 +1,25 @@
+package org.sopt.alarmpreference.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.alarmpreference.domain.AlarmPreference;
+import org.sopt.alarmpreference.exception.AlarmPreferenceCoreErrorCode;
+import org.sopt.alarmpreference.exception.NotFoundAlarmPreferenceRow;
+import org.sopt.alarmpreference.repository.AlarmPreferenceRepository;
+import org.sopt.alarmpreference.type.AlarmType;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class AlarmPreferenceUpdater {
+
+    private final AlarmPreferenceRepository alarmPreferenceRepository;
+
+    @Transactional
+    public void toggle(final long userId, final AlarmType type) {
+        AlarmPreference pref = alarmPreferenceRepository.findByUserIdAndAlarmType(userId, type)
+                .orElseThrow(() -> new NotFoundAlarmPreferenceRow(AlarmPreferenceCoreErrorCode.NOT_FOUND_ALARM_PREFERENCE_ROW));
+        pref.toggle();
+    }
+
+}

--- a/hilingual-domain/src/main/java/org/sopt/alarmpreference/repository/AlarmPreferenceRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/alarmpreference/repository/AlarmPreferenceRepository.java
@@ -1,7 +1,18 @@
 package org.sopt.alarmpreference.repository;
 
 import org.sopt.alarmpreference.domain.AlarmPreference;
+import org.sopt.alarmpreference.type.AlarmType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface AlarmPreferenceRepository extends JpaRepository<AlarmPreference, Long> {
+
+    // 특정 유저의 모든 알림설정 조회
+    List<AlarmPreference> findByUserId(Long userId);
+
+    // 특정 유저의 특정 알림 타입 설정을 조회
+    Optional<AlarmPreference> findByUserIdAndAlarmType(Long userId, AlarmType alarmType);
+
 }

--- a/hilingual-domain/src/main/java/org/sopt/alarmpreference/type/AlarmType.java
+++ b/hilingual-domain/src/main/java/org/sopt/alarmpreference/type/AlarmType.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.sopt.alarmpreference.exception.AlarmPreferenceCoreErrorCode;
 import org.sopt.alarmpreference.exception.InvalidAlarmTypeException;
+import org.sopt.exception.code.GlobalErrorCode;
 
 import java.util.Arrays;
 
@@ -14,6 +15,17 @@ public enum AlarmType {
     MARKETING(2);
 
     private final int code;
+
+    public static AlarmType from(String notiType) {
+        if (notiType == null) {
+            throw new InvalidAlarmTypeException(GlobalErrorCode.INVALID_INPUT_VALUE);
+        }
+        try {
+            return AlarmType.valueOf(notiType.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new InvalidAlarmTypeException(AlarmPreferenceCoreErrorCode.INVALID_ALARM_TYPE);
+        }
+    }
 
     public static AlarmType fromCode(int code) {
         return Arrays.stream(values())


### PR DESCRIPTION
[feat] #191 유저의 현재 알림 설정 상태 확인 API && 알림 설정 ON/OFF API 구현

## Related issue 🛠
- closed #191 
- closed #192 

## Work Description ✏️
### 유저의 현재 알림 설정 상태 확인 API
- `AlarmPreferenceFacade` → `AlarmPreferenceRetriever`에서 `EnumMap<AlarmType, Boolean>` 반환하도록 구현  
- Map 사용 이유
  - Domain 계층이 API 모듈의 DTO(`NotiStatusRes`)에 종속되지 않도록 하기 위함 -> 이후 API 계층에서 `NotiStatusRes` DTO로 변환하여 클라이언트에 응답
  - 알림 타입(`AlarmType`)을 key로 두어 확장성 ↑
  - FEED, MARKETING 외 알림 타입이 추가되더라도 동일한 구조로 쉽게 처리 가능
- `UserService.getUserNotiStatus()`에서 `NotiStatusRes`로 변환하여 응답
  - FEED 알림 기본값: ON(true)
  - MARKETING 알림 기본값: OFF(false)
  - row 없을 경우 예외(`NotFoundAlarmPreferenceRowException`) 발생  


### 알림 설정 ON/OFF API
- `AlarmPreference.toggle()` 메서드 추가 → ON/OFF 상태 토글 처리
- `AlarmPreferenceUpdater`에서 DB row를 조회 후 상태 반전
  - row 없을 경우 예외(`NotFoundAlarmPreferenceRowException`) 발생  
  - (회원가입 시 반드시 row가 생성되므로 정상 flow에서는 발생하지 않습니다)
- API 응답 시 현재 설정 상태를 반환하도록 함
  - 데이터 정합성 확보 (클라 state 동기화 목적)

##  유저의 현재 알림 설정 상태 확인 API Screenshot 📸 
| 설명 | 사진 |
| --- | --- |
| AlarmPreference 테이블에 row 자체가 생성 안되어 있는 경우 예외(원래는 회원가입 시 생성되어야 하므로) | <img width="2048" height="922" alt="image" src="https://github.com/user-attachments/assets/2cf08dcf-f047-4d84-b200-0f682a7c66f9" /> |
| 현재 알림 상태 확인 API 성공 | <img width="2048" height="1071" alt="image" src="https://github.com/user-attachments/assets/9b044626-328a-447d-bd6e-adf67ee2f1a4" /> |

## 알림 설정 ON/OFF API Screenshot 📸
| 설명 | 사진 |
| --- | --- |
| AlarmPreference 테이블에 row 자체가 생성 안되어 있는 경우 예외(원래는 회원가입 시 생성되어야 하므로) | <img width="1080" height="515" alt="image" src="https://github.com/user-attachments/assets/ec4ab40a-1738-4471-82c8-3ea03465d217" /> |
| 알림 설정 OFF | <img width="2048" height="1071" alt="image" src="https://github.com/user-attachments/assets/6d36ab43-cbc0-497c-b533-2b7d3052a12d" /> |
| 한 번 더 요청시 알림 설정 ON | <img width="2048" height="1091" alt="image" src="https://github.com/user-attachments/assets/e091fa69-2c0d-4da1-b3ea-437f0fbdf75e" /> |

## Uncompleted Tasks 😅
- 회원가입 시 `AlarmPreference` 테이블에 FEED/ MARKETING row가 반드시 생성되어야 합니다.  

## To Reviewers 📢
- 더 발생할 수 있는 예외가 있을지 확인 부탁드립니다!