### PR TITLE
[fix] #237 팔로우 등록 API에서 유저의 현재 알림 상태 확인해서 쏴주도록 수정

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/follow/service/FollowService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/follow/service/FollowService.java
@@ -2,6 +2,8 @@ package org.sopt.controller.follow.service;
 
 import lombok.RequiredArgsConstructor;
 
+import org.sopt.alarmpreference.facade.AlarmPreferenceFacade;
+import org.sopt.alarmpreference.type.AlarmType;
 import org.sopt.block.facade.BlockFacade;
 
 import org.sopt.controller.follow.dto.NewFollowInfoRes;
@@ -40,6 +42,7 @@ public class FollowService {
     private final BlockFacade blockFacade;
     private final UserProfileFacade userProfileFacade;
     private final FeedAlarmFacade feedAlarmFacade;
+    private final AlarmPreferenceFacade alarmPreferenceFacade;
 
     @Transactional
     public void follow(Long userId, Long targetUserId) {
@@ -60,7 +63,9 @@ public class FollowService {
         follower.getUserProfile().increaseFollowingCount();
         followee.getUserProfile().increaseFollowerCount();
 
-        feedAlarmFacade.createFollowAlarm(followee, follower);
+        if (alarmPreferenceFacade.isEnabled(followee.getId(), AlarmType.FEED)) {
+            feedAlarmFacade.createFollowAlarm(followee, follower);
+        }
     }
 
     @Transactional

--- a/hilingual-domain/src/main/java/org/sopt/feedalarm/domain/FeedAlarm.java
+++ b/hilingual-domain/src/main/java/org/sopt/feedalarm/domain/FeedAlarm.java
@@ -16,7 +16,15 @@ import java.time.LocalDateTime;
 import static org.sopt.feedalarm.domain.FeedAlarmTableConstants.*;
 
 @Entity
-@Table(name = TABLE_FEED_ALARM)
+@Table(
+        name = TABLE_FEED_ALARM,
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = UK_FEED_ALARM_FOLLOW,
+                        columnNames = {COLUMN_TYPE, COLUMN_TARGET_TYPE, COLUMN_ACTOR_ID}
+                )
+        }
+)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -57,19 +65,6 @@ public class FeedAlarm extends BaseTimeEntity {
         }
     }
 
-    public static FeedAlarm createFollowUser(User targetUser, Long actorId, String title) {
-        return new FeedAlarm(
-                null,
-                targetUser,
-                FeedAlarmType.FOLLOW_USER,
-                TargetType.USER,
-                actorId,
-                actorId,
-                title,
-                null
-        );
-    }
-
     public static FeedAlarm createLikeDiary(User targetUser, Long diaryId, Long actorId, String title) {
         return new FeedAlarm(
                 null,
@@ -83,4 +78,16 @@ public class FeedAlarm extends BaseTimeEntity {
         );
     }
 
+    public static FeedAlarm createFollow(User targetUser, Long actorId, String title) {
+        return new FeedAlarm(
+                null,
+                targetUser,                   // 알림 받는 유저
+                FeedAlarmType.FOLLOW_USER,    // 알림 타입
+                TargetType.USER,              // 타겟은 USER
+                actorId,
+                actorId,
+                title,
+                null
+        );
+    }
 }

--- a/hilingual-domain/src/main/java/org/sopt/feedalarm/domain/FeedAlarmTableConstants.java
+++ b/hilingual-domain/src/main/java/org/sopt/feedalarm/domain/FeedAlarmTableConstants.java
@@ -1,7 +1,11 @@
 package org.sopt.feedalarm.domain;
 
 public class FeedAlarmTableConstants {
+
+    // Table
     public static final String TABLE_FEED_ALARM = "feed_alarm";
+
+    // Columns
     public static final String COLUMN_ID = "id";
     public static final String COLUMN_USER_ID = "user_id";
     public static final String COLUMN_TYPE = "type";
@@ -10,5 +14,8 @@ public class FeedAlarmTableConstants {
     public static final String COLUMN_ACTOR_ID = "actor_id";
     public static final String COLUMN_TITLE = "title";
     public static final String COLUMN_READ_AT = "read_at";
+
+    // Constraints
+    public static final String UK_FEED_ALARM_FOLLOW = "uk_feed_alarm_follow_unique";
 
 }

--- a/hilingual-domain/src/main/java/org/sopt/feedalarm/facade/FeedAlarmFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/feedalarm/facade/FeedAlarmFacade.java
@@ -27,12 +27,22 @@ public class FeedAlarmFacade {
 
     @Transactional
     public void createFollowAlarm(User targetUser, User actor) {
-        FeedAlarm alarm = FeedAlarm.createFollowUser(
-                targetUser,
-                actor.getId(),       
-                actor.getUserProfile().getNickname() + "님이 당신을 팔로우했습니다."
-        );
-        feedAlarmSaver.save(alarm);
+        final Long targetUserId = targetUser.getId();
+        final Long actorId = actor.getId();
+
+        // 이미 동일 알림 있으면 생성 X
+        if (feedAlarmRetriever.existsFollowAlarm(targetUserId, actorId)) {
+            return;
+        }
+
+        final String title = actor.getUserProfile().getNickname() + "님이 당신을 팔로우했습니다.";
+        final FeedAlarm alarm = FeedAlarm.createFollow(targetUser, actorId, title);
+
+        try {
+            feedAlarmSaver.save(alarm);
+        } catch (org.springframework.dao.DataIntegrityViolationException ignore) {
+            // 동시성 환경에서 중복 insert 시 무시
+        }
     }
 
     @Transactional

--- a/hilingual-domain/src/main/java/org/sopt/feedalarm/facade/FeedAlarmRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/feedalarm/facade/FeedAlarmRetriever.java
@@ -6,6 +6,7 @@ import org.sopt.feedalarm.exception.FeedAlarmCoreErrorCode;
 import org.sopt.feedalarm.exception.FeedAlarmNotFoundException;
 import org.sopt.feedalarm.repository.FeedAlarmRepository;
 import org.sopt.feedalarm.type.FeedAlarmType;
+import org.sopt.feedalarm.type.TargetType;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,4 +38,10 @@ public class FeedAlarmRetriever {
         );
     }
 
+    @Transactional(readOnly = true)
+    public boolean existsFollowAlarm(final long userId, final long actorId) {
+        return feedAlarmRepository.existsByUserIdAndActorIdAndTypeAndTargetType(
+                userId, actorId, FeedAlarmType.FOLLOW_USER, TargetType.USER
+        );
+    }
 }

