### PR TITLE
[feat] #208 공지 사항 알림 상세보기 API 구현

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/user/api/UserController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/api/UserController.java
@@ -3,6 +3,7 @@ package org.sopt.controller.user.api;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.sopt.controller.user.dto.NicknameAvailableRes;
+import org.sopt.controller.user.dto.NoticeDetailRes;
 import org.sopt.controller.user.dto.UserDefaultInfoRes;
 import org.sopt.controller.user.service.UserService;
 import org.sopt.dto.BaseResponseDto;
@@ -47,5 +48,14 @@ public class UserController {
             @UserId Long userId
     ) {
         return ResponseEntity.ok(userService.getUserDefaultInfo(userId));
+    }
+
+    // 공지 사항 알림 상세보기 API
+    @GetMapping("/notifications/{noticeId}")
+    public ResponseEntity<NoticeDetailRes> getNotificationDetail(
+            @UserId Long userId,
+            @PathVariable Long noticeId
+    ) {
+        return ResponseEntity.ok(userService.getNotificationDetail(userId, noticeId));
     }
 }

--- a/hilingual-api/src/main/java/org/sopt/controller/user/dto/NoticeDetailRes.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/dto/NoticeDetailRes.java
@@ -1,0 +1,22 @@
+package org.sopt.controller.user.dto;
+
+import org.sopt.notice.domain.Notice;
+import org.sopt.noticedetail.domain.NoticeDetail;
+
+import java.time.format.DateTimeFormatter;
+
+public record NoticeDetailRes(
+        String title,
+        String createdAt,
+        String content
+) {
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    public static NoticeDetailRes from(Notice notice, NoticeDetail detail) {
+        return new NoticeDetailRes(
+                notice.getTitle(),
+                notice.getCreatedAt().format(FORMATTER),
+                detail.getContent()
+        );
+    }
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/user/service/UserService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/service/UserService.java
@@ -9,8 +9,16 @@ import org.sopt.jwt.auth.dto.ReissueTokensRes;
 import org.sopt.user.domain.User;
 import org.sopt.controller.user.dto.HomeUserProfileRes;
 import org.sopt.user.facade.UserFacade;
+import org.sopt.userprofile.facade.UserProfileFacade;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.sopt.controller.user.dto.NicknameAvailableRes;
+import org.sopt.controller.user.dto.NoticeDetailRes;
+import org.sopt.noticedelivery.domain.NoticeDelivery;
+import org.sopt.noticedelivery.facade.NoticeDeliveryFacade;
+
+
+import java.time.LocalDateTime;
 
 @Service
 @Transactional(readOnly = true)
@@ -19,6 +27,8 @@ public class UserService {
 
     private final TokenService tokenService;
     private final UserFacade userFacade;
+    private final UserProfileFacade userProfileFacade;
+    private final NoticeDeliveryFacade noticeDeliveryFacade;
 
     public UserDefaultInfoRes getUserDefaultInfo(final long userId) {
         User user = userFacade.getUserById(userId);
@@ -57,5 +67,19 @@ public class UserService {
                 throw new CannotLoadProviderException(UserApiErrorCode.PROVIDER_LOAD_ERROR);
         }
         return loginProviderInfo;
+    }
+
+    @Transactional
+    public NoticeDetailRes getNotificationDetail(final long userId, final long noticeId) {
+        NoticeDelivery delivery = noticeDeliveryFacade
+                .findByUserIdAndNoticeIdWithDetail(userId, noticeId);
+
+        delivery.markReadIfNeeded(LocalDateTime.now());
+
+        return NoticeDetailRes.from(
+                delivery.getNotice(),
+                delivery.getNotice().getNoticeDetail()
+        );
+
     }
 }

--- a/hilingual-domain/src/main/java/org/sopt/notice/domain/Notice.java
+++ b/hilingual-domain/src/main/java/org/sopt/notice/domain/Notice.java
@@ -9,33 +9,31 @@ import org.sopt.common.config.BaseTimeEntity;
 import org.sopt.notice.type.Category;
 import org.sopt.notice.type.CategoryConverter;
 import org.sopt.noticedetail.domain.NoticeDetail;
-import java.time.LocalDateTime;
+
+import static org.sopt.notice.domain.NoticeTableConstants.*;
 
 @Entity
-@Table(name = NoticeTableConstants.TABLE_NOTICE)
+@Table(name = TABLE_NOTICE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Notice extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = NoticeTableConstants.COLUMN_ID)
+    @Column(name = COLUMN_ID)
     private Long id;
 
     @Convert(converter = CategoryConverter.class)
-    @Column(name = NoticeTableConstants.COLUMN_CATEGORY, nullable = false)
+    @Column(name = COLUMN_CATEGORY, nullable = false)
     private Category category;
 
-    @Column(name = NoticeTableConstants.COLUMN_TITLE, nullable = false, length = 100)
+    @Column(name = COLUMN_TITLE, nullable = false, length = 100)
     private String title;
 
-    @Column(name = NoticeTableConstants.COLUMN_IS_ACTIVE, nullable = false)
+    @Column(name = COLUMN_IS_ACTIVE, nullable = false)
     private Boolean isActive;
 
-    @Column(name = NoticeTableConstants.COLUMN_READ_AT)
-    private LocalDateTime readAt;
-
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    @JoinColumn(name = NoticeTableConstants.COLUMN_NOTICE_DETAIL_ID, nullable = false)
+    @JoinColumn(name = COLUMN_NOTICE_DETAIL_ID, nullable = false)
     private NoticeDetail noticeDetail;
 }

