### PR TITLE
[feat] #222 피드 좋아요 지정/해제 API 구현

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/feed/api/FeedController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/feed/api/FeedController.java
@@ -90,4 +90,14 @@ public class FeedController {
     ) {
         return ResponseEntity.ok(feedService.getFollowFeeds(userId, page, size));
     }
+
+    // 피드 좋아요 지정/해제 API
+    @PostMapping("/likes/{diaryId}")
+    public ResponseEntity<LikeToggleRes> toggleLike(
+            @UserId Long userId,
+            @PathVariable Long diaryId,
+            @RequestBody LikeToggleReq req
+    ) {
+        return ResponseEntity.ok(feedService.toggleLike(userId, diaryId, req.isLiked()));
+    }
 }

--- a/hilingual-api/src/main/java/org/sopt/controller/feed/dto/LikeToggleReq.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/feed/dto/LikeToggleReq.java
@@ -1,0 +1,6 @@
+package org.sopt.controller.feed.dto;
+
+public record LikeToggleReq(
+        boolean isLiked
+) {
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/feed/dto/LikeToggleRes.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/feed/dto/LikeToggleRes.java
@@ -1,0 +1,7 @@
+package org.sopt.controller.feed.dto;
+
+public record LikeToggleRes(boolean isLiked) {
+    public static LikeToggleRes of(boolean isLiked) {
+        return new LikeToggleRes(isLiked);
+    }
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/feed/service/FeedService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/feed/service/FeedService.java
@@ -1,6 +1,8 @@
 package org.sopt.controller.feed.service;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.alarmpreference.facade.AlarmPreferenceFacade;
+import org.sopt.alarmpreference.type.AlarmType;
 import org.sopt.aws.s3.service.S3Service;
 import org.sopt.block.facade.BlockFacade;
 import org.sopt.controller.feed.dto.*;
@@ -13,10 +15,12 @@ import org.sopt.diary.domain.Diary;
 import org.sopt.diary.facade.DiaryFacade;
 import org.sopt.feed.dto.FeedProjection;
 import org.sopt.feed.facade.FeedFacade;
+import org.sopt.feedalarm.facade.FeedAlarmFacade;
 import org.sopt.follow.dto.FollowRelation;
 import org.sopt.follow.facade.FollowFacade;
 import org.sopt.likeddiary.domain.LikedDiary;
 import org.sopt.likeddiary.facade.LikedDiaryFacade;
+import org.sopt.user.domain.User;
 import org.sopt.user.facade.UserFacade;
 import org.sopt.userprofile.domain.UserProfile;
 import org.sopt.userprofile.dto.UserSearchProjection;
@@ -47,6 +51,8 @@ public class FeedService {
     private final LikedDiaryFacade likedDiaryFacade;
     private final FeedFacade feedFacade;
     private final S3Service s3Service;
+    private final FeedAlarmFacade feedAlarmFacade;
+    private final AlarmPreferenceFacade alarmPreferenceFacade;
 
     @Transactional(readOnly = true)
     public FeedProfileRes getFeedProfile(Long userId, Long targetUserId) {
@@ -288,6 +294,35 @@ public class FeedService {
                         "isLiked", likedDiaryIds.contains(diary.getId())
                 ))
                 .toList();
+    }
+
+    @Transactional
+    public LikeToggleRes toggleLike(Long userId, Long diaryId, boolean wantLike) {
+        diaryFacade.validateReadable(userId, diaryId);
+
+        User user  = userFacade.getUserById(userId);
+        Diary diary = diaryFacade.getDiaryById(diaryId);
+
+        boolean alreadyLiked = likedDiaryFacade.findUserAndDiaryExist(user.getId(), diary.getId());
+
+        if (wantLike && !alreadyLiked) {
+            likedDiaryFacade.like(user, diary);
+            diaryFacade.increaseLikeCount(diaryId);
+
+            // FEED 알림 허용 사용자만 알림 생성
+            if (alarmPreferenceFacade.isEnabled(diary.getUser().getId(), AlarmType.FEED)) {
+                // 같은 다이어리/같은 액터의 중복 알림 방지 로직은 Facade 내부에서 처리
+                feedAlarmFacade.createLikeDiaryAlarm(diary, user);
+            }
+            return LikeToggleRes.of(true);
+        }
+
+        if (!wantLike && alreadyLiked) {
+            likedDiaryFacade.unlike(user.getId(), diary.getId());
+            diaryFacade.decreaseLikeCount(diaryId);
+            return LikeToggleRes.of(false);
+        }
+        return LikeToggleRes.of(alreadyLiked);
     }
 
 }

--- a/hilingual-domain/src/main/java/org/sopt/alarmpreference/facade/AlarmPreferenceFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/alarmpreference/facade/AlarmPreferenceFacade.java
@@ -29,4 +29,10 @@ public class AlarmPreferenceFacade {
     public AlarmPreference save(AlarmPreference alarmPreference) {
         return alarmPreferenceSaver.save(alarmPreference);
     }
+
+    // type 에 해당하는 알람 수신 여부
+    @Transactional(readOnly = true)
+    public boolean isEnabled(final long userId, final AlarmType type) {
+        return alarmPreferenceRetriever.isEnabled(userId, type);
+    }
 }

--- a/hilingual-domain/src/main/java/org/sopt/alarmpreference/facade/AlarmPreferenceRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/alarmpreference/facade/AlarmPreferenceRetriever.java
@@ -30,4 +30,12 @@ public class AlarmPreferenceRetriever {
         prefs.forEach(p -> map.put(p.getAlarmType(), Boolean.TRUE.equals(p.getIsEnabled())));
         return map;
     }
+
+    @Transactional(readOnly = true)
+    public boolean isEnabled(Long userId, AlarmType type) {
+        return alarmPreferenceRepository.findByUserIdAndAlarmType(userId, type)
+                .map(AlarmPreference::getIsEnabled)
+                .orElse(false);
+    }
+
 }

