### PR TITLE
[feat] #229 로그아웃 API 구현, 회원탈퇴 API 일부 구현

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/auth/api/AuthController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/auth/api/AuthController.java
@@ -1,10 +1,13 @@
 package org.sopt.controller.auth.api;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.sopt.controller.auth.dto.SocialLoginReq;
 import org.sopt.controller.auth.dto.SocialLoginRes;
 import org.sopt.controller.auth.service.AuthService;
+import org.sopt.jwt.annotation.UserId;
+import org.sopt.jwt.core.JwtTokenProvider;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     /*
      * 소셜 로그인(구글, 애플)
@@ -26,4 +30,14 @@ public class AuthController {
         return ResponseEntity.ok(authService.socialLogin(providerToken, req));
     }
 
+    /*
+     * 로그아웃
+     */
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(
+            HttpServletRequest request
+    ) {
+        String accessToken = jwtTokenProvider.getJwtFromRequest(request);
+        return ResponseEntity.ok(authService.logout(accessToken));
+    }
 }

--- a/hilingual-api/src/main/java/org/sopt/controller/auth/api/AuthController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/auth/api/AuthController.java
@@ -40,4 +40,16 @@ public class AuthController {
         String accessToken = jwtTokenProvider.getJwtFromRequest(request);
         return ResponseEntity.ok(authService.logout(accessToken));
     }
+
+    /*
+     * 회원탈퇴
+     */
+    @PostMapping("/leave")
+    public ResponseEntity<Void> leave(
+            @UserId Long userId,
+            HttpServletRequest request
+    ) {
+        String accessToken = jwtTokenProvider.getJwtFromRequest(request);
+        return ResponseEntity.ok(authService.leave(userId, accessToken));
+    }
 }