--- a/hilingual-domain/src/main/java/org/sopt/notice/domain/NoticeTableConstants.java
+++ b/hilingual-domain/src/main/java/org/sopt/notice/domain/NoticeTableConstants.java
@@ -6,6 +6,5 @@ public class NoticeTableConstants {
     public static final String COLUMN_CATEGORY = "category";
     public static final String COLUMN_IS_ACTIVE = "is_active";
     public static final String COLUMN_NOTICE_DETAIL_ID = "notice_detail_id";
-    public static final String COLUMN_READ_AT = "read_at";
     public static final String COLUMN_TITLE = "title";
 }

--- a/hilingual-domain/src/main/java/org/sopt/noticedelivery/domain/NoticeDelivery.java
+++ b/hilingual-domain/src/main/java/org/sopt/noticedelivery/domain/NoticeDelivery.java
@@ -36,4 +36,10 @@ public class NoticeDelivery {
     @Column(name = NoticeDeliveryTableConstants.COLUMN_READ_AT)
     private LocalDateTime readAt;
 
+    public void markReadIfNeeded(LocalDateTime now) {
+        if (this.readAt == null) {
+            this.readAt = now;
+        }
+    }
+
 }

--- a/hilingual-domain/src/main/java/org/sopt/noticedelivery/exception/NoticeDeliveryCoreException.java
+++ b/hilingual-domain/src/main/java/org/sopt/noticedelivery/exception/NoticeDeliveryCoreException.java
@@ -1,0 +1,10 @@
+package org.sopt.noticedelivery.exception;
+
+import org.sopt.exception.base.HilingualBaseException;
+import org.sopt.exception.code.ErrorCode;
+
+public abstract class NoticeDeliveryCoreException extends HilingualBaseException {
+    protected NoticeDeliveryCoreException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/hilingual-domain/src/main/java/org/sopt/noticedelivery/exception/NoticeDeliveryErrorCode.java
+++ b/hilingual-domain/src/main/java/org/sopt/noticedelivery/exception/NoticeDeliveryErrorCode.java
@@ -1,0 +1,30 @@
+package org.sopt.noticedelivery.exception;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum NoticeDeliveryErrorCode implements ErrorCode {
+    NOTICE_DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, 40499, "해당 공지는 존재하지 않거나 이 유저에게 발송되지 않았습니다."),
+    ;
+
+    public final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    @Override
+    public org.springframework.http.HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public int getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/hilingual-domain/src/main/java/org/sopt/noticedelivery/exception/NoticeDeliveryNoFoundException.java
+++ b/hilingual-domain/src/main/java/org/sopt/noticedelivery/exception/NoticeDeliveryNoFoundException.java
@@ -1,0 +1,15 @@
+package org.sopt.noticedelivery.exception;
+
+import org.sopt.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class NoticeDeliveryNoFoundException extends NoticeDeliveryCoreException{
+    public NoticeDeliveryNoFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.NOT_FOUND;
+    }
+}

--- a/hilingual-domain/src/main/java/org/sopt/noticedelivery/facade/NoticeDeliveryFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/noticedelivery/facade/NoticeDeliveryFacade.java
@@ -1,0 +1,17 @@
+package org.sopt.noticedelivery.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.noticedelivery.domain.NoticeDelivery;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NoticeDeliveryFacade {
+
+    private final NoticeDeliveryRetriever noticeDeliveryRetriever;
+
+    public NoticeDelivery findByUserIdAndNoticeIdWithDetail(final long userId, final long noticeId){
+        return noticeDeliveryRetriever.findByUserIdAndNoticeIdWithDetail(userId, noticeId);
+    }
+
+}