--- a/hilingual-domain/src/main/java/org/sopt/diary/domain/Diary.java
+++ b/hilingual-domain/src/main/java/org/sopt/diary/domain/Diary.java
@@ -89,4 +89,12 @@ public class Diary extends BaseTimeEntity {
         );
     }
 
+    public void increaseLikeCount() {
+        this.isLiked = (this.isLiked == null ? 0 : this.isLiked) + 1;
+    }
+    public void decreaseLikeCount() {
+        int cur = (this.isLiked == null ? 0 : this.isLiked);
+        this.isLiked = Math.max(0, cur - 1);
+    }
+
 }

--- a/hilingual-domain/src/main/java/org/sopt/diary/facade/DiaryFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/diary/facade/DiaryFacade.java
@@ -90,4 +90,17 @@ public class DiaryFacade {
         Diary diary = diaryRetriever.findOwnedByIdOrThrow(userId, diaryId);
         diaryUpdater.unpublish(diary);
     }
+
+    @Transactional
+    public void increaseLikeCount(Long diaryId) {
+        Diary diary = diaryRetriever.findById(diaryId);
+        diaryUpdater.increaseLike(diary);
+    }
+
+    @Transactional
+    public void decreaseLikeCount(Long diaryId) {
+        Diary diary = diaryRetriever.findById(diaryId);
+        diaryUpdater.decreaseLike(diary);
+    }
+
 }

--- a/hilingual-domain/src/main/java/org/sopt/diary/facade/DiaryUpdater.java
+++ b/hilingual-domain/src/main/java/org/sopt/diary/facade/DiaryUpdater.java
@@ -17,4 +17,12 @@ public class DiaryUpdater {
         diary.unpublish();
     }
 
+    public void increaseLike(Diary diary) {
+        diary.increaseLikeCount();
+    }
+
+    public void decreaseLike(Diary diary) {
+        diary.decreaseLikeCount();
+    }
+
 }

--- a/hilingual-domain/src/main/java/org/sopt/feedalarm/domain/FeedAlarm.java
+++ b/hilingual-domain/src/main/java/org/sopt/feedalarm/domain/FeedAlarm.java
@@ -70,4 +70,17 @@ public class FeedAlarm extends BaseTimeEntity {
         );
     }
 
+    public static FeedAlarm createLikeDiary(User targetUser, Long diaryId, Long actorId, String title) {
+        return new FeedAlarm(
+                null,
+                targetUser,
+                FeedAlarmType.LIKE_DIARY,
+                TargetType.DIARY,
+                diaryId,
+                actorId,
+                title,
+                null
+        );
+    }
+
 }

--- a/hilingual-domain/src/main/java/org/sopt/feedalarm/facade/FeedAlarmFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/feedalarm/facade/FeedAlarmFacade.java
@@ -1,11 +1,13 @@
 package org.sopt.feedalarm.facade;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.diary.domain.Diary;
 import org.sopt.feedalarm.domain.FeedAlarm;
 import org.sopt.user.domain.User;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 @Component
@@ -31,6 +33,40 @@ public class FeedAlarmFacade {
                 actor.getUserProfile().getNickname() + "님이 당신을 팔로우했습니다."
         );
         feedAlarmSaver.save(alarm);
