### PR TITLE
[feat] #198 닉네임 검사 - 금지어 포함 여부 판단 API 구현

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/user/api/UserController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/api/UserController.java
@@ -21,13 +21,6 @@ public class UserController {
     private final UserService userService;
     private final JwtTokenProvider jwtTokenProvider;
 
-    @GetMapping("/profile")
-    public BaseResponseDto<NicknameAvailableRes> getUserProfile(
-            @RequestParam(value = "nickname") String nickname
-    ) {
-        return userService.getNicknameAvailable(nickname);
-    }
-
     @PostMapping("/reissue")
     public ResponseEntity<ReissueTokensRes> reissue(
             HttpServletRequest request

--- a/hilingual-api/src/main/java/org/sopt/controller/user/service/UserService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/service/UserService.java
@@ -30,20 +30,6 @@ public class UserService {
     private static final int MAX_NICKNAME_LENGTH = 10;
 
     private final UserFacade userFacade;
-    private final UserProfileFacade userProfileFacade;
-
-    public BaseResponseDto<NicknameAvailableRes> getNicknameAvailable(String nickname) {
-        if (!isValidFormat(nickname)) {
-            return unavailableNickname(UserSuccessCode.NICKNAME_SPECIAL_SYMBOLS);
-        }
-        if (!isValidLength(nickname)) {
-            return unavailableNickname(UserSuccessCode.NICKNAME_COUNT);
-        }
-        if (userFacade.isNicknameExists(nickname)) {
-            return unavailableNickname(UserSuccessCode.NICKNAME_DUPLICATED);
-        }
-        return availableNickname();
-    }
 
     public UserDefaultInfoRes getUserDefaultInfo(final long userId) {
         User user = userFacade.getUserById(userId);
@@ -61,23 +47,6 @@ public class UserService {
                 user.getUserProfile(),
                 user.getNotifyStatus()
         );
-    }
-
-    private boolean isValidFormat(String nickname) {
-        return nickname.matches(NICKNAME_PATTERN);
-    }
-
-    private boolean isValidLength(String nickname) {
-        int length = nickname.length();
-        return length >= MIN_NICKNAME_LENGTH && length <= MAX_NICKNAME_LENGTH;
-    }
-
-    private BaseResponseDto<NicknameAvailableRes> availableNickname() {
-        return BaseResponseDto.success(UserSuccessCode.NICKNAME_AVAILABLE, new NicknameAvailableRes(true));
-    }
-
-    private BaseResponseDto<NicknameAvailableRes> unavailableNickname(UserSuccessCode code) {
-        return BaseResponseDto.success(code, new NicknameAvailableRes(false));
     }
 
     @Transactional

--- a/hilingual-api/src/main/java/org/sopt/controller/user/service/UserService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/service/UserService.java
@@ -18,13 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final TokenService tokenService;
-
-    // TODO : 닉네임 중복 체크 아예 Custom Validator 로 빼자. 현재 UserService 의 책임이 너무 무거움.
-
-    private static final String NICKNAME_PATTERN = "^[가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9]+$";
-    private static final int MIN_NICKNAME_LENGTH = 2;
-    private static final int MAX_NICKNAME_LENGTH = 10;
-
     private final UserFacade userFacade;
 
     public UserDefaultInfoRes getUserDefaultInfo(final long userId) {

--- a/hilingual-api/src/main/java/org/sopt/controller/user/service/UserService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/service/UserService.java
@@ -2,17 +2,13 @@ package org.sopt.controller.user.service;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.controller.token.TokenService;
-import org.sopt.controller.user.dto.NicknameAvailableRes;
 import org.sopt.controller.user.dto.UserDefaultInfoRes;
 import org.sopt.controller.user.exception.CannotLoadProviderException;
 import org.sopt.controller.user.exception.UserApiErrorCode;
-import org.sopt.controller.user.exception.UserSuccessCode;
-import org.sopt.dto.BaseResponseDto;
 import org.sopt.jwt.auth.dto.ReissueTokensRes;
 import org.sopt.user.domain.User;
 import org.sopt.controller.user.dto.HomeUserProfileRes;
 import org.sopt.user.facade.UserFacade;
-import org.sopt.userprofile.facade.UserProfileFacade;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/hilingual-api/src/main/java/org/sopt/controller/userprofile/api/UserProfileController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/userprofile/api/UserProfileController.java
@@ -1,7 +1,9 @@
 package org.sopt.controller.userprofile.api;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.controller.user.dto.NicknameAvailableRes;
 import org.sopt.controller.userprofile.dto.UserProfileReq;
+import org.sopt.dto.BaseResponseDto;
 import org.sopt.jwt.annotation.UserId;
 import org.sopt.controller.userprofile.service.UserProfileService;
 import org.sopt.exception.code.GlobalSuccessCode;
@@ -14,6 +16,13 @@ import org.springframework.web.bind.annotation.*;
 public class UserProfileController {
 
     private final UserProfileService userProfileService;
+
+    @GetMapping("/profile")
+    public BaseResponseDto<NicknameAvailableRes> getUserProfile(
+            @RequestParam(value = "nickname") String nickname
+    ) {
+        return userProfileService.getNicknameAvailable(nickname);
+    }
 
     @PostMapping("/profile")
     public ResponseEntity<?> saveUserProfile(

--- a/hilingual-api/src/main/java/org/sopt/controller/userprofile/exception/UserProfileSuccessCode.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/userprofile/exception/UserProfileSuccessCode.java
@@ -1,15 +1,16 @@
-package org.sopt.controller.user.exception;
+package org.sopt.controller.userprofile.exception;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.exception.code.SuccessCode;
 import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
-public enum UserSuccessCode implements SuccessCode {
+public enum UserProfileSuccessCode implements SuccessCode {
     NICKNAME_AVAILABLE(HttpStatus.OK, 20000, "사용 가능한 닉네임입니다."),
     NICKNAME_DUPLICATED(HttpStatus.OK, 20001, "중복된 닉네임입니다."),
     NICKNAME_SPECIAL_SYMBOLS(HttpStatus.OK, 20002, "특수문자, 이모지가 포함된 닉네임입니다."),
-    NICKNAME_COUNT(HttpStatus.OK, 20003, "2자 미만이거나 10자 초과된 닉네임입니다.");
+    NICKNAME_COUNT(HttpStatus.OK, 20003, "2자 미만이거나 10자 초과된 닉네임입니다."),
+    NICKNAME_FORBIDDEN(HttpStatus.OK, 20004, "금지어가 포함된 닉네임입니다.");
 
     public final HttpStatus httpStatus;
     private final int code;

--- a/hilingual-api/src/main/java/org/sopt/controller/userprofile/service/UserProfileService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/userprofile/service/UserProfileService.java
@@ -1,7 +1,10 @@
 package org.sopt.controller.userprofile.service;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.controller.user.dto.NicknameAvailableRes;
+import org.sopt.controller.user.exception.UserSuccessCode;
 import org.sopt.controller.userprofile.dto.UserProfileReq;
+import org.sopt.dto.BaseResponseDto;
 import org.sopt.user.facade.UserFacade;
 import org.sopt.user.domain.User;
 import org.sopt.userprofile.domain.UserProfile;
@@ -15,6 +18,25 @@ import org.springframework.stereotype.Service;
 public class UserProfileService {
     private final UserFacade userFacade;
     private final UserProfileFacade userProfileFacade;
+
+    // TODO : 닉네임 중복 체크 아예 Custom Validator 로 빼자
+
+    private static final String NICKNAME_PATTERN = "^[가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9]+$";
+    private static final int MIN_NICKNAME_LENGTH = 2;
+    private static final int MAX_NICKNAME_LENGTH = 10;
+
+    public BaseResponseDto<NicknameAvailableRes> getNicknameAvailable(String nickname) {
+        if (!isValidFormat(nickname)) {
+            return unavailableNickname(UserSuccessCode.NICKNAME_SPECIAL_SYMBOLS);
+        }
+        if (!isValidLength(nickname)) {
+            return unavailableNickname(UserSuccessCode.NICKNAME_COUNT);
+        }
+        if (userFacade.isNicknameExists(nickname)) {
+            return unavailableNickname(UserSuccessCode.NICKNAME_DUPLICATED);
+        }
+        return availableNickname();
+    }
 
     public void save(Long userId, UserProfileReq userProfileReq) {
         // TODO : Custom error
@@ -31,4 +53,22 @@ public class UserProfileService {
         user.setIsCompleted(true);
         userFacade.save(user);
     }
+
+    private boolean isValidFormat(String nickname) {
+        return nickname.matches(NICKNAME_PATTERN);
+    }
+
+    private boolean isValidLength(String nickname) {
+        int length = nickname.length();
+        return length >= MIN_NICKNAME_LENGTH && length <= MAX_NICKNAME_LENGTH;
+    }
+
+    private BaseResponseDto<NicknameAvailableRes> availableNickname() {
+        return BaseResponseDto.success(UserSuccessCode.NICKNAME_AVAILABLE, new NicknameAvailableRes(true));
+    }
+
+    private BaseResponseDto<NicknameAvailableRes> unavailableNickname(UserSuccessCode code) {
+        return BaseResponseDto.success(code, new NicknameAvailableRes(false));
+    }
+
 }

--- a/hilingual-api/src/main/java/org/sopt/controller/userprofile/service/UserProfileService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/userprofile/service/UserProfileService.java
@@ -34,7 +34,7 @@ public class UserProfileService {
         if (!isValidLength(nickname)) {
             return unavailableNickname(UserProfileSuccessCode.NICKNAME_COUNT);
         }
-        if (userFacade.isNicknameExists(nickname)) {
+        if (userProfileFacade.isNicknameExists(nickname)) {
             return unavailableNickname(UserProfileSuccessCode.NICKNAME_DUPLICATED);
         }
         if (forbiddenWordFacade.findIsInForbiddenWord(nickname)) {

--- a/hilingual-api/src/main/java/org/sopt/controller/userprofile/service/UserProfileService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/userprofile/service/UserProfileService.java
@@ -2,9 +2,10 @@ package org.sopt.controller.userprofile.service;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.controller.user.dto.NicknameAvailableRes;
-import org.sopt.controller.user.exception.UserSuccessCode;
+import org.sopt.controller.userprofile.exception.UserProfileSuccessCode;
 import org.sopt.controller.userprofile.dto.UserProfileReq;
 import org.sopt.dto.BaseResponseDto;
+import org.sopt.forbiddenword.facade.ForbiddenWordFacade;
 import org.sopt.user.facade.UserFacade;
 import org.sopt.user.domain.User;
 import org.sopt.userprofile.domain.UserProfile;
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Service;
 public class UserProfileService {
     private final UserFacade userFacade;
     private final UserProfileFacade userProfileFacade;
+    private final ForbiddenWordFacade forbiddenWordFacade;
 
     // TODO : 닉네임 중복 체크 아예 Custom Validator 로 빼자
 
@@ -27,13 +29,16 @@ public class UserProfileService {
 
     public BaseResponseDto<NicknameAvailableRes> getNicknameAvailable(String nickname) {
         if (!isValidFormat(nickname)) {
-            return unavailableNickname(UserSuccessCode.NICKNAME_SPECIAL_SYMBOLS);
+            return unavailableNickname(UserProfileSuccessCode.NICKNAME_SPECIAL_SYMBOLS);
         }
         if (!isValidLength(nickname)) {
-            return unavailableNickname(UserSuccessCode.NICKNAME_COUNT);
+            return unavailableNickname(UserProfileSuccessCode.NICKNAME_COUNT);
         }
         if (userFacade.isNicknameExists(nickname)) {
-            return unavailableNickname(UserSuccessCode.NICKNAME_DUPLICATED);
+            return unavailableNickname(UserProfileSuccessCode.NICKNAME_DUPLICATED);
+        }
+        if (forbiddenWordFacade.findIsInForbiddenWord(nickname)) {
+            return unavailableNickname(UserProfileSuccessCode.NICKNAME_FORBIDDEN);
         }
         return availableNickname();
     }
@@ -64,10 +69,10 @@ public class UserProfileService {
     }
 
     private BaseResponseDto<NicknameAvailableRes> availableNickname() {
-        return BaseResponseDto.success(UserSuccessCode.NICKNAME_AVAILABLE, new NicknameAvailableRes(true));
+        return BaseResponseDto.success(UserProfileSuccessCode.NICKNAME_AVAILABLE, new NicknameAvailableRes(true));
     }
 
-    private BaseResponseDto<NicknameAvailableRes> unavailableNickname(UserSuccessCode code) {
+    private BaseResponseDto<NicknameAvailableRes> unavailableNickname(UserProfileSuccessCode code) {
         return BaseResponseDto.success(code, new NicknameAvailableRes(false));
     }
 

--- a/hilingual-domain/src/main/java/org/sopt/forbiddenword/domain/ForbiddenWord.java
+++ b/hilingual-domain/src/main/java/org/sopt/forbiddenword/domain/ForbiddenWord.java
@@ -1,15 +1,14 @@
 package org.sopt.forbiddenword.domain;
 
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Getter;
 
 @Getter
 @Entity
 public class ForbiddenWord {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(length = 50)

--- a/hilingual-domain/src/main/java/org/sopt/forbiddenword/facade/ForbiddenWordFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/forbiddenword/facade/ForbiddenWordFacade.java
@@ -1,0 +1,17 @@
+package org.sopt.forbiddenword.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+
+@Component
+@RequiredArgsConstructor
+public class ForbiddenWordFacade {
+
+    private final ForbiddenWordRetriever forbiddenWordRetriever;
+
+    public boolean findIsInForbiddenWord(String nickname) {
+        return forbiddenWordRetriever.findIsInForbiddenWord(nickname);
+    }
+
+}

--- a/hilingual-domain/src/main/java/org/sopt/forbiddenword/facade/ForbiddenWordRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/forbiddenword/facade/ForbiddenWordRetriever.java
@@ -1,0 +1,19 @@
+package org.sopt.forbiddenword.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.forbiddenword.repository.ForbiddenWordRepository;
+
+import org.springframework.stereotype.Component;
+
+
+@Component
+@RequiredArgsConstructor
+public class ForbiddenWordRetriever {
+
+    private final ForbiddenWordRepository forbiddenWordRepository;
+
+    public boolean findIsInForbiddenWord(final String nickname) {
+        return forbiddenWordRepository.existsByForbiddenWordInNickname(nickname);
+    }
+
+}

--- a/hilingual-domain/src/main/java/org/sopt/forbiddenword/repository/ForbiddenWordRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/forbiddenword/repository/ForbiddenWordRepository.java
@@ -1,0 +1,15 @@
+package org.sopt.forbiddenword.repository;
+
+import org.sopt.forbiddenword.domain.ForbiddenWord;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ForbiddenWordRepository extends JpaRepository<ForbiddenWord, Long> {
+    @Query("""
+        SELECT EXISTS (
+            SELECT 1 FROM ForbiddenWord f WHERE LOWER(:nickname) LIKE CONCAT('%', LOWER(f.forbiddenWord), '%')
+        )
+    """)
+    boolean existsByForbiddenWordInNickname(@Param("nickname") String nickname);
+}

--- a/hilingual-domain/src/main/java/org/sopt/user/facade/UserFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/user/facade/UserFacade.java
@@ -22,8 +22,4 @@ public class UserFacade {
     public void save(final User user){
         userSaver.save(user);
     }
-
-    public boolean isNicknameExists(final String nickname) {
-        return userRetriever.isNicknameExists(nickname);
-    }
 }

--- a/hilingual-domain/src/main/java/org/sopt/user/facade/UserRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/user/facade/UserRetriever.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Component;
 public class UserRetriever {
 
     private final UserRepository userRepository;
-    private final UserProfileRepository userProfileRepository;
 
     public User findByUserId(final long userId) {
         return userRepository.findById(userId)
@@ -24,10 +23,6 @@ public class UserRetriever {
     public User findByUserIdWithLock(final long userId) {
         return userRepository.findByIdWithLock(userId)
                 .orElseThrow(() -> new UserNotFoundException(UserCoreErrorCode.USER_NOT_FOUND));
-    }
-
-    public boolean isNicknameExists(String nickname) {
-        return userProfileRepository.existsByNickname(nickname);
     }
   
 }

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileFacade.java
@@ -40,6 +40,11 @@ public class UserProfileFacade {
         return userProfileRetriever.findByUserId(userId);
     }
 
+
+    public boolean isNicknameExists(final String nickname) {
+        return userProfileRetriever.isNicknameExists(nickname);
+    }
+
     /**
     saver
      */

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileRetriever.java
@@ -16,7 +16,6 @@ public class UserProfileRetriever {
 
     private final UserProfileRepository userProfileRepository;
 
-
     public UserProfile findByUserId(final Long userId) {
         return userProfileRepository.findByUserId(userId)
                 .orElseThrow(() -> new UserProfileNotFoundException(UserProfileCoreErrorCode.USER_PROFILE_NOT_FOUND));
@@ -32,5 +31,9 @@ public class UserProfileRetriever {
 
     public List<UserProfile> findByUserIds(List<Long> userIds) {
         return userProfileRepository.findByUserIds(userIds);
+    }
+
+    public boolean isNicknameExists(String nickname) {
+        return userProfileRepository.existsByNickname(nickname);
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #198 

## Work Description ✏️
- 금지어 포함 여부 판단 API 구현

<br>

> ### 구현 로직
- Forbidden Word에서 Query를 활용해 금지어 포함 여부를 확인하고 존재하는 경우 다 조회하지 않고 즉시 true를 반환하도록 구현
- UserController에 위치하던 책임을 UserController로 변경
- SQL Injection 공격 방지를 위해 LIKE를 사용할 때 “%” + f.forbiddenword + “%” 처럼 바로 사용하는 것이 아니라 CONCAT을 활용해 %와 결합
- 가장 무거운 조회 로직이므로 특수문자, 글자수, 중복 포함 여부 이후 판단하는 것으로 구현

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 금지어 oral이 포함된 경우 | <img width="353" height="444" alt="image" src="https://github.com/user-attachments/assets/9311cc57-8c00-4fbc-be19-64fa32016484" /> |
| 금지어 개등신이 포함된 경우 | <img width="338" height="441" alt="image" src="https://github.com/user-attachments/assets/ad95df3c-1892-47c8-9824-ed379014f6f9" /> |
| 금지어 맞아죽을뇬과 이모지가 포함된 경우 | <img width="406" height="434" alt="image" src="https://github.com/user-attachments/assets/d5740bfe-57cd-4458-b2c3-ceedbfa2cb7b" /> |
| 금지어 맞아죽을뇬이 포함되고 글자수가 10자 초과인 경우 | <img width="374" height="451" alt="image" src="https://github.com/user-attachments/assets/54ef3b2f-16a7-4096-8413-a8f0af34477f" /> |

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A