### PR TITLE
[feat] #196 사용자 검색하기 API 구현

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/feed/api/FeedController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/feed/api/FeedController.java
@@ -1,7 +1,7 @@
 package org.sopt.controller.feed.api;
 
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.sopt.controller.feed.dto.DiaryWriterProfileRes;
 import org.sopt.controller.feed.dto.FeedProfileRes;

--- a/hilingual-api/src/main/java/org/sopt/controller/feed/api/FeedController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/feed/api/FeedController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.controller.feed.dto.FeedProfileRes;
 import org.sopt.controller.feed.dto.LikedDiaryListRes;
 import org.sopt.controller.feed.dto.SharedDiaryListRes;
+import org.sopt.controller.feed.dto.UserListRes;
 import org.sopt.controller.feed.service.FeedService;
 import org.sopt.jwt.annotation.UserId;
 import org.springframework.http.ResponseEntity;
@@ -52,4 +53,11 @@ public class FeedController {
         return ResponseEntity.ok(feedService.getLikedDiaries(targetUserId));
     }
 
+    @GetMapping("/search")
+    public ResponseEntity<UserListRes> getUserList(
+            @UserId Long userId,
+            @RequestParam(value = "keyword") String keyword
+    ) {
+        return ResponseEntity.ok(feedService.getUserList(userId, keyword));
+    }
 }

--- a/hilingual-api/src/main/java/org/sopt/controller/feed/dto/UserListRes.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/feed/dto/UserListRes.java
@@ -1,35 +1,15 @@
 package org.sopt.controller.feed.dto;
 
-import org.sopt.userprofile.dto.UserSearchProjection;
-
 import java.util.List;
 
 public record UserListRes(
         List<SearchUser> userList
 ) {
-    public static UserListRes of(final List<UserSearchProjection> userList) {
-        List<SearchUser> searchUserList = userList.stream()
-                .map(SearchUser::of)
-                .toList();
-
-        return new UserListRes(searchUserList);
-    }
-
-    record SearchUser(
+    public record SearchUser(
             Long userId,
             String profileImg,
             String nickname,
             Boolean isFollowing,
             Boolean isFollowed
-    ){
-        static SearchUser of(UserSearchProjection userList) {
-            return new SearchUser(
-                    userList.getUserId(),
-                    (userList.getProfileImg() != null) ? userList.getProfileImg() : " ",
-                    userList.getNickname(),
-                    userList.getIsFollowing(),
-                    userList.getIsFollowed()
-            );
-        }
-    }
+    ){ }
 }