+    }
+
+    @Transactional
+    public void createLikeDiaryAlarm(Diary targetDiary, User actor) {
+        final Long targetUserId = targetDiary.getUser().getId();
+        final Long actorId = actor.getId();
+
+        // 자기 글이면 알림 생성 X
+        if (targetUserId.equals(actorId)) {
+            return;
+        }
+
+        // 이미 동일 알림 있으면 생성 X
+        if (feedAlarmRetriever.existsLikeDiaryAlarm(targetUserId, actorId, targetDiary.getId())) {
+            return;
+        }
+
+        String dateStr = targetDiary.getWrittenDate()
+                .format(DateTimeFormatter.ofPattern("M월 d일"));
+        String title = actor.getUserProfile().getNickname()
+                + "님이 당신의 " + dateStr + " 일기에 공감했습니다.";
+
+        final FeedAlarm alarm = FeedAlarm.createLikeDiary(
+                targetDiary.getUser(),
+                targetDiary.getId(),
+                actorId,
+                title
+        );
+
+        try {
+            feedAlarmSaver.save(alarm);
+        } catch (org.springframework.dao.DataIntegrityViolationException e) {
+            // 동시성 환경에서 중복 insert 시 무시
+        }
     }
 
 }

--- a/hilingual-domain/src/main/java/org/sopt/feedalarm/facade/FeedAlarmRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/feedalarm/facade/FeedAlarmRetriever.java
@@ -5,6 +5,7 @@ import org.sopt.feedalarm.domain.FeedAlarm;
 import org.sopt.feedalarm.exception.FeedAlarmCoreErrorCode;
 import org.sopt.feedalarm.exception.FeedAlarmNotFoundException;
 import org.sopt.feedalarm.repository.FeedAlarmRepository;
+import org.sopt.feedalarm.type.FeedAlarmType;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,10 +24,17 @@ public class FeedAlarmRetriever {
         alarm.markAsRead();
     }
 
-
     // 최근 N개의 알림 조회
     @Transactional(readOnly = true)
     public List<FeedAlarm> findLatestByUserId(final long userId) {
         return feedAlarmRepository.findTop500ByUserIdOrderByCreatedAtDesc(userId);
     }
+
+    @Transactional(readOnly = true)
+    public boolean existsLikeDiaryAlarm(final long userId, final long actorId, final long targetId) {
+        return feedAlarmRepository.existsByUserIdAndActorIdAndTypeAndTargetId(
+                userId, actorId, FeedAlarmType.LIKE_DIARY, targetId
+        );
+    }
+
 }

--- a/hilingual-domain/src/main/java/org/sopt/feedalarm/repository/FeedAlarmRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/feedalarm/repository/FeedAlarmRepository.java
@@ -1,6 +1,7 @@
 package org.sopt.feedalarm.repository;
 
 import org.sopt.feedalarm.domain.FeedAlarm;
