### PR TITLE
[feat] #221 알림 읽음 처리 API 구현

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/user/api/UserController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/api/UserController.java
@@ -58,4 +58,14 @@ public class UserController {
     ) {
         return ResponseEntity.ok(userService.getNotificationDetail(userId, noticeId));
     }
+
+    // 알림 읽음 처리 API
+    @PatchMapping("/notifications/{noticeId}/read")
+    public ResponseEntity<Void> markNoticeRead(
+            @UserId Long userId,
+            @PathVariable Long noticeId
+    ) {
+        userService.markNoticeRead(userId, noticeId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/hilingual-api/src/main/java/org/sopt/controller/user/service/UserService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/service/UserService.java
@@ -5,6 +5,7 @@ import org.sopt.controller.token.TokenService;
 import org.sopt.controller.user.dto.UserDefaultInfoRes;
 import org.sopt.controller.user.exception.CannotLoadProviderException;
 import org.sopt.controller.user.exception.UserApiErrorCode;
+import org.sopt.feedalarm.facade.FeedAlarmFacade;
 import org.sopt.jwt.auth.dto.ReissueTokensRes;
 import org.sopt.user.domain.User;
 import org.sopt.controller.user.dto.HomeUserProfileRes;
@@ -12,7 +13,6 @@ import org.sopt.user.facade.UserFacade;
 import org.sopt.userprofile.facade.UserProfileFacade;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.sopt.controller.user.dto.NicknameAvailableRes;
 import org.sopt.controller.user.dto.NoticeDetailRes;
 import org.sopt.noticedelivery.domain.NoticeDelivery;
 import org.sopt.noticedelivery.facade.NoticeDeliveryFacade;
@@ -29,6 +29,7 @@ public class UserService {
     private final UserFacade userFacade;
     private final UserProfileFacade userProfileFacade;
     private final NoticeDeliveryFacade noticeDeliveryFacade;
+    private final FeedAlarmFacade feedAlarmFacade;
 
     public UserDefaultInfoRes getUserDefaultInfo(final long userId) {
         User user = userFacade.getUserById(userId);
@@ -82,4 +83,11 @@ public class UserService {
         );
 
     }
+
+    @Transactional
+    public void markNoticeRead(final long userId, final long noticeId){
+        feedAlarmFacade.markAlarmAsRead(userId, noticeId);
+        return;
+    }
+
 }

--- a/hilingual-domain/src/main/java/org/sopt/feedalarm/domain/FeedAlarm.java
+++ b/hilingual-domain/src/main/java/org/sopt/feedalarm/domain/FeedAlarm.java
@@ -13,9 +13,10 @@ import org.sopt.feedalarm.type.TargetTypeConverter;
 import org.sopt.user.domain.User;
 
 import java.time.LocalDateTime;
+import static org.sopt.feedalarm.domain.FeedAlarmTableConstants.*;
 
 @Entity
-@Table(name = FeedAlarmTableConstants.TABLE_FEED_ALARM)
+@Table(name = TABLE_FEED_ALARM)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -23,30 +24,37 @@ public class FeedAlarm extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = FeedAlarmTableConstants.COLUMN_ID)
+    @Column(name = COLUMN_ID)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = FeedAlarmTableConstants.COLUMN_USER_ID, nullable = false)
+    @JoinColumn(name = COLUMN_USER_ID, nullable = false)
     private User user;
 
     @Convert(converter = FeedAlarmTypeConverter.class)
-    @Column(name = FeedAlarmTableConstants.COLUMN_TYPE, nullable = false)
+    @Column(name = COLUMN_TYPE, nullable = false)
     private FeedAlarmType type;
 
     @Convert(converter = TargetTypeConverter.class)
-    @Column(name = FeedAlarmTableConstants.COLUMN_TARGET_TYPE, nullable = false)
+    @Column(name = COLUMN_TARGET_TYPE, nullable = false)
     private TargetType targetType;
 
-    @Column(name = FeedAlarmTableConstants.COLUMN_TARGET_ID, nullable = false)
+    @Column(name = COLUMN_TARGET_ID, nullable = false)
     private Long targetId;
 
-    @Column(name = FeedAlarmTableConstants.COLUMN_ACTOR_ID, nullable = false)
+    @Column(name = COLUMN_ACTOR_ID, nullable = false)
     private Long actorId;
 
-    @Column(name = FeedAlarmTableConstants.COLUMN_TITLE, nullable = false, length = 100)
+    @Column(name = COLUMN_TITLE, nullable = false, length = 100)
     private String title;
 
-    @Column(name = FeedAlarmTableConstants.COLUMN_READ_AT)
+    @Column(name = COLUMN_READ_AT)
     private LocalDateTime readAt;
+
+    public void markAsRead() {
+        if (this.readAt == null) {
+            this.readAt = LocalDateTime.now();
+        }
+    }
+
 }