--- a/hilingual-domain/src/main/java/org/sopt/noticedelivery/facade/NoticeDeliveryRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/noticedelivery/facade/NoticeDeliveryRetriever.java
@@ -1,0 +1,20 @@
+package org.sopt.noticedelivery.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.noticedelivery.domain.NoticeDelivery;
+import org.sopt.noticedelivery.exception.NoticeDeliveryErrorCode;
+import org.sopt.noticedelivery.exception.NoticeDeliveryNoFoundException;
+import org.sopt.noticedelivery.repository.NoticeDeliveryRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NoticeDeliveryRetriever {
+
+    private final NoticeDeliveryRepository noticeDeliveryRepository;
+
+    public NoticeDelivery findByUserIdAndNoticeIdWithDetail(final long userId, final long noticeId){
+        return noticeDeliveryRepository.findByUserIdAndNoticeIdWithDetail(userId, noticeId)
+                .orElseThrow(() -> new NoticeDeliveryNoFoundException(NoticeDeliveryErrorCode.NOTICE_DELIVERY_NOT_FOUND));
+    }
+}

--- a/hilingual-domain/src/main/java/org/sopt/noticedelivery/repository/NoticeDeliveryRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/noticedelivery/repository/NoticeDeliveryRepository.java
@@ -1,0 +1,23 @@
+package org.sopt.noticedelivery.repository;
+
+import org.sopt.noticedelivery.domain.NoticeDelivery;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface NoticeDeliveryRepository extends JpaRepository<NoticeDelivery, Long> {
+
+    // userId에 해당하는 공지문 상세 조회
+    @Query("""
+        select nd
+          from NoticeDelivery nd
+          join fetch nd.notice n
+          join fetch n.noticeDetail d
+         where nd.user.id = :userId
+           and n.id = :noticeId
+    """)
+    Optional<NoticeDelivery> findByUserIdAndNoticeIdWithDetail(@Param("userId") Long userId,
+                                                               @Param("noticeId") Long noticeId);
+}

--- a/hilingual-domain/src/main/java/org/sopt/user/domain/User.java
+++ b/hilingual-domain/src/main/java/org/sopt/user/domain/User.java
@@ -36,6 +36,7 @@ public class User extends BaseTimeEntity {
     private Long id;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = COLUMN_ROLE)
     private UserRole role;
 
     @Column(name = COLUMN_PROVIDER, nullable = false, length = 20)

--- a/hilingual-domain/src/main/java/org/sopt/user/domain/UserTableConstants.java
+++ b/hilingual-domain/src/main/java/org/sopt/user/domain/UserTableConstants.java
@@ -4,6 +4,7 @@ package org.sopt.user.domain;
 public class UserTableConstants {
     public static final String TABLE_USER = "users";
     public static final String COLUMN_ID = "id";
+    public static final String COLUMN_ROLE = "role";
     public static final String COLUMN_PROVIDER = "provider";
     public static final String COLUMN_PROVIDER_ID = "provider_id";
     public static final String COLUMN_IS_COMPLETED = "is_completed";


### PR DESCRIPTION
## Related issue 🛠
- closed #208 

## Work Description ✏️
- Notice 테이블 구조 수정
  - Notice는 Master이므로 유저마다 개별인 NoticeDelivery에만 readAt이 있으면 됩니다. 그래서 Notice에 있던 readAt 칼럼 삭제했습니다.
- User 테이블 구조 수정
  - role 필드에 `@Column` 안걸어놨더라구요,, 추가했습니다
- 상세보기 시 자동 읽음 처리 (`readAt` 갱신) -클라 요청 반영

## Screenshot 📸
| 설명 | 캡처 |
|:---:|:---:|
| 테스트에 사용한 더미 쿼리 | <img width="1528" height="398" alt="image" src="https://github.com/user-attachments/assets/0a48dd2d-643b-4a29-b026-0dcf6d564129" /> |
| NoticeDetail | <img width="1346" height="366" alt="image" src="https://github.com/user-attachments/assets/1fbbc1a3-9489-4915-9030-fc0c386a2b73" /> |
| Notice | <img width="2048" height="342" alt="image" src="https://github.com/user-attachments/assets/c94d71d3-a791-48d7-bbee-0c24a0da473f" /> |
| NoticeDelivery | <img width="1862" height="350" alt="image" src="https://github.com/user-attachments/assets/dd27b5f5-df23-4a73-8571-3a0c81854dfa" /> |
| 공지사항 겟또! | <img width="2048" height="950" alt="image" src="https://github.com/user-attachments/assets/379b23ed-e85d-4b7a-b27d-10c65f1a95eb" /> |
| 읽은 시간도 동시에 업데이트(readAt) | <img width="1746" height="452" alt="image" src="https://github.com/user-attachments/assets/cf914a84-67f2-4567-8b51-18e304204126" /> |
| 예외 | <img width="2048" height="826" alt="image" src="https://github.com/user-attachments/assets/4934a2e2-c7ac-4833-a378-96449a9e1d75" /> |

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
근데 공지 관련도 UserController에 몽땅 넣어버리려고 했는데 괜찮을까?
고민안하고싶도리.... 리팩 빡세게해요 화이팅..