### PR TITLE
[fix] #211 작성된 일기 썸네일 조회 API에 isPublish 값 추가

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/usercalendar/api/UserCalendarController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/usercalendar/api/UserCalendarController.java
@@ -16,13 +16,13 @@ import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 
 @RestController
-@RequestMapping("/api/v1/calendar")
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class UserCalendarController {
 
     private final UserCalendarService userCalendarService;
 
-    @GetMapping("/{date}")
+    @GetMapping("/home/calendar/{date}")
     public ResponseEntity<UserCalendarDiarySummaryRes> getDiarySummaryByDate(
             @UserId Long userId,
             @PathVariable final String date
@@ -38,7 +38,7 @@ public class UserCalendarController {
         return ResponseEntity.ok(userCalendarService.getDiarySummary(parsedDate, userId));
     }
 
-    @GetMapping("/{date}/topic")
+    @GetMapping("/calendar/{date}/topic")
     public ResponseEntity<UserCalendarTopicRes> getTopicByDate(@PathVariable final String date) {
         final LocalDate parsedDate;
 
@@ -51,7 +51,7 @@ public class UserCalendarController {
         return ResponseEntity.ok(userCalendarService.getTopicByDate(parsedDate));
     }
 
-    @GetMapping("/month")
+    @GetMapping("/calendar/month")
     public ResponseEntity<UserCalendarMonthlyRes> getMonthlyCalendar(
             @UserId Long userId,
             @RequestParam final int year,

--- a/hilingual-api/src/main/java/org/sopt/controller/usercalendar/service/UserCalendarService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/usercalendar/service/UserCalendarService.java
@@ -1,9 +1,10 @@
 package org.sopt.controller.usercalendar.service;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.aws.s3.utils.S3UrlResolver;
+import org.sopt.aws.s3.service.S3Service;
 import org.sopt.controller.usercalendar.exception.FutureDateNotAllowedException;
 import org.sopt.controller.usercalendar.exception.UserCalendarApiErrorCode;
+import org.sopt.diary.domain.Diary;
 import org.sopt.topic.facade.TopicFacade;
 import org.sopt.usercalendar.facade.UserCalendarFacade;
 import org.sopt.usercalendar.dto.UserCalendarDiarySummaryRes;
@@ -22,18 +23,14 @@ public class UserCalendarService {
 
     private final UserCalendarFacade userCalendarFacade;
     private final TopicFacade topicFacade;
+    private final S3Service s3Service;
 
     public UserCalendarDiarySummaryRes getDiarySummary(final LocalDate date, final Long userId) {
         validateNotFuture(date);
 
-        var raw = userCalendarFacade.findDiaryByDate(userId, date);
-
-        return new UserCalendarDiarySummaryRes(
-                raw.diaryId(),
-                raw.createdAt(),
-                S3UrlResolver.resolve(raw.imageUrl()),
-                raw.originalText()
-        );
+        final Diary diary = userCalendarFacade.findDiaryByDate(userId, date);
+        final String diaryImgUrl = s3Service.toPublicUrl(diary.getImageUrl());
+        return UserCalendarDiarySummaryRes.of(diary, diaryImgUrl);
 
     }
 

--- a/hilingual-domain/src/main/java/org/sopt/diary/repository/DiaryRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/diary/repository/DiaryRepository.java
@@ -24,6 +24,7 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     /** 본인 소유의 일기 단건 조회*/
     Optional<Diary> findFirstByUserIdAndWrittenDate(Long userId, LocalDate writtenDate);
+
     Optional<Diary> findByIdAndUserId(Long diaryId, Long userId);
 
     List<Diary> findByUserIdAndIsPublicTrueOrderBySharedTimeDesc(Long userId);

--- a/hilingual-domain/src/main/java/org/sopt/usercalendar/dto/UserCalendarDiarySummaryRes.java
+++ b/hilingual-domain/src/main/java/org/sopt/usercalendar/dto/UserCalendarDiarySummaryRes.java
@@ -1,21 +1,19 @@
 package org.sopt.usercalendar.dto;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import org.sopt.diary.domain.Diary;
 
 public record UserCalendarDiarySummaryRes(
         Long diaryId,
-        String createdAt,
         String imageUrl,
-        String originalText
+        String originalText,
+        Boolean isPublished
 ) {
-    public static UserCalendarDiarySummaryRes of(
-            Long diaryId,
-            LocalDateTime createdAt,
-            String imageUrl,
-            String originalText
-    ) {
-        String formattedTime = createdAt.format(DateTimeFormatter.ofPattern("HH:mm"));
-        return new UserCalendarDiarySummaryRes(diaryId, formattedTime, imageUrl, originalText);
+    public static UserCalendarDiarySummaryRes of(Diary diary, String diaryImgUrl) {
+        return new UserCalendarDiarySummaryRes(
+                diary.getId(),
+                diaryImgUrl,
+                diary.getOriginalText(),
+                diary.getIsPublic()
+        );
     }
 }

--- a/hilingual-domain/src/main/java/org/sopt/usercalendar/facade/UserCalendarFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/usercalendar/facade/UserCalendarFacade.java
@@ -1,6 +1,7 @@
 package org.sopt.usercalendar.facade;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.diary.domain.Diary;
 import org.sopt.user.domain.User;
 import org.sopt.usercalendar.domain.UserCalendar;
 import org.sopt.usercalendar.dto.UserCalendarDiarySummaryRes;
@@ -26,7 +27,7 @@ public class UserCalendarFacade {
                 );
     }
 
-    public UserCalendarDiarySummaryRes findDiaryByDate(Long userId, LocalDate date) {
+    public Diary findDiaryByDate(Long userId, LocalDate date) {
         return userCalendarRetriever.findDiaryByDate(userId, date);
     }
 

--- a/hilingual-domain/src/main/java/org/sopt/usercalendar/facade/UserCalendarRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/usercalendar/facade/UserCalendarRetriever.java
@@ -1,6 +1,7 @@
 package org.sopt.usercalendar.facade;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.diary.domain.Diary;
 import org.sopt.diary.repository.DiaryRepository;
 import org.sopt.user.domain.User;
 import org.sopt.usercalendar.domain.UserCalendar;
@@ -33,16 +34,9 @@ public class UserCalendarRetriever {
         return userCalendarRepository.findWrittenDatesByUserIdAndYearAndMonth(userId, year, month);
     }
 
-    public UserCalendarDiarySummaryRes findDiaryByDate(final Long userId, final LocalDate date) {
+    public Diary findDiaryByDate(final Long userId, final LocalDate date) {
         return diaryRepository.findFirstByUserIdAndWrittenDate(userId, date)
-                .map(diary -> UserCalendarDiarySummaryRes.of(
-                        diary.getId(),
-                        diary.getCreatedAt(),
-                        diary.getImageUrl(),
-                        diary.getOriginalText()))
-                .orElseThrow(() ->
-                        new UserCalendarDiaryNotFoundException(
-                                UserCalendarCoreErrorCode.DIARY_NOT_FOUND));
+                .orElseThrow(() -> new UserCalendarDiaryNotFoundException(UserCalendarCoreErrorCode.DIARY_NOT_FOUND));
     }
 
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #211 

## Work Description ✏️
- isPublish값 추가
- 로직 정리

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 2025-08-06 | <img width="407" height="455" alt="image" src="https://github.com/user-attachments/assets/10861042-e343-407f-b518-8e90b9b52c7b" /> |
| 올바르지 않은 날짜 형식 | <img width="440" height="434" alt="image" src="https://github.com/user-attachments/assets/6bad8072-8c20-4923-8880-d84c526feb00" /> |
| 작성된 일기가 없는 경우 | <img width="431" height="422" alt="image" src="https://github.com/user-attachments/assets/1c0c1b2d-414a-477b-a4c8-7cd76d3be10e" /> |
| 이미지 없는 경우 | <img width="304" height="470" alt="image" src="https://github.com/user-attachments/assets/41589d67-a845-43ff-89be-5280dfb2fdec" /> |

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢

> ### **Facade, Service에서 Dto Res를 반환해주는 것이 좋을까 Entity 그 자체를 반환해주는 것이 좋을까?**

엔티티 자체를 반환하는 방식은 애플리케이션 내부에서만 사용되고, 데이터 노출의 위험이 없는 내부 전용 모듈에선 편리함. 하지만 이 데이터가 클라이언트에게 API 응답으로 전달될 예정이라면, DTO를 반환하는 것이 좋은 설계 원칙에 부합함.

따라서, Facade나 Service 계층에서 DTO를 반환하는 것을 기본 원칙으로 삼고, 엔티티를 다루는 것은 Repository나 Facade/Service 내부에서만 하는 것이 좋을듯.

1. **관심사 분리:** DTO(Data Transfer Object)는 계층 간 데이터 전송을 위해 설계된 객체DTO를 사용하면 **프레젠테이션(Presentation) 계층** (API 응답)이 **도메인(Domain) 계층**의 엔티티 구조에 직접 의존하지 않게 됨
    - 엔티티는 데이터베이스 구조와 비즈니스 로직을 표현합
    - DTO는 클라이언트(API 소비자)에게 필요한 데이터 형태를 표현
    - `Facade`나 `Service`가 엔티티를 반환하면, API 응답을 위해 컨트롤러나 다른 서비스에서 엔티티의 모든 필드를 다시 DTO로 변환해야 하거나, 엔티티의 불필요한 필드까지 노출될 수 있음
2. **데이터 노출 최소화 (보안):** 엔티티는 민감한 정보를 포함할 수 있음. DTO를 사용하면 **클라이언트에게 필요한 데이터만 선택적으로 전달**할 수 있어 보안성이 높아짐.
3. **유연성 및 유지보수 용이성:** DTO를 사용하면 도메인 엔티티의 변경이 프레젠테이션 계층에 미치는 영향을 최소화할 수 있습니다.
    - **예시:** `Diary` 엔티티에 새로운 필드(`secretText`)가 추가되더라도, API 응답에 영향을 주지 않으려면 DTO에 해당 필드를 추가하지 않으면 됨. 만약 엔티티를 직접 반환했다면, 클라이언트가 알 필요 없는 `secretText` 필드까지 받게 되어 API 계약이 바뀌고 클라이언트에게 혼란을 줄 수 있음
4. **성능 최적화:** DTO를 사용하면 필요한 데이터만 포함할 수 있으므로, 네트워크를 통해 전송되는 데이터의 양을 줄일 수 있음. 특히 많은 필드를 가진 복잡한 엔티티의 경우 효과적!

=> 하지만 S3Service를 통해 publicUrl로의 변환하는 과정이 Service에서 이루어져야 하기 때문에 일단 제가 기존에 하던 방식으로 구현했습니다. 앞으로는 Repository는 Entity, Retreiver - Facade 부터는 Dto를 반환하는 식으로 구현하려구요!