### PR TITLE
[fix] #240 피드 좋아요 지정 API/팔로우 등록 API : 최근 1분 내 동일 알림 중복 방지

### DIFF
--- a/hilingual-domain/src/main/java/org/sopt/feedalarm/domain/FeedAlarm.java
+++ b/hilingual-domain/src/main/java/org/sopt/feedalarm/domain/FeedAlarm.java
@@ -16,15 +16,7 @@ import java.time.LocalDateTime;
 import static org.sopt.feedalarm.domain.FeedAlarmTableConstants.*;
 
 @Entity
-@Table(
-        name = TABLE_FEED_ALARM,
-        uniqueConstraints = {
-                @UniqueConstraint(
-                        name = UK_FEED_ALARM_FOLLOW,
-                        columnNames = {COLUMN_TYPE, COLUMN_TARGET_TYPE, COLUMN_ACTOR_ID}
-                )
-        }
-)
+@Table(name = TABLE_FEED_ALARM)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -81,9 +73,9 @@ public class FeedAlarm extends BaseTimeEntity {
     public static FeedAlarm createFollow(User targetUser, Long actorId, String title) {
         return new FeedAlarm(
                 null,
-                targetUser,                   // 알림 받는 유저
-                FeedAlarmType.FOLLOW_USER,    // 알림 타입
-                TargetType.USER,              // 타겟은 USER
+                targetUser,
+                FeedAlarmType.FOLLOW_USER,
+                TargetType.USER,
                 actorId,
                 actorId,
                 title,

--- a/hilingual-domain/src/main/java/org/sopt/feedalarm/facade/FeedAlarmFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/feedalarm/facade/FeedAlarmFacade.java
@@ -31,7 +31,7 @@ public class FeedAlarmFacade {
         final Long actorId = actor.getId();
 
         // 이미 동일 알림 있으면 생성 X
-        if (feedAlarmRetriever.existsFollowAlarm(targetUserId, actorId)) {
+        if (feedAlarmRetriever.existsRecentFollowAlarm(targetUserId, actorId)) {
             return;
         }
 
@@ -55,8 +55,8 @@ public class FeedAlarmFacade {
             return;
         }
 
-        // 이미 동일 알림 있으면 생성 X
-        if (feedAlarmRetriever.existsLikeDiaryAlarm(targetUserId, actorId, targetDiary.getId())) {
+        // 최근 1분 내 동일 알림 존재 시 스킵
+        if (feedAlarmRetriever.existsRecentLikeDiaryAlarm(targetUserId, actorId, targetDiary.getId())) {
             return;
         }
 

--- a/hilingual-domain/src/main/java/org/sopt/feedalarm/facade/FeedAlarmRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/feedalarm/facade/FeedAlarmRetriever.java
@@ -6,10 +6,10 @@ import org.sopt.feedalarm.exception.FeedAlarmCoreErrorCode;
 import org.sopt.feedalarm.exception.FeedAlarmNotFoundException;
 import org.sopt.feedalarm.repository.FeedAlarmRepository;
 import org.sopt.feedalarm.type.FeedAlarmType;
-import org.sopt.feedalarm.type.TargetType;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Component
@@ -32,16 +32,18 @@ public class FeedAlarmRetriever {
     }
 
     @Transactional(readOnly = true)
-    public boolean existsLikeDiaryAlarm(final long userId, final long actorId, final long targetId) {
-        return feedAlarmRepository.existsByUserIdAndActorIdAndTypeAndTargetId(
-                userId, actorId, FeedAlarmType.LIKE_DIARY, targetId
+    public boolean existsRecentLikeDiaryAlarm(long userId, long actorId, long diaryId) {
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(1);
+        return feedAlarmRepository.existsRecentSameAlarm(
+                userId, actorId, FeedAlarmType.LIKE_DIARY, diaryId, threshold
         );
     }
 
     @Transactional(readOnly = true)
-    public boolean existsFollowAlarm(final long userId, final long actorId) {
-        return feedAlarmRepository.existsByUserIdAndActorIdAndTypeAndTargetType(
-                userId, actorId, FeedAlarmType.FOLLOW_USER, TargetType.USER
+    public boolean existsRecentFollowAlarm(long userId, long actorId) {
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(1);
+        return feedAlarmRepository.existsRecentSameAlarm(
+                userId, actorId, FeedAlarmType.FOLLOW_USER, actorId, threshold
         );
     }
 }

--- a/hilingual-domain/src/main/java/org/sopt/feedalarm/repository/FeedAlarmRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/feedalarm/repository/FeedAlarmRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -37,12 +38,22 @@ public interface FeedAlarmRepository extends JpaRepository<FeedAlarm, Long> {
         """, nativeQuery = true)
     void deleteAllUsersBeyondLimit(@Param("limit") int limit);
 
-    boolean existsByUserIdAndActorIdAndTypeAndTargetId(
-            Long userId, Long actorId, FeedAlarmType type, Long targetId
-    );
-
-    boolean existsByUserIdAndActorIdAndTypeAndTargetType(
-            Long userId, Long actorId, FeedAlarmType type, TargetType targetType
+    // 최근 1분 내 동일 알림 존재 여부 확인
+    @Query("""
+    select (count(a) > 0)
+    from FeedAlarm a
+    where a.user.id   = :userId
+      and a.actorId  = :actorId
+      and a.type     = :type
+      and a.targetId = :targetId
+      and a.createdAt >= :threshold
+""")
+    boolean existsRecentSameAlarm(
+            @Param("userId") Long userId,
+            @Param("actorId") Long actorId,
+            @Param("type") FeedAlarmType type,
+            @Param("targetId") Long targetId,  
+            @Param("threshold") LocalDateTime threshold
     );
 
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #240 

## Work Description ✏️
- 알림 생성 정책: 이벤트 발생 시 항상 알림 생성(단 최근 1분 내 동일 알림 존재 시 생성 스킵)
- 피드 좋아요 / 팔로우 알림 공통 로직화: (userId, actorId, type, targetId, createdAt>=now-1m)로 판별

## Uncompleted Tasks 😅
추후 인덱스 도입해서 속도 개선하면 좋을 것 같아요!

## To Reviewers 📢
N/A