--- a/hilingual-api/src/main/java/org/sopt/controller/auth/exception/AppleUnlinkErrorException.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/auth/exception/AppleUnlinkErrorException.java
@@ -1,0 +1,15 @@
+package org.sopt.controller.auth.exception;
+
+import org.sopt.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class AppleUnlinkErrorException extends AuthApiException {
+    public AppleUnlinkErrorException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.SERVICE_UNAVAILABLE;
+    }
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/auth/exception/AuthApiErrorCode.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/auth/exception/AuthApiErrorCode.java
@@ -13,8 +13,9 @@ public enum AuthApiErrorCode implements ErrorCode {
 
     // 503
     AUTH_GOOGLE_SERVER_ERROR(HttpStatus.SERVICE_UNAVAILABLE, 50305, "구글 로그인에서 에러가 발생했습니다."),
-    AUTH_APPLE_SERVER_ERROR(HttpStatus.SERVICE_UNAVAILABLE, 50306, "애플 로그인에서 에러가 발생했습니다.");
-    ;
+    AUTH_APPLE_SERVER_ERROR(HttpStatus.SERVICE_UNAVAILABLE, 50306, "애플 로그인에서 에러가 발생했습니다."),
+    AUTH_GOOGLE_UNLINK_ERROR(HttpStatus.SERVICE_UNAVAILABLE, 50307, "구글 회원탈퇴에서 에러가 발생했습니다."),
+    AUTH_APPLE_UNLINK_ERROR(HttpStatus.SERVICE_UNAVAILABLE, 50308, "애플 회원탈퇴에서 에러가 발생했습니다.");
 
     public final HttpStatus httpStatus;
     private final int code;

--- a/hilingual-api/src/main/java/org/sopt/controller/auth/exception/GoogleUnlinkErrorException.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/auth/exception/GoogleUnlinkErrorException.java
@@ -1,0 +1,15 @@
+package org.sopt.controller.auth.exception;
+
+import org.sopt.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class GoogleUnlinkErrorException extends AuthApiException {
+    public GoogleUnlinkErrorException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.SERVICE_UNAVAILABLE;
+    }
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/auth/service/AuthService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/auth/service/AuthService.java
@@ -27,6 +27,7 @@ import org.sopt.user.repository.UserRepository;
 import org.sopt.user.type.RegisterStatus;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
@@ -43,12 +44,12 @@ import java.util.*;
 @Service
 @RequiredArgsConstructor
 public class AuthService {
-    private final UserRepository userRepository;
 
     private final TokenService tokenService;
     private final UserFacade userFacade;
     private final AppleKeyService appleKeyService;
     private final TaskScheduler taskScheduler;
+    private final RedisTemplate<String, String> redisTemplate;
 
     private static final Integer PROVIDER_TOKEN_MIN_LENGTH = 101;
 
@@ -86,24 +87,23 @@ public class AuthService {
         user.setDeletedAt(LocalDateTime.now());
         userFacade.save(user);
 
-        // Refresh Token 및 User Provider 조회
-        final String refreshToken = tokenService.extractRefreshToken(accessToken);
-
         // 30일 후 실행되도록 스케줄링
-        Runnable unlinkTask = getUnlinkTask(user, refreshToken);
+        Runnable unlinkTask = getUnlinkTask(userId);
         Instant scheduledTime = Instant.now().plusSeconds(60);
         taskScheduler.schedule(unlinkTask, scheduledTime);
 
         return null;
     }
 
-    private Runnable getUnlinkTask(User user, String refreshToken) {
-        final String authProvider = user.getProvider();
-
+    private Runnable getUnlinkTask(final long userId) {
         // User Provider에 따라 google unlink, apple unlink 스케줄링
         return () -> {
           try {
-              switch (authProvider) {
+              // Redis에 임시 보관된 토큰 정보 조회
+              String refreshToken = redisTemplate.opsForValue().get("unlink_token:" + userId);
+              String provider = redisTemplate.opsForValue().get("unlink_provider:" + userId);
+
+              switch (provider) {
                   case "GOOGLE":
                       googleUnlink(refreshToken);
                       break;
@@ -111,56 +111,51 @@ public class AuthService {
                       appleUnlink(refreshToken);
                       break;
                   default:
-                      // 소셜로그인이 아닌 경우 Unlink 작업 불필요
-                      log.warn("유저 {}는 소셜 로그인 유저가 아닙니다.", user.getId());
+                      log.warn("유저 {}는 소셜 로그인 유저가 아닙니다.", userId);
               }
 
-              // unlink 성공 시 DB에서 사용자 정보 삭제
-              userFacade.deleteUserById(user.getId());
+              // unlink 성공 시 DB에서 사용자 정보 삭제 및 저장해두었던 임시 RefreshToken 삭제
+              userFacade.deleteUserById(userId);
+              redisTemplate.delete("unlink_token:" + userId);
+              redisTemplate.delete("unlink_provider:" + userId);
+
           } catch (Exception e) {
-              log.error("언링크 실패. 유저{}: {}", user.getId(), e.getMessage());
-              throw new InvalidProviderException(AuthApiErrorCode.INVALID_PROVIDER);
+              log.error("언링크 실패. 유저{}: {}", userId, e.getMessage(), e);
           }
         };
     }
 
     private void googleUnlink(String refreshToken) {
-        String revokeUrl = "https://accounts.google.com/o/oauth2/revoke?token=" + refreshToken;
+        WebClient webClient = WebClient.builder().build();
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("token", refreshToken);
 
-        try {
-            WebClient webClient = WebClient.builder().build();
-            webClient.post()
-                    .uri(revokeUrl)
-                    .retrieve()
-                    .bodyToMono(Void.class)
-                    .block();
-        } catch (Exception e) {
-            throw new GoogleUnlinkErrorException(AuthApiErrorCode.AUTH_GOOGLE_UNLINK_ERROR);
-        }
+        webClient.post()
+                .uri("https://accounts.google.com/o/oauth2/revoke")
+                .body(BodyInserters.fromFormData(formData))
+                .retrieve()
+                .bodyToMono(Void.class)
+                .block();
     }
 
     private void appleUnlink(String refreshToken) {
-        try {
-            String clientSecret = appleKeyService.makeClientSecretToken();
+        String clientSecret = appleKeyService.makeClientSecretToken();
 
-            // revoke API에 전달할 폼 데이터
-            MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
-            formData.add("client_id", appleKeyService.appleClientId);
-            formData.add("client_secret", clientSecret);
-            formData.add("token", refreshToken);
-            formData.add("token_type_hint", "refresh_token");
+        // revoke API에 전달할 폼 데이터
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("client_id", appleKeyService.appleClientId);
+        formData.add("client_secret", clientSecret);
+        formData.add("token", refreshToken);
+        formData.add("token_type_hint", "refresh_token");
 
-            // Apple revoke api 호출
-            WebClient webClient = WebClient.builder().build();
-            webClient.post()
-                    .uri("https://appleid.apple.com/auth/oauth2/v2/revoke")
-                    .body(BodyInserters.fromFormData(formData))
-                    .retrieve()
-                    .bodyToMono(Void.class)
-                    .block();
-        } catch (Exception e) {
-            throw new AppleUnlinkErrorException(AuthApiErrorCode.AUTH_APPLE_UNLINK_ERROR);
-        }
+        // Apple revoke api 호출
+        WebClient webClient = WebClient.builder().build();
+        webClient.post()
+                .uri("https://appleid.apple.com/auth/oauth2/v2/revoke")
+                .body(BodyInserters.fromFormData(formData))
+                .retrieve()
+                .bodyToMono(Void.class)
+                .block();
     }
 
     private SocialLoginRes googleLogin(String providerToken, SocialLoginReq req) {

--- a/hilingual-api/src/main/java/org/sopt/controller/auth/service/AuthService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/auth/service/AuthService.java
@@ -60,6 +60,12 @@ public class AuthService {
         throw new InvalidProviderException(AuthApiErrorCode.INVALID_PROVIDER);
     }
 
+    public Void logout(String accessToken) {
+        tokenService.logout(accessToken);
+
+        return null;
+    }
+
     private SocialLoginRes googleLogin(String providerToken, SocialLoginReq req) {
 
         GoogleIdToken.Payload payload = verifyGoogleIdentityToken(providerToken);

--- a/hilingual-api/src/main/java/org/sopt/controller/auth/service/AuthService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/auth/service/AuthService.java
@@ -8,6 +8,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.sopt.controller.auth.util.AppleKeyService;
 import org.sopt.controller.auth.util.ApplePublicKeyList;
 import org.sopt.controller.auth.dto.SocialLoginReq;
 import org.sopt.controller.auth.dto.SocialLoginRes;
@@ -22,22 +23,33 @@ import org.sopt.jwt.auth.authentication.UserRole;
 import org.sopt.jwt.auth.domain.type.AuthProvider;
 import org.sopt.user.domain.User;
 import org.sopt.user.facade.UserFacade;
+import org.sopt.user.repository.UserRepository;
 import org.sopt.user.type.RegisterStatus;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.*;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
+    private final UserRepository userRepository;
 
     private final TokenService tokenService;
     private final UserFacade userFacade;
+    private final WebClient webClient;
+    private final AppleKeyService appleKeyService;
+    private final TaskScheduler taskScheduler;
 
     private static final Integer PROVIDER_TOKEN_MIN_LENGTH = 101;
 
@@ -62,8 +74,91 @@ public class AuthService {
 
     public Void logout(String accessToken) {
         tokenService.logout(accessToken);
+        return null;
+    }
+
+    public Void leave(Long userId, String accessToken) {
+        // 토큰 삭제 및 무효화
+        tokenService.logout(accessToken);
+
+        // User 정보 Soft Delete
+        User user = userFacade.getUserById(userId);
+        user.setIsDeleted(true);
+        user.setDeletedAt(LocalDateTime.now());
+        userFacade.save(user);
+
+        // Refresh Token 및 User Provider 조회
+        final String refreshToken = tokenService.extractRefreshToken(accessToken);
+
+        // 30일 후 실행되도록 스케줄링
+        Runnable unlinkTask = getUnlinkTask(user, refreshToken);
+        Instant scheduledTime = Instant.now().plusSeconds(60 * 60 * 24 * 30);
+        taskScheduler.schedule(unlinkTask, scheduledTime);
 
         return null;
+    }
+
+    private Runnable getUnlinkTask(User user, String refreshToken) {
+        final String authProvider = user.getProvider();
+
+        // User Provider에 따라 google unlink, apple unlink 스케줄링
+        return () -> {
+          try {
+              switch (authProvider) {
+                  case "GOOGLE":
+                      googleUnlink(refreshToken);
+                      break;
+                  case "APPLE":
+                      appleUnlink(refreshToken);
+                      break;
+                  default:
+                      // 소셜로그인이 아닌 경우 Unlink 작업 불필요
+                      throw new InvalidProviderException(AuthApiErrorCode.INVALID_PROVIDER);
+              }
+
+              // unlink 성공 시 DB에서 사용자 정보 삭제
+              userFacade.deleteUserById(user.getId());
+          } catch (Exception e) {
+              throw new InvalidProviderException(AuthApiErrorCode.INVALID_PROVIDER);
+          }
+        };
+    }
+
+    private void googleUnlink(String refreshToken) {
+        String revokeUrl = "https://accounts.google.com/o/oauth2/revoke?token=" + refreshToken;
+
+        try {
+            webClient.post()
+                    .uri(revokeUrl)
+                    .retrieve()
+                    .bodyToMono(Void.class)
+                    .block();
+        } catch (Exception e) {
+            throw new GoogleUnlinkErrorException(AuthApiErrorCode.AUTH_GOOGLE_UNLINK_ERROR);
+        }
+    }
+
+    private void appleUnlink(String refreshToken) {
+        try {
+            String clientSecret = appleKeyService.makeClientSecretToken();
+
+            // revoke API에 전달할 폼 데이터
+            MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+            formData.add("client_id", appleKeyService.appleClientId);
+            formData.add("client_secret", clientSecret);
+            formData.add("token", refreshToken);
+            formData.add("token_type_hint", "refresh_token");
+
+            // Apple revoke api 호출
+            webClient.post()
+                    .uri("https://appleid.apple.com/auth/oauth2/v2/revoke")
+                    .body(BodyInserters.fromFormData(formData))
+                    .retrieve()
+                    .bodyToMono(Void.class)
+                    .block();
+        } catch (Exception e) {
+            throw new AppleUnlinkErrorException(AuthApiErrorCode.AUTH_APPLE_UNLINK_ERROR);
+        }
     }
 
     private SocialLoginRes googleLogin(String providerToken, SocialLoginReq req) {

--- a/hilingual-api/src/main/java/org/sopt/controller/auth/service/AuthService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/auth/service/AuthService.java
@@ -47,7 +47,6 @@ public class AuthService {
 
     private final TokenService tokenService;
     private final UserFacade userFacade;
-    private final WebClient webClient;
     private final AppleKeyService appleKeyService;
     private final TaskScheduler taskScheduler;
 
@@ -79,7 +78,7 @@ public class AuthService {
 
     public Void leave(Long userId, String accessToken) {
         // 토큰 삭제 및 무효화
-        tokenService.logout(accessToken);
+        tokenService.leave(accessToken);
 
         // User 정보 Soft Delete
         User user = userFacade.getUserById(userId);
@@ -92,7 +91,7 @@ public class AuthService {
 
         // 30일 후 실행되도록 스케줄링
         Runnable unlinkTask = getUnlinkTask(user, refreshToken);
-        Instant scheduledTime = Instant.now().plusSeconds(60 * 60 * 24 * 30);
+        Instant scheduledTime = Instant.now().plusSeconds(60);
         taskScheduler.schedule(unlinkTask, scheduledTime);
 
         return null;
@@ -113,12 +112,13 @@ public class AuthService {
                       break;
                   default:
                       // 소셜로그인이 아닌 경우 Unlink 작업 불필요
-                      throw new InvalidProviderException(AuthApiErrorCode.INVALID_PROVIDER);
+                      log.warn("유저 {}는 소셜 로그인 유저가 아닙니다.", user.getId());
               }
 
               // unlink 성공 시 DB에서 사용자 정보 삭제
               userFacade.deleteUserById(user.getId());
           } catch (Exception e) {
+              log.error("언링크 실패. 유저{}: {}", user.getId(), e.getMessage());
               throw new InvalidProviderException(AuthApiErrorCode.INVALID_PROVIDER);
           }
         };
@@ -128,6 +128,7 @@ public class AuthService {
         String revokeUrl = "https://accounts.google.com/o/oauth2/revoke?token=" + refreshToken;
 
         try {
+            WebClient webClient = WebClient.builder().build();
             webClient.post()
                     .uri(revokeUrl)
                     .retrieve()
@@ -150,6 +151,7 @@ public class AuthService {
             formData.add("token_type_hint", "refresh_token");
 
             // Apple revoke api 호출
+            WebClient webClient = WebClient.builder().build();
             webClient.post()
                     .uri("https://appleid.apple.com/auth/oauth2/v2/revoke")
                     .body(BodyInserters.fromFormData(formData))

--- a/hilingual-api/src/main/java/org/sopt/controller/auth/util/AppleKeyService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/auth/util/AppleKeyService.java
@@ -1,0 +1,66 @@
+package org.sopt.controller.auth.util;
+
+import io.jsonwebtoken.Jwts;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.security.PrivateKey;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+public class AppleKeyService {
+    @Value("${spring.security.oauth2.client.registration.apple.client-id}")
+    public String appleClientId;
+
+    @Value("${apple.oauth.key-id}")
+    private String appleKeyId;
+
+    @Value("${apple.oauth.team-id}")
+    private String appleTeamId;
+
+    @Value("${apple.oauth.private-key-value}")
+    private String applePrivateKey;
+
+    private static final long THIRTY_DAYS_MS = 1000L * 60 * 60 * 24 * 30;
+
+    public String makeClientSecretToken() {
+        return Jwts.builder()
+                .subject(appleClientId) // sub (Service ID / Client ID)
+                .issuer(appleTeamId) // iss (Team ID)
+                .issuedAt(new Date()) // iat
+                .expiration(new Date(System.currentTimeMillis() + THIRTY_DAYS_MS)) // exp (최대 6개월)
+                .audience() // <--- 인자 없이 호출
+                .add("https://appleid.apple.com") // <--- AudienceBuilder에 add()
+                .and() // <--- 다시 JwtBuilder로 돌아감
+                .header() // 헤더 빌더 시작
+                .keyId(appleKeyId) // kid (Key ID) 설정
+                .and() // 다시 JWT 빌더로 돌아감
+                .signWith(getPrivateKey(), Jwts.SIG.ES256) // 개인 키로 서명 (JJWT 0.12.0+ 필요)
+                .compact();
+    }
+
+    private PrivateKey getPrivateKey() {
+        try {
+            byte[] decodedKeyBytes = Base64.getDecoder().decode(applePrivateKey);
+            String pemKeyContent = new String(decodedKeyBytes, StandardCharsets.UTF_8);
+
+            PEMParser pemParser = new PEMParser(new StringReader(pemKeyContent));
+            Object object = pemParser.readObject();
+
+            if (object instanceof PrivateKeyInfo) {
+                JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
+                return converter.getPrivateKey((PrivateKeyInfo) object);
+            } else {
+                throw new RuntimeException("애플 로그인 실패: 개인 키 파싱 실패 - 예상치 못한 형식");
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("애플 로그인 실패: 개인 키 로드 중 오류 발생", e);
+        }
+    }
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/token/TokenService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/token/TokenService.java
@@ -174,7 +174,8 @@ public class TokenService {
 
         // Unlink에 사용할 모든 RefreshToken 조회 및 임시저장
         List<Token> userTokens = tokenRepository.findByUserId(userId);
-        if (!userTokens.isEmpty()) {
+        /*if (!userTokens.isEmpty()) {
+            // TODO 수정
             Token firstToken = userTokens.getFirst();
             String refreshTokenHash = firstToken.getRefreshTokenHash();
 
@@ -191,7 +192,7 @@ public class TokenService {
                     31,
                     TimeUnit.DAYS
             );
-        }
+        }*/
 
         // 기존의 모든 RefreshToken을 Redis에서 삭제
         tokenRepository.deleteByUserId(userId);

--- a/hilingual-api/src/main/java/org/sopt/controller/token/TokenService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/token/TokenService.java
@@ -158,6 +158,34 @@ public class TokenService {
         }
     }
 
+    @Transactional
+    public void leave(final String accessToken) {
+        Claims claims = jwtTokenProvider.parseAndVerify(accessToken);
+
+        // AccessToken이 맞는지 검증
+        final String type = claims.get(JwtClaimsKeys.TYPE, String.class);
+        if (!JwtClaimsKeys.ACCESS.equals(type)) {
+            throw new InvalidTokenException(AuthErrorCode.TYPE_ERROR_JWT_TOKEN);
+        }
+
+        // 현재 Access Token을 Redis 블랙리스트에 추가
+        long expirationTime = claims.getExpiration().getTime();
+        long now = System.currentTimeMillis();
+        long remainingExpirationSeconds = (expirationTime - now) / 1000;
+
+        if (remainingExpirationSeconds > 0) {
+            redisTemplate.opsForValue().set(
+                    "blacklist:" + accessToken,
+                    "logged_out",
+                    remainingExpirationSeconds,
+                    TimeUnit.SECONDS
+            );
+        }
+
+        // Claim 에서 정보 추출 및 Redis 에서 회원에 대한 모든 리프레쉬 토큰 삭제
+        Long userId = claims.get(AuthConstants.USER_ID_CLAIM_NAME, Long.class);
+        tokenRepository.deleteByUserId(userId);
+    }
 
     @Transactional
     public String extractRefreshToken(final String accessToken){

--- a/hilingual-api/src/main/java/org/sopt/controller/token/TokenService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/token/TokenService.java
@@ -19,10 +19,12 @@ import org.sopt.jwt.core.TokenId;
 import org.sopt.jwt.support.AuthConstants;
 import org.sopt.user.facade.UserFacade;
 import org.sopt.user.type.RegisterStatus;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -32,6 +34,7 @@ public class TokenService {
     private final TokenRepository tokenRepository;
     private final TokenHasher tokenHasher;
     private final UserFacade userFacade;
+    private final RedisTemplate<String, String> redisTemplate;
 
     @Transactional
     public ReissueTokensRes reissue(String refreshToken) {
@@ -120,5 +123,38 @@ public class TokenService {
         tokenRepository.save(token);
 
         return SocialLoginRes.of(accessToken, refreshToken, registerStatus);
+    }
+
+    @Transactional
+    public void logout(final String accessToken) {
+        Claims claims = jwtTokenProvider.parseAndVerify(accessToken);
+
+        // AccessToken이 맞는지 검증
+        final String type = claims.get(JwtClaimsKeys.TYPE, String.class);
+        if (!JwtClaimsKeys.ACCESS.equals(type)) {
+            throw new InvalidTokenException(AuthErrorCode.TYPE_ERROR_JWT_TOKEN);
+        }
+
+        // Claim 에서 정보 추출
+        Long userId = claims.get(AuthConstants.USER_ID_CLAIM_NAME, Long.class);
+        String sessionId = claims.get(JwtClaimsKeys.SESSIONID, String.class);
+
+        // Redis 에서 기존 토큰 삭제
+        String tokenId = new TokenId(userId, sessionId).toString();
+        tokenRepository.deleteById(tokenId);
+
+        // 현재 Access Token을 Redis 블랙리스트에 추가
+        long expirationTime = claims.getExpiration().getTime();
+        long now = System.currentTimeMillis();
+        long remainingExpirationSeconds = (expirationTime - now) / 1000;
+
+        if (remainingExpirationSeconds > 0) {
+            redisTemplate.opsForValue().set(
+                    "blacklist:" + accessToken,
+                    "logged_out",
+                    remainingExpirationSeconds,
+                    TimeUnit.SECONDS
+            );
+        }
     }
 }

--- a/hilingual-api/src/main/java/org/sopt/controller/token/TokenService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/token/TokenService.java
@@ -157,4 +157,12 @@ public class TokenService {
             );
         }
     }
+
+
+    @Transactional
+    public String extractRefreshToken(final String accessToken){
+        // RefreshToken 추출
+        Claims claims = jwtTokenProvider.parseAndVerify(accessToken);
+        return claims.get(JwtClaimsKeys.REFRESH, String.class);
+    }
 }

--- a/hilingual-api/src/main/java/org/sopt/controller/token/TokenService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/token/TokenService.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -168,6 +169,33 @@ public class TokenService {
             throw new InvalidTokenException(AuthErrorCode.TYPE_ERROR_JWT_TOKEN);
         }
 
+        // Claim 에서 정보 추출
+        Long userId = claims.get(AuthConstants.USER_ID_CLAIM_NAME, Long.class);
+
+        // Unlink에 사용할 모든 RefreshToken 조회 및 임시저장
+        List<Token> userTokens = tokenRepository.findByUserId(userId);
+        if (!userTokens.isEmpty()) {
+            Token firstToken = userTokens.getFirst();
+            String refreshTokenHash = firstToken.getRefreshTokenHash();
+
+            redisTemplate.opsForValue().set(
+                    "unlink_token:" + userId,
+                    refreshTokenHash, // 토큰 해시값을 저장
+                    31,
+                    TimeUnit.DAYS
+            );
+
+            redisTemplate.opsForValue().set(
+                    "unlink_provider:" + userId,
+                    firstToken.getAuthProvider().name(),
+                    31,
+                    TimeUnit.DAYS
+            );
+        }
+
+        // 기존의 모든 RefreshToken을 Redis에서 삭제
+        tokenRepository.deleteByUserId(userId);
+
         // 현재 Access Token을 Redis 블랙리스트에 추가
         long expirationTime = claims.getExpiration().getTime();
         long now = System.currentTimeMillis();
@@ -181,10 +209,6 @@ public class TokenService {
                     TimeUnit.SECONDS
             );
         }
-
-        // Claim 에서 정보 추출 및 Redis 에서 회원에 대한 모든 리프레쉬 토큰 삭제
-        Long userId = claims.get(AuthConstants.USER_ID_CLAIM_NAME, Long.class);
-        tokenRepository.deleteByUserId(userId);
     }
 
     @Transactional

--- a/hilingual-auth/src/main/java/org/sopt/jwt/auth/domain/TokenRepository.java
+++ b/hilingual-auth/src/main/java/org/sopt/jwt/auth/domain/TokenRepository.java
@@ -9,7 +9,8 @@ public interface TokenRepository extends CrudRepository<Token, String> {
     // 사용자 ID로 모든 토큰 조회 (멀티 디바이스 지원)
     List<Token> findByUserId(Long userId);
 
-    // 사용자 ID로 모든 토큰 삭제 (로그아웃 시 사용)
+    // 사용자 ID로 모든 토큰 삭제 (회원탈퇴 시 사용)
     void deleteByUserId(Long userId);
 
+    // 멀티디바이스를 고려해 userId:sessionId를 id로 갖는 토큰 삭제 (로그아웃 시 사용)
 }

--- a/hilingual-auth/src/main/java/org/sopt/jwt/auth/web/JwtAuthenticationFilter.java
+++ b/hilingual-auth/src/main/java/org/sopt/jwt/auth/web/JwtAuthenticationFilter.java
@@ -8,9 +8,14 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.sopt.exception.AuthErrorCode;
+import org.sopt.exception.InvalidTokenException;
+import org.sopt.exception.UnAuthorizedException;
+import org.sopt.exception.code.ErrorCode;
 import org.sopt.jwt.core.JwtClaimsKeys;
 import org.sopt.jwt.core.JwtTokenProvider;
 import org.sopt.jwt.auth.authentication.UserAuthenticationFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
@@ -30,6 +35,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final UserAuthenticationFactory userAuthenticationFactory;
+    private final RedisTemplate<String, String> redisTemplate;
 
     private static final AntPathMatcher PM = new AntPathMatcher();
     private static final List<String> SKIP = List.of(
@@ -62,6 +68,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         /** 헤더에서 토큰 추출 */
         final String token = jwtTokenProvider.getJwtFromRequest(request);
+        if(redisTemplate.hasKey("blacklist:" + token)){
+            throw new UnAuthorizedException(AuthErrorCode.UNAUTHORIZED);
+        }
+
         /** 유효하면 파싱 및 검증해서 Claim 획득 */
         if (StringUtils.hasText(token)) {
             Claims claims = jwtTokenProvider.parseAndVerify(token);

--- a/hilingual-domain/src/main/java/org/sopt/user/facade/UserFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/user/facade/UserFacade.java
@@ -12,6 +12,7 @@ public class UserFacade {
 
     private final UserRetriever userRetriever;
     private final UserSaver userSaver;
+    private final UserRemover userRemover;
 
     public Optional<User> getByProviderAndProviderId(final String provider, final String providerId) {
         return userRetriever.findByProviderAndProviderId(provider, providerId);
@@ -27,5 +28,9 @@ public class UserFacade {
 
     public User save(final User user){
         return userSaver.save(user);
+    }
+
+    public void deleteUserById(final long userId) {
+        userRemover.deleteUserById(userId);
     }
 }

--- a/hilingual-domain/src/main/java/org/sopt/user/facade/UserRemover.java
+++ b/hilingual-domain/src/main/java/org/sopt/user/facade/UserRemover.java
@@ -1,0 +1,23 @@
+package org.sopt.user.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.user.exception.UserCoreErrorCode;
+import org.sopt.user.exception.UserNotFoundException;
+import org.sopt.user.repository.UserRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class UserRemover {
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void deleteUserById(Long userId) {
+        if (!userRepository.existsById(userId)) {
+            throw new UserNotFoundException(UserCoreErrorCode.USER_NOT_FOUND);
+        }
+
+        userRepository.deleteById(userId);
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #229 

## Work Description ✏️
- 로그아웃 API
    - Redis에서 리프레쉬 토큰 삭제
    - AccessToken 남은 TTL 동안 blacklist에 넣어두고 인증되지 않도록 무효화 로직 구현
- 회원탈퇴 API
    - 회원탈퇴 시 로그아웃과 같은 로직으로 토큰 삭제
    - 30일간 `isDeleted=true` 설정
    - 30일 후 Unlink 및 DB에서 최종 삭제

## Screenshot 📸
### 로그아웃
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 로그아웃 | <img width="437" height="476" alt="image" src="https://github.com/user-attachments/assets/a7c57d85-297e-444f-b8cc-ac2552880764" /> |
| 로그아웃한 토큰으로 다른 API 사용 시 | <img width="392" height="435" alt="image" src="https://github.com/user-attachments/assets/76586586-069b-487c-8f07-70521fe6968a" /> |

### 회원탈퇴
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 회원탈퇴(유저아이디2) | <img width="466" height="485" alt="image" src="https://github.com/user-attachments/assets/16187401-73e8-42b3-acfe-2406006e7cdb" /> |
| 회원탈퇴 직후 유저DB | <img width="584" height="103" alt="image" src="https://github.com/user-attachments/assets/ac6bc25f-a7d3-4363-ac34-dc8a28454781" /> |
| 회원탈퇴 직후 같은 액세스토큰으로 회원탈퇴 쐈을 때 | <img width="748" height="572" alt="image" src="https://github.com/user-attachments/assets/0960e9af-3586-485c-bd49-71c78d049f2f" /> |
 


## Uncompleted Tasks 😅
- [ ] 로그아웃한 토큰으로 또 API 쏘는 경우 401 내려주려고 했는데 일단 걍 500 뜨게 했습니다..(클라 단에서 토큰 잘 지우겠지!)

## To Reviewers 📢
로그아웃 먼저 머지하는 것이 좋을 것 같아 회원탈퇴 API 이슈 새로 파고 얘만 먼저 머지합니다!