--- a/hilingual-domain/src/main/java/org/sopt/feedalarm/exception/FeedAlarmCoreErrorCode.java
+++ b/hilingual-domain/src/main/java/org/sopt/feedalarm/exception/FeedAlarmCoreErrorCode.java
@@ -10,6 +10,10 @@ public enum FeedAlarmCoreErrorCode implements ErrorCode {
     // 400
     INVALID_FEED_ALARM_TYPE(HttpStatus.BAD_REQUEST, 40018, "올바르지 않은 피드 알림 타입입니다."),
     INVALID_TARGET_TYPE(HttpStatus.BAD_REQUEST, 40019, "올바르지 않은 타켓 타입입니다."),
+
+    // 404
+    FEED_ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, 40409, "id에 해당하는 알람이 없습니다.")
+
     ;
 
     public final HttpStatus httpStatus;

--- a/hilingual-domain/src/main/java/org/sopt/feedalarm/exception/FeedAlarmNotFoundException.java
+++ b/hilingual-domain/src/main/java/org/sopt/feedalarm/exception/FeedAlarmNotFoundException.java
@@ -1,0 +1,15 @@
+package org.sopt.feedalarm.exception;
+
+import org.sopt.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class FeedAlarmNotFoundException extends FeedAlarmCoreException{
+    public FeedAlarmNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.NOT_FOUND;
+    }
+}

--- a/hilingual-domain/src/main/java/org/sopt/feedalarm/facade/FeedAlarmFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/feedalarm/facade/FeedAlarmFacade.java
@@ -1,0 +1,16 @@
+package org.sopt.feedalarm.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FeedAlarmFacade {
+
+    private final FeedAlarmRetriever feedAlarmRetriever;
+
+    public void markAlarmAsRead(Long userId, Long alarmId) {
+        feedAlarmRetriever.markAlarmAsRead(userId, alarmId);
+    }
+
+}

--- a/hilingual-domain/src/main/java/org/sopt/feedalarm/facade/FeedAlarmRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/feedalarm/facade/FeedAlarmRetriever.java
@@ -1,0 +1,23 @@
+package org.sopt.feedalarm.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.feedalarm.domain.FeedAlarm;
+import org.sopt.feedalarm.exception.FeedAlarmCoreErrorCode;
+import org.sopt.feedalarm.exception.FeedAlarmNotFoundException;
+import org.sopt.feedalarm.repository.FeedAlarmRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class FeedAlarmRetriever {
+
+    private final FeedAlarmRepository feedAlarmRepository;
+
+    @Transactional
+    public void markAlarmAsRead(Long userId, Long alarmId) {
+        FeedAlarm alarm = feedAlarmRepository.findByIdAndUserId(alarmId, userId)
+                .orElseThrow(() -> new FeedAlarmNotFoundException(FeedAlarmCoreErrorCode.FEED_ALARM_NOT_FOUND));
+        alarm.markAsRead();
+    }
+}

--- a/hilingual-domain/src/main/java/org/sopt/feedalarm/repository/FeedAlarmRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/feedalarm/repository/FeedAlarmRepository.java
@@ -1,0 +1,12 @@
+package org.sopt.feedalarm.repository;
+
+import org.sopt.feedalarm.domain.FeedAlarm;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FeedAlarmRepository extends JpaRepository<FeedAlarm, Long> {
+
+    Optional<FeedAlarm> findByIdAndUserId(Long alarmId, Long userId);
+
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #221 

## Work Description ✏️
- 사용자가 특정 알림(FeedAlarm)을 읽을 때 readAt 필드가 현재 시각으로 업데이트되도록 구현
  - 본인 소유 알림이 아닐 경우 FeedAlarmNotFoundException 발생 처리
- Notice vs FeedAlarm 
  - Notice(공지사항) 읽기 시에는 자동으로 readAt 갱신 (#208)
  - 이번 PR은 FeedAlarm(개인 알림)에 대해서만 읽음 처리

## Screenshot 📸
| 설명 | 캡처 |
|:---:|:---:|
| FeedAlarm 테이블 | <img width="2048" height="363" alt="image" src="https://github.com/user-attachments/assets/48f64791-fb3e-4074-a312-193a9882a4e6" /> |
| 예외 | <img width="2048" height="1052" alt="image" src="https://github.com/user-attachments/assets/540ca8a0-785d-4d97-82ab-3aabdeb6c4ca" /> |
| 알림 읽음 처리 API 호출 | <img width="2048" height="1013" alt="image" src="https://github.com/user-attachments/assets/2459ff3a-8874-4434-a765-b6e5cd8480ad" /> |
| id = 100은 readAt 갱신 | <img width="2048" height="341" alt="image" src="https://github.com/user-attachments/assets/14a49af8-d619-4927-a292-c26f5ae4739f" /> |


## Uncompleted Tasks 😅
<img width="1033" height="308" alt="image" src="https://github.com/user-attachments/assets/3407a839-0d3b-4826-a5db-bc1486c606a3" />

## To Reviewers 📢
Work Description에도 적었지만
저희가 Notice랑 FeedAlarm 테이블을 구분해 뒀는데, #208 "공지 사항 알림 상세보기 API"는 공지사항 읽을 때 자동으로 readAt 갱신해주므로 현재 올린 PR의 "알림 읽음 처리 API"는 사실상 FeedAlarm에 있는 row를 업데이트 할 때만 사용됩니다!