--- a/hilingual-api/src/main/java/org/sopt/controller/feed/dto/UserListRes.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/feed/dto/UserListRes.java
@@ -25,7 +25,7 @@ public record UserListRes(
         static SearchUser of(UserSearchProjection userList) {
             return new SearchUser(
                     userList.getUserId(),
-                    userList.getProfileImg(),
+                    (userList.getProfileImg() != null) ? userList.getProfileImg() : " ",
                     userList.getNickname(),
                     userList.getIsFollowing(),
                     userList.getIsFollowed()

--- a/hilingual-api/src/main/java/org/sopt/controller/feed/dto/UserListRes.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/feed/dto/UserListRes.java
@@ -1,0 +1,35 @@
+package org.sopt.controller.feed.dto;
+
+import org.sopt.userprofile.dto.UserSearchProjection;
+
+import java.util.List;
+
+public record UserListRes(
+        List<SearchUser> userList
+) {
+    public static UserListRes of(final List<UserSearchProjection> userList) {
+        List<SearchUser> searchUserList = userList.stream()
+                .map(SearchUser::of)
+                .toList();
+
+        return new UserListRes(searchUserList);
+    }
+
+    record SearchUser(
+            Long userId,
+            String profileImg,
+            String nickname,
+            Boolean isFollowing,
+            Boolean isFollowed
+    ){
+        static SearchUser of(UserSearchProjection userList) {
+            return new SearchUser(
+                    userList.getUserId(),
+                    userList.getProfileImg(),
+                    userList.getNickname(),
+                    userList.getIsFollowing(),
+                    userList.getIsFollowed()
+            );
+        }
+    }
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/feed/service/FeedService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/feed/service/FeedService.java
@@ -5,6 +5,7 @@ import org.sopt.block.facade.BlockFacade;
 import org.sopt.controller.feed.dto.FeedProfileRes;
 import org.sopt.controller.feed.dto.LikedDiaryListRes;
 import org.sopt.controller.feed.dto.SharedDiaryListRes;
+import org.sopt.controller.feed.dto.UserListRes;
 import org.sopt.diary.domain.Diary;
 import org.sopt.diary.facade.DiaryFacade;
 import org.sopt.follow.dto.FollowRelation;
@@ -13,6 +14,7 @@ import org.sopt.likeddiary.domain.LikedDiary;
 import org.sopt.likeddiary.facade.LikedDiaryFacade;
 import org.sopt.user.facade.UserFacade;
 import org.sopt.userprofile.domain.UserProfile;
+import org.sopt.userprofile.dto.UserSearchProjection;
 import org.sopt.userprofile.facade.UserProfileFacade;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -99,6 +101,14 @@ public class FeedService {
                         })
                         .toList()
         );
+    }
+
+    public UserListRes getUserList(Long userId, String keyword) {
+        String likeKeyword = "%" + keyword + "%";
+        String startKeyword = keyword + "%";
+
+        List<UserSearchProjection> userList = userProfileFacade.getUserListByNickname(userId, likeKeyword, startKeyword);
+        return UserListRes.of(userList);
     }
 
     // TODO 사용위치 확인 후 Diary 쪽으로 옮기는 것도 고려해볼 것

--- a/hilingual-api/src/main/java/org/sopt/controller/feed/service/FeedService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/feed/service/FeedService.java
@@ -155,7 +155,23 @@ public class FeedService {
         String startKeyword = keyword + "%";
 
         List<UserSearchProjection> userList = userProfileFacade.getUserListByNickname(userId, likeKeyword, startKeyword);
-        return UserListRes.of(userList);
+
+        List<UserListRes.SearchUser> searchUserList = userList.stream()
+                .map(projection -> {
+                    String originalImgUrl = projection.getProfileImg();
+                    String publicImgUrl = (originalImgUrl != null) ? s3Service.toPublicUrl(originalImgUrl) : " ";
+
+                    return new UserListRes.SearchUser(
+                            projection.getUserId(),
+                            (publicImgUrl != null) ? publicImgUrl : " ",
+                            projection.getNickname(),
+                            projection.getIsFollowing(),
+                            projection.getIsFollowed()
+                    );
+                })
+                .toList();
+
+        return new UserListRes(searchUserList);
     }
 
     private List<Map<String, Object>> getPublicDiariesWithIsLiked(Long userId) {

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/dto/UserSearchProjection.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/dto/UserSearchProjection.java
@@ -1,0 +1,9 @@
+package org.sopt.userprofile.dto;
+
+public interface UserSearchProjection {
+    Long getUserId();
+    String getProfileImg();
+    String getNickname();
+    Boolean getIsFollowing();
+    Boolean getIsFollowed();
+}

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileFacade.java
@@ -2,8 +2,8 @@ package org.sopt.userprofile.facade;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.userprofile.domain.UserProfile;
+import org.sopt.userprofile.dto.UserSearchProjection;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -38,6 +38,10 @@ public class UserProfileFacade {
 
     public UserProfile getProfileByUserId(Long userId) {
         return userProfileRetriever.findByUserId(userId);
+    }
+
+    public List<UserSearchProjection> getUserListByNickname(Long userId, String keyword, String startKeyword) {
+        return userProfileRetriever.findUsersByNickname(userId, keyword, startKeyword);
     }
 
     /**

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileRetriever.java
@@ -2,6 +2,7 @@ package org.sopt.userprofile.facade;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.userprofile.domain.UserProfile;
+import org.sopt.userprofile.dto.UserSearchProjection;
 import org.sopt.userprofile.exception.UserProfileNotFoundException;
 import org.sopt.userprofile.exception.UserProfileCoreErrorCode;
 import org.sopt.userprofile.repository.UserProfileRepository;
@@ -32,5 +33,9 @@ public class UserProfileRetriever {
 
     public List<UserProfile> findByUserIds(List<Long> userIds) {
         return userProfileRepository.findByUserIds(userIds);
+    }
+
+    public List<UserSearchProjection> findUsersByNickname(Long userId, String keyword, String startKeyword) {
+        return userProfileRepository.searchUserListByKeyword(userId, keyword, startKeyword);
     }
 }

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/repository/UserProfileRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/repository/UserProfileRepository.java
@@ -2,6 +2,7 @@ package org.sopt.userprofile.repository;
 
 import org.sopt.user.domain.User;
 import org.sopt.userprofile.domain.UserProfile;
+import org.sopt.userprofile.dto.UserSearchProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -27,5 +28,40 @@ public interface UserProfileRepository extends JpaRepository<UserProfile, Long> 
            WHERE up.user.id IN :userIds
            """)
     List<UserProfile> findByUserIds(@Param("userIds") List<Long> userIds);
-}
 
+    /*
+     * 검색 nickname에 해당하는 유저 리스트 검색
+     * - 차단한 or 차단당한 유저는 검색되지 않음
+     * - 앞단어가 일치하는 순서부터 중간 단어가 일치해도 표시
+     * isFollowing, isFollowed 값을 함께 response로 내려줄 것
+     */
+    @Query("""
+        SELECT
+            up.user.id AS userId,
+            up.profileImg AS profileImg,
+            up.nickname AS nickname,
+            CASE WHEN EXISTS (
+                SELECT 1 FROM Follow f WHERE f.follower.id = :currentUserId AND f.followee.id = up.user.id
+            ) THEN TRUE ELSE FALSE END AS isFollowing,
+            CASE WHEN EXISTS (
+                SELECT 1 FROM Follow f WHERE f.follower.id = up.user.id AND f.followee.id = :currentUserId
+            ) THEN TRUE ELSE FALSE END AS isFollowed
+        FROM UserProfile up
+        WHERE up.user.id != :currentUserId
+          AND up.nickname LIKE :keyword
+          AND up.user.id NOT IN (
+              SELECT b.blocked.id FROM Block b WHERE b.blocker.id = :currentUserId
+          )
+          AND up.user.id NOT IN (
+              SELECT b.blocker.id FROM Block b WHERE b.blocked.id = :currentUserId
+          )
+        ORDER BY
+            CASE WHEN up.nickname LIKE :startWithKeyword THEN 0 ELSE 1 END,
+            up.nickname
+        """)
+    List<UserSearchProjection> searchUserListByKeyword(
+            @Param("currentUserId") Long currentUserId,
+            @Param("keyword") String keyword,
+            @Param("startWithKeyword") String startWithKeyword
+    );
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #196 

## Work Description ✏️
- 사용자 검색하기 API 구현

> ### 구현 로직
- 해당 nickname에 해당하는 유저 검색 → `UserProfile` 에서 검색해서 `User` 리스트를 추출
    - 차단한, 차단당한 유저는 검색되지 않음
    - 검색 내용과 일치하는 닉네임을 표시 → 앞단어가 일치하는 순서부터 표시하고 중간 단어가 일치해도 표시 ex. ‘하’를 검색했을 때 ‘하이링구얼’, ‘하지은’, ‘하마’, ‘아하’ 이런 식으로..
- domain 모듈에서 api 모듈의 dto를 사용하지 않아야 하나 repository에서 query문을 작성할 때 dto와 동일한 형태로 한번에 조회하고자 함 → interface 활용
```
public interface UserSearchProjection {
    Long getUserId();
    String getProfileImg();
    String getNickname();
    Boolean getIsFollowing();
    Boolean getIsFollowed();
}


// 실제 DTO
public record SearchUser(
            Long userId,
            String profileImg,
            String nickname,
            Boolean isFollowing,
            Boolean isFollowed
    ){
        static SearchUser of(final User user, final boolean isFollowing, final boolean isFollowed) {
            return new SearchUser(
                    user.getId(),
                    user.getUserProfile().getProfileImg(),
                    user.getUserProfile().getNickname(),
                    isFollowing,
                    isFollowed
            );
        }
    }
```
이렇게 모듈간 분리한 후, Query를 활용해 검색 로직을 구현했습니다.
```
@Query("""
        SELECT
            up.user.id AS userId,
            up.profileImg AS profileImg,
            up.nickname AS nickname,
            CASE WHEN EXISTS (
                SELECT 1 FROM Follow f WHERE f.follower.id = :currentUserId AND f.followee.id = up.user.id
            ) THEN TRUE ELSE FALSE END AS isFollowing,
            CASE WHEN EXISTS (
                SELECT 1 FROM Follow f WHERE f.follower.id = up.user.id AND f.followee.id = :currentUserId
            ) THEN TRUE ELSE FALSE END AS isFollowed
        FROM UserProfile up
        WHERE up.user.id != :currentUserId
          AND up.nickname LIKE :keyword
          AND up.user.id NOT IN (
              SELECT b.blocked.id FROM Block b WHERE b.blocker.id = :currentUserId
          )
          AND up.user.id NOT IN (
              SELECT b.blocker.id FROM Block b WHERE b.blocked.id = :currentUserId
          )
        ORDER BY
            CASE WHEN up.nickname LIKE :startWithKeyword THEN 0 ELSE 1 END,
            up.nickname
        """)
    List<UserSearchProjection> searchUserListByKeyword(
            @Param("currentUserId") Long currentUserId,
            @Param("keyword") String keyword,
            @Param("startWithKeyword") String startWithKeyword
    );
```

## Screenshot 📸
- userId 1로 테스트(닉네임 : 하이링구얼)

|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 유저프로필 DB | <img width="221" height="122" alt="image" src="https://github.com/user-attachments/assets/ed598c7f-2064-4657-82c7-a8c47dc056d9" /> |
| 팔로우 DB(1번이 3, 4번 팔로우/3번이 1번 팔로우) | <img width="427" height="131" alt="image" src="https://github.com/user-attachments/assets/5162b2d6-49b0-4dd8-b7bf-23c3e9b01248" /> |
| 차단 DB(1번이 2번 차단, 5번이 1번 차단) | <img width="298" height="86" alt="image" src="https://github.com/user-attachments/assets/dceb09e7-1a8d-4dc2-86f2-034d18323e7a" /> |
| '하' 검색 시 결과(모든 유저 있음, 맨 앞이 하인 사람부터 정렬) | <img width="356" height="545" alt="image" src="https://github.com/user-attachments/assets/59915503-7dcd-41e5-b4a5-37ccc9c7f936" /> |
| '노' 검색 시 결과(유저 없음) | <img width="312" height="335" alt="image" src="https://github.com/user-attachments/assets/c4c4247e-aa1c-4983-86f8-8e4a5c971b14" /> |

## Uncompleted Tasks 😅
- [x] 프로필 이미지 내려줄 때 cdn 붙여서 내리기

## To Reviewers 📢
N/A