+import org.sopt.feedalarm.type.FeedAlarmType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -34,4 +35,9 @@ public interface FeedAlarmRepository extends JpaRepository<FeedAlarm, Long> {
           and r.rn > :limit
         """, nativeQuery = true)
     void deleteAllUsersBeyondLimit(@Param("limit") int limit);
+
+    boolean existsByUserIdAndActorIdAndTypeAndTargetId(
+            Long userId, Long actorId, FeedAlarmType type, Long targetId
+    );
+
 }

--- a/hilingual-domain/src/main/java/org/sopt/likeddiary/facade/LikedDiaryFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/likeddiary/facade/LikedDiaryFacade.java
@@ -1,8 +1,11 @@
 package org.sopt.likeddiary.facade;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.diary.domain.Diary;
 import org.sopt.likeddiary.domain.LikedDiary;
+import org.sopt.user.domain.User;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -11,6 +14,8 @@ import java.util.List;
 public class LikedDiaryFacade {
 
     private final LikedDiaryRetriever likedDiaryRetriever;
+    private final LikedDiarySaver likedDiarySaver;
+    private final LikedDiaryRemover likedDiaryRemover;
 
     public List<Long> findLikedDiaryIdsByUserIdAndDiaryIdsIn(Long userId, List<Long> diaryIds) {
         return likedDiaryRetriever.findLikedDiaryIdsByUserIdAndDiaryIdsIn(userId, diaryIds);
@@ -23,4 +28,17 @@ public class LikedDiaryFacade {
     public Boolean findUserAndDiaryExist(Long userId, Long diaryId) {
         return likedDiaryRetriever.findUserAndDiaryExist(userId, diaryId);
     }
+
+    @Transactional
+    public void like(User user, Diary diary) {
+        if (!findUserAndDiaryExist(user.getId(), diary.getId())) {
+            likedDiarySaver.save(LikedDiary.create(user, diary));
+        }
+    }
+
+    @Transactional
+    public void unlike(Long userId, Long diaryId) {
+        likedDiaryRemover.deleteByUserIdAndDiaryId(userId, diaryId);
+    }
+
 }

--- a/hilingual-domain/src/main/java/org/sopt/likeddiary/facade/LikedDiaryRemover.java
+++ b/hilingual-domain/src/main/java/org/sopt/likeddiary/facade/LikedDiaryRemover.java
@@ -1,0 +1,18 @@
+package org.sopt.likeddiary.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.likeddiary.repository.LikedDiaryRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class LikedDiaryRemover {
+    private final LikedDiaryRepository likedDiaryRepository;
+
+    @Transactional
+    public void deleteByUserIdAndDiaryId(Long userId, Long diaryId) {
+        likedDiaryRepository.deleteByUserIdAndDiaryId(userId, diaryId);
+    }
+
+}

--- a/hilingual-domain/src/main/java/org/sopt/likeddiary/facade/LikedDiarySaver.java
+++ b/hilingual-domain/src/main/java/org/sopt/likeddiary/facade/LikedDiarySaver.java
@@ -1,0 +1,19 @@
+package org.sopt.likeddiary.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.likeddiary.domain.LikedDiary;
+import org.sopt.likeddiary.repository.LikedDiaryRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class LikedDiarySaver {
+    private final LikedDiaryRepository likedDiaryRepository;
+
+    @Transactional
+    public LikedDiary save(LikedDiary entity) {
+        return likedDiaryRepository.save(entity);
+    }
+
+}

--- a/hilingual-domain/src/main/java/org/sopt/likeddiary/repository/LikedDiaryRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/likeddiary/repository/LikedDiaryRepository.java
@@ -35,4 +35,8 @@ public interface LikedDiaryRepository extends JpaRepository<LikedDiary, Long> {
 
     // 유저ID와 다이어리ID가 존재하는지 확인(isLiked 여부 확인을 위해)
     boolean existsByUserIdAndDiaryId(@Param("userId") Long userId, @Param("diaryId") Long diaryId);
+
+    // 해제
+    void deleteByUserIdAndDiaryId(Long userId, Long diaryId);
+
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #222 

## Work Description ✏️
- 읽기 권한 검증
  - 내 글이거나 공개 글만 좋아요 가능 (DiaryFacade.validateReadable)
- isLiked 카운트 업데이트
  - 좋아요 지정 시 +1, 해제 시 -1 (최소 0 유지)
- LikedDiary 저장/삭제 
  - 이미 좋아요 상태/ 해제 상태 에서 다시 true/false 요청 → 저장/삭제 안 함 (멱등)
- 알림(FeedAlarm) 생성
  - FEED 알림이 활성화된 사용자만 생성 (AlarmPreferenceFacade.isEnabled(userId, FEED))
  - 자기 글에 본인이 누른 좋아요는 알림 생성 안 함
  - 중복 방지: 동일 actor가 동일 일기에 대해 이미 LIKE_DIARY 알림이 존재하면 생성 안 함
  - 응답용 dto에서 targetId는 actor의 userId(나의 일기를 좋아요한 사람)로 설정 → 프로필 딥링크에 사용

## Screenshot 📸
| 설명 | 캡처 |
|:---:|:---:|
| 추천 피드 탭 | <img width="1960" height="1638" alt="image" src="https://github.com/user-attachments/assets/bce343ff-3801-4d10-91ac-809f342036de" /> | 
| 유저1의 FEED 알림은 **활성화** 상태 | <img width="1864" height="932" alt="image" src="https://github.com/user-attachments/assets/dced4f96-4c69-4402-8900-9e4bc51da6a3" /> | 
| 유저2가 유저1의 일기1번(피드)에 좋아요 | <img width="1848" height="1030" alt="image" src="https://github.com/user-attachments/assets/13f7dae5-3655-4ae8-afbf-771094fcdb26" /> | 
| 유저 1의 FEED 알림 탭 | <img width="1810" height="1272" alt="image" src="https://github.com/user-attachments/assets/815db668-9257-4a0b-9c16-2ddf2c55566e" /> | 
| 유저1의 FEED 알림은 **비활성화** 상태 | <img width="1858" height="932" alt="image" src="https://github.com/user-attachments/assets/43de98b6-fd10-43ce-aab5-b4b4b2427454" /> | 
| 누가 좋아요 눌러도 아무것도 없음 | <img width="1888" height="946" alt="image" src="https://github.com/user-attachments/assets/7a96a47d-f6f8-44b3-b724-c34367fef6b1" /> | 


## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
- 이후 Diary.isLiked 네이밍은 likeCount로 리팩 고려중. boolean 에 쓰는 네이밍으로 되어있어서 혼동의 여지가 있어요.
- 무한 스크롤 도입 시 알림 목록은 Pageable 전환 예정