--- a/hilingual-domain/src/main/java/org/sopt/feedalarm/repository/FeedAlarmRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/feedalarm/repository/FeedAlarmRepository.java
@@ -2,6 +2,7 @@ package org.sopt.feedalarm.repository;
 
 import org.sopt.feedalarm.domain.FeedAlarm;
 import org.sopt.feedalarm.type.FeedAlarmType;
+import org.sopt.feedalarm.type.TargetType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -38,6 +39,10 @@ public interface FeedAlarmRepository extends JpaRepository<FeedAlarm, Long> {
 
     boolean existsByUserIdAndActorIdAndTypeAndTargetId(
             Long userId, Long actorId, FeedAlarmType type, Long targetId
+    );
+
+    boolean existsByUserIdAndActorIdAndTypeAndTargetType(
+            Long userId, Long actorId, FeedAlarmType type, TargetType targetType
     );
 
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #237 

## Work Description ✏️
- 알림 생성 전 `AlarmPreference(FEED)` 상태 확인하여 알림 허용 시에만 발송
- `FeedAlarm` 엔티티 유니크 제약 `(type, target_type, user_id, actor_id)` 적용

## Screenshot 📸
| 설명 | 캡처 |
|:---:|:---:|
| 유저2의 현재 알림 상태 (FEED = true) | <img width="1694" height="912" alt="image" src="https://github.com/user-attachments/assets/b138696e-93c5-4cbe-b63e-5b4e5c15d4f5" /> | 
| 유저1 → 유저2 팔로우 | <img width="1630" height="1040" alt="image" src="https://github.com/user-attachments/assets/db9144aa-f681-44ae-9c0f-7427bfde7657" /> | 
| 중복 요청 방지 | <img width="1644" height="1014" alt="image" src="https://github.com/user-attachments/assets/e71f6690-5244-4749-a8c2-a7a6407f30ad" /> | 
| 유저2의 FEED 알림 탭 | <img width="1656" height="1092" alt="image" src="https://github.com/user-attachments/assets/0f11ef10-ad02-4c75-8c8f-e3bba9f428f3" /> | 
| 유저2의 현재 알림 상태 (FEED = false) | <img width="1646" height="906" alt="image" src="https://github.com/user-attachments/assets/4d2f853a-ff05-460c-bb09-fd147680a735" /> | 
|위와 같은 과정 반복 후 유저2의 FEED 알림 탭 | <img width="1640" height="790" alt="image" src="https://github.com/user-attachments/assets/e3bae3db-b636-48f3-afa4-5ee68d0e74ae" /> | 


## Uncompleted Tasks 😅
현재는 유저가 **처음 팔로우할 때만** FeedAlarm 테이블에 알림이 생성됩니다.  
따라서 `user1 → user2` 팔로우 후 → 언팔로우 → 다시 팔로우 하는 경우, **기존 알림만 남고 새로운 알림은 쌓이지 않습니다.**

이 부분에 대해서는 기획과의 논의가 필요할 것 같습니다.
- 팔로우 이벤트가 발생할 때마다 **항상 새로운 알림을 생성**할 것인지,  
- 동일한 리소스(같은 유저)에 대한 이벤트라면 **기존 알림을 지우고 다시 생성**할 것인지

## To Reviewers 📢
팔로우 알림도 좋아요 알림과 동일한 패턴으로 중복 방지 및 알림 설정 반영 처리했습니다.