### PR TITLE
[feat] #220 알림 리스트 확인하기 API 구현 및 #231 팔로우 등록 API 호출 시 유저의 현재 알림 설정 상태에 따라 FeedAlarm 테이블에 알림 쌓이도록 수정

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/follow/service/FollowService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/follow/service/FollowService.java
@@ -13,6 +13,7 @@ import org.sopt.controller.follow.dto.FollowerListRes;
 import org.sopt.controller.follow.dto.FollowingListRes;
 import org.sopt.controller.userprofile.dto.UserProfileSummaryRes;
 
+import org.sopt.feedalarm.facade.FeedAlarmFacade;
 import org.sopt.follow.dto.FolloweeIdAndIsFollowed;
 import org.sopt.follow.dto.FollowerIdAndIsFollowing;
 import org.sopt.follow.facade.FollowFacade;
@@ -38,6 +39,7 @@ public class FollowService {
     private final FollowFacade followFacade;
     private final BlockFacade blockFacade;
     private final UserProfileFacade userProfileFacade;
+    private final FeedAlarmFacade feedAlarmFacade;
 
     @Transactional
     public void follow(Long userId, Long targetUserId) {
@@ -57,6 +59,8 @@ public class FollowService {
 
         follower.getUserProfile().increaseFollowingCount();
         followee.getUserProfile().increaseFollowerCount();
+
+        feedAlarmFacade.createFollowAlarm(followee, follower);
     }
 
     @Transactional

--- a/hilingual-api/src/main/java/org/sopt/controller/user/api/UserController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/api/UserController.java
@@ -3,16 +3,16 @@ package org.sopt.controller.user.api;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.sopt.alarmpreference.type.AlarmType;
-import org.sopt.controller.user.dto.NotiStatusRes;
-import org.sopt.controller.user.dto.NoticeDetailRes;
-import org.sopt.controller.user.dto.UserDefaultInfoRes;
-import org.sopt.controller.user.dto.HomeUserProfileRes;
+import org.sopt.controller.user.dto.*;
 import org.sopt.controller.user.service.UserService;
 import org.sopt.jwt.core.JwtTokenProvider;
 import org.sopt.jwt.auth.dto.ReissueTokensRes;
 import org.sopt.jwt.annotation.UserId;
+import org.sopt.user.type.NotificationTab;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -82,4 +82,20 @@ public class UserController {
         userService.markNoticeRead(userId, noticeId);
         return ResponseEntity.ok().build();
     }
+
+    // 알림 리스트 확인하기 API
+    @GetMapping("/notifications")
+    public ResponseEntity<List<? extends NotificationItemRes>> getNotifications(
+            @UserId Long userId,
+            @RequestParam(defaultValue = "FEED") String tab
+    ) {
+        NotificationTab t = NotificationTab.from(tab);
+
+        if (t == NotificationTab.FEED) {
+            return ResponseEntity.ok(userService.getFeedAlarms(userId));
+        } else {
+            return ResponseEntity.ok(userService.getNoticeAlarms(userId));
+        }
+    }
+
 }

--- a/hilingual-api/src/main/java/org/sopt/controller/user/dto/FeedAlarmItemRes.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/dto/FeedAlarmItemRes.java
@@ -1,0 +1,28 @@
+package org.sopt.controller.user.dto;
+
+import org.sopt.feedalarm.domain.FeedAlarm;
+
+import java.time.format.DateTimeFormatter;
+
+public record FeedAlarmItemRes(
+        Long noticeId,
+        String type,
+        String title,
+        Long targetId,
+        boolean isRead,
+        String publishedAt
+) implements NotificationItemRes {
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+    public static FeedAlarmItemRes from(FeedAlarm a) {
+        return new FeedAlarmItemRes(
+                a.getId(),
+                a.getType().name(),
+                a.getTitle(),
+                a.getTargetId(),
+                a.getReadAt() != null,
+                a.getCreatedAt().toLocalDate().format(DATE_FORMATTER)
+        );
+    }
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/user/dto/NoticeListItemRes.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/dto/NoticeListItemRes.java
@@ -1,0 +1,28 @@
+package org.sopt.controller.user.dto;
+
+import org.sopt.noticedelivery.domain.NoticeDelivery;
+
+import java.time.format.DateTimeFormatter;
+
+public record NoticeListItemRes(
+        Long noticeId,
+        String category,
+        String title,
+        boolean isRead,
+        String publishedAt
+) implements NotificationItemRes {
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+    public static NoticeListItemRes from(NoticeDelivery d) {
+        var notice = d.getNotice();
+
+        return new NoticeListItemRes(
+                notice.getId(),
+                notice.getCategory().name(),
+                notice.getTitle(),
+                d.getReadAt() != null,
+                notice.getCreatedAt().toLocalDate().format(DATE_FORMATTER)
+        );
+    }
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/user/dto/NotificationItemRes.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/dto/NotificationItemRes.java
@@ -1,0 +1,4 @@
+package org.sopt.controller.user.dto;
+
+public interface NotificationItemRes {
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/user/service/NotificationDeleteJob.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/service/NotificationDeleteJob.java
@@ -1,0 +1,24 @@
+package org.sopt.controller.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.feedalarm.repository.FeedAlarmRepository;
+import org.sopt.noticedelivery.repository.NoticeDeliveryRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationDeleteJob {
+
+    private final FeedAlarmRepository feedRepo;
+    private final NoticeDeliveryRepository noticeRepo;
+
+    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
+    @Transactional
+    public void trim() {
+        int limit = 500;
+        feedRepo.deleteAllUsersBeyondLimit(limit);
+        noticeRepo.deleteAllUsersBeyondLimit(limit);
+    }
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/user/service/UserService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/service/UserService.java
@@ -4,22 +4,20 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.alarmpreference.facade.AlarmPreferenceFacade;
 import org.sopt.alarmpreference.type.AlarmType;
 import org.sopt.controller.token.TokenService;
-import org.sopt.controller.user.dto.NotiStatusRes;
-import org.sopt.controller.user.dto.UserDefaultInfoRes;
+import org.sopt.controller.user.dto.*;
 import org.sopt.controller.user.exception.CannotLoadProviderException;
 import org.sopt.controller.user.exception.UserApiErrorCode;
 import org.sopt.feedalarm.facade.FeedAlarmFacade;
 import org.sopt.jwt.auth.dto.ReissueTokensRes;
 import org.sopt.user.domain.User;
-import org.sopt.controller.user.dto.HomeUserProfileRes;
 import org.sopt.user.facade.UserFacade;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.sopt.controller.user.dto.NoticeDetailRes;
 import org.sopt.noticedelivery.domain.NoticeDelivery;
 import org.sopt.noticedelivery.facade.NoticeDeliveryFacade;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 
 @Service
@@ -105,6 +103,16 @@ public class UserService {
     public void markNoticeRead(final long userId, final long noticeId){
         feedAlarmFacade.markAlarmAsRead(userId, noticeId);
         return;
+    }
+
+    public List<NoticeListItemRes> getNoticeAlarms(long userId) {
+        return noticeDeliveryFacade.findLatestByUserId(userId)
+                .stream().map(NoticeListItemRes::from).toList();
+    }
+
+    public List<FeedAlarmItemRes> getFeedAlarms(long userId) {
+        return feedAlarmFacade.findLatestByUserId(userId)
+                .stream().map(FeedAlarmItemRes::from).toList();
     }
 
 }

--- a/hilingual-domain/src/main/java/org/sopt/feedalarm/domain/FeedAlarm.java
+++ b/hilingual-domain/src/main/java/org/sopt/feedalarm/domain/FeedAlarm.java
@@ -63,7 +63,7 @@ public class FeedAlarm extends BaseTimeEntity {
                 targetUser,
                 FeedAlarmType.FOLLOW_USER,
                 TargetType.USER,
-                targetUser.getId(),
+                actorId,
                 actorId,
                 title,
                 null

--- a/hilingual-domain/src/main/java/org/sopt/feedalarm/domain/FeedAlarm.java
+++ b/hilingual-domain/src/main/java/org/sopt/feedalarm/domain/FeedAlarm.java
@@ -57,4 +57,17 @@ public class FeedAlarm extends BaseTimeEntity {
         }
     }
 
+    public static FeedAlarm createFollowUser(User targetUser, Long actorId, String title) {
+        return new FeedAlarm(
+                null,
+                targetUser,
+                FeedAlarmType.FOLLOW_USER,
+                TargetType.USER,
+                targetUser.getId(),
+                actorId,
+                title,
+                null
+        );
+    }
+
 }

--- a/hilingual-domain/src/main/java/org/sopt/feedalarm/facade/FeedAlarmFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/feedalarm/facade/FeedAlarmFacade.java
@@ -1,16 +1,36 @@
 package org.sopt.feedalarm.facade;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.feedalarm.domain.FeedAlarm;
+import org.sopt.user.domain.User;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 public class FeedAlarmFacade {
 
     private final FeedAlarmRetriever feedAlarmRetriever;
+    private final FeedAlarmSaver feedAlarmSaver;
 
     public void markAlarmAsRead(Long userId, Long alarmId) {
         feedAlarmRetriever.markAlarmAsRead(userId, alarmId);
+    }
+
+    public List<FeedAlarm> findLatestByUserId(final long userId) {
+        return feedAlarmRetriever.findLatestByUserId(userId);
+    }
+
+    @Transactional
+    public void createFollowAlarm(User targetUser, User actor) {
+        FeedAlarm alarm = FeedAlarm.createFollowUser(
+                targetUser,
+                actor.getId(),       
+                actor.getUserProfile().getNickname() + "님이 당신을 팔로우했습니다."
+        );
+        feedAlarmSaver.save(alarm);
     }
 
 }

--- a/hilingual-domain/src/main/java/org/sopt/feedalarm/facade/FeedAlarmRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/feedalarm/facade/FeedAlarmRetriever.java
@@ -8,6 +8,8 @@ import org.sopt.feedalarm.repository.FeedAlarmRepository;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class FeedAlarmRetriever {
@@ -19,5 +21,12 @@ public class FeedAlarmRetriever {
         FeedAlarm alarm = feedAlarmRepository.findByIdAndUserId(alarmId, userId)
                 .orElseThrow(() -> new FeedAlarmNotFoundException(FeedAlarmCoreErrorCode.FEED_ALARM_NOT_FOUND));
         alarm.markAsRead();
+    }
+
+
+    // 최근 N개의 알림 조회
+    @Transactional(readOnly = true)
+    public List<FeedAlarm> findLatestByUserId(final long userId) {
+        return feedAlarmRepository.findTop500ByUserIdOrderByCreatedAtDesc(userId);
     }
 }

--- a/hilingual-domain/src/main/java/org/sopt/feedalarm/facade/FeedAlarmSaver.java
+++ b/hilingual-domain/src/main/java/org/sopt/feedalarm/facade/FeedAlarmSaver.java
@@ -1,0 +1,20 @@
+package org.sopt.feedalarm.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.feedalarm.domain.FeedAlarm;
+import org.sopt.feedalarm.repository.FeedAlarmRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class FeedAlarmSaver {
+
+    private final FeedAlarmRepository feedAlarmRepository;
+
+    @Transactional
+    public FeedAlarm save(FeedAlarm alarm) {
+        return feedAlarmRepository.save(alarm);
+    }
+
+}

--- a/hilingual-domain/src/main/java/org/sopt/feedalarm/repository/FeedAlarmRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/feedalarm/repository/FeedAlarmRepository.java
@@ -2,11 +2,36 @@ package org.sopt.feedalarm.repository;
 
 import org.sopt.feedalarm.domain.FeedAlarm;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FeedAlarmRepository extends JpaRepository<FeedAlarm, Long> {
 
     Optional<FeedAlarm> findByIdAndUserId(Long alarmId, Long userId);
 
+    @Query("""
+        select f
+          from FeedAlarm f
+         where f.user.id = :userId
+         order by f.createdAt desc, f.id desc
+    """)
+    List<FeedAlarm> findTop500ByUserIdOrderByCreatedAtDesc(Long userId);
+
+    @Modifying
+    @Query(value = """
+        with ranked as (
+            select id,
+                   row_number() over (partition by user_id order by created_at desc) as rn
+            from feed_alarm
+        )
+        delete from feed_alarm fa
+        using ranked r
+        where fa.id = r.id
+          and r.rn > :limit
+        """, nativeQuery = true)
+    void deleteAllUsersBeyondLimit(@Param("limit") int limit);
 }

--- a/hilingual-domain/src/main/java/org/sopt/noticedelivery/facade/NoticeDeliveryFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/noticedelivery/facade/NoticeDeliveryFacade.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.noticedelivery.domain.NoticeDelivery;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class NoticeDeliveryFacade {
@@ -12,6 +14,10 @@ public class NoticeDeliveryFacade {
 
     public NoticeDelivery findByUserIdAndNoticeIdWithDetail(final long userId, final long noticeId){
         return noticeDeliveryRetriever.findByUserIdAndNoticeIdWithDetail(userId, noticeId);
+    }
+
+    public List<NoticeDelivery> findLatestByUserId(final long userId) {
+        return noticeDeliveryRetriever.findLatestByUserId(userId);
     }
 
 }

--- a/hilingual-domain/src/main/java/org/sopt/noticedelivery/facade/NoticeDeliveryRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/noticedelivery/facade/NoticeDeliveryRetriever.java
@@ -6,6 +6,9 @@ import org.sopt.noticedelivery.exception.NoticeDeliveryErrorCode;
 import org.sopt.noticedelivery.exception.NoticeDeliveryNoFoundException;
 import org.sopt.noticedelivery.repository.NoticeDeliveryRepository;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -17,4 +20,10 @@ public class NoticeDeliveryRetriever {
         return noticeDeliveryRepository.findByUserIdAndNoticeIdWithDetail(userId, noticeId)
                 .orElseThrow(() -> new NoticeDeliveryNoFoundException(NoticeDeliveryErrorCode.NOTICE_DELIVERY_NOT_FOUND));
     }
+
+    @Transactional(readOnly = true)
+    public List<NoticeDelivery> findLatestByUserId(final long userId) {
+        return noticeDeliveryRepository.findTop500ByUserIdOrderByDeliveredAtDesc(userId);
+    }
+
 }

--- a/hilingual-domain/src/main/java/org/sopt/noticedelivery/repository/NoticeDeliveryRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/noticedelivery/repository/NoticeDeliveryRepository.java
@@ -2,9 +2,11 @@ package org.sopt.noticedelivery.repository;
 
 import org.sopt.noticedelivery.domain.NoticeDelivery;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface NoticeDeliveryRepository extends JpaRepository<NoticeDelivery, Long> {
@@ -20,4 +22,28 @@ public interface NoticeDeliveryRepository extends JpaRepository<NoticeDelivery, 
     """)
     Optional<NoticeDelivery> findByUserIdAndNoticeIdWithDetail(@Param("userId") Long userId,
                                                                @Param("noticeId") Long noticeId);
+
+    // 최근 알림 목록 최대 500개, 수신시각 최신순
+    @Query("""
+        select nd
+          from NoticeDelivery nd
+          join fetch nd.notice n
+         where nd.user.id = :userId
+         order by nd.deliveredAt desc, nd.id desc
+    """)
+    List<NoticeDelivery> findTop500ByUserIdOrderByDeliveredAtDesc(Long userId);
+
+    @Modifying
+    @Query(value = """
+        with ranked as (
+            select id,
+                   row_number() over (partition by user_id order by delivered_at desc) as rn
+            from notice_delivery
+        )
+        delete from notice_delivery nd
+        using ranked r
+        where nd.id = r.id
+          and r.rn > :limit
+        """, nativeQuery = true)
+    void deleteAllUsersBeyondLimit(@Param("limit") int limit);
 }

--- a/hilingual-domain/src/main/java/org/sopt/user/type/NotificationTab.java
+++ b/hilingual-domain/src/main/java/org/sopt/user/type/NotificationTab.java
@@ -1,0 +1,15 @@
+package org.sopt.user.type;
+
+public enum NotificationTab {
+    FEED,
+    NOTIFICATION
+    ;
+
+    public static NotificationTab from(String raw) {
+        try {
+            return NotificationTab.valueOf(raw.toUpperCase());
+        } catch (Exception e) {
+            return FEED;
+        }
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #220 
- closed #231 

## Work Description ✏️
- 알림 리스트 확인하기 API 구현
  - 기본값(tab=FEED) → 피드 알림 목록 조회
  - tab=NOTIFICATION → 공지사항 알림 목록 조회
  - 응답 데이터 정렬 : 항상 최신 생성 순(createdAt DESC)
- 팔로우 등록 API 수정
  - 팔로우 성공 시, FeedAlarm 테이블에 알림 row 자동 생성
  - 알림 내용은 팔로워 닉네임 기반 메시지로 구성
- 알림 배치 작업
  - 하루 1회 (매일 03:00, Asia/Seoul 기준) 배치 실행
  - FeedAlarm, NoticeDelivery 테이블 각각 500개 초과 시 → 오래된 row부터 삭제

## 알림 리스트 확인하기 API Screenshot 📸
| 설명 | 캡처 |
|:---:|:---:|
| Default=FEED 조회 | <img width="1888" height="1736" alt="image" src="https://github.com/user-attachments/assets/4a136f23-ba98-49f9-8347-b3ed01011c7f" /> |
| NOTIFICATION 조회 | <img width="1904" height="1716" alt="image" src="https://github.com/user-attachments/assets/2c4957bb-4c10-4360-9cda-05bb05613c8a" />|
| noticeId = 11 로 “공지사항 알림 상세보기 API 호출” | <img width="1882" height="990" alt="image" src="https://github.com/user-attachments/assets/fa25f5a5-fbcc-4ef3-96db-98f32445c6e5" /> |
| 배치 테스트(1분 후 삭제되도록 테스트 → 1분 후 API 재요청 후 응답값) | <img width="1840" height="1458" alt="image" src="https://github.com/user-attachments/assets/287d65a0-c542-4254-8534-4dc30d994434" /> |

## 팔로우 등록 API Screenshot 📸
| 설명 | 캡처 |
|:---:|:---:|
| 유저1이 유저2 팔로우 | <img width="1866" height="962" alt="image" src="https://github.com/user-attachments/assets/4c674dbc-63b8-4c07-bd5c-b635eb6e5558" /> | 
| 유저2가 자신의 알림 리스트 확인 | <img width="920" height="636" alt="image" src="https://github.com/user-attachments/assets/e467a5c7-a95c-4b87-b906-36f5ed6300f7" /> | 

## Uncompleted Tasks 😅
추후 무한 스크롤 지원 시 Pageable 도입 예정

## To Reviewers 📢
@HAJIEUN02 피드에 좋아요 누를 시 FeedAlarm 생성되게끔 수정 부탁드립니다! 🙏