### PR TITLE
[feat] 회원탈퇴 API 구현

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/auth/service/AuthService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/auth/service/AuthService.java
@@ -23,20 +23,16 @@ import org.sopt.jwt.auth.authentication.UserRole;
 import org.sopt.jwt.auth.domain.type.AuthProvider;
 import org.sopt.user.domain.User;
 import org.sopt.user.facade.UserFacade;
-import org.sopt.user.repository.UserRepository;
 import org.sopt.user.type.RegisterStatus;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
-import java.time.Instant;
+import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import java.util.*;
 
@@ -83,79 +79,31 @@ public class AuthService {
 
         // User 정보 Soft Delete
         User user = userFacade.getUserById(userId);
+
+        // User Provider Id 변경
+        String newProviderId = generateUniqueProviderId();
+        user.setProviderId(newProviderId);
         user.setIsDeleted(true);
         user.setDeletedAt(LocalDateTime.now());
         userFacade.save(user);
 
-        // 30일 후 실행되도록 스케줄링
-        Runnable unlinkTask = getUnlinkTask(userId);
-        Instant scheduledTime = Instant.now().plusSeconds(60);
-        taskScheduler.schedule(unlinkTask, scheduledTime);
-
         return null;
     }
 
-    private Runnable getUnlinkTask(final long userId) {
-        // User Provider에 따라 google unlink, apple unlink 스케줄링
-        return () -> {
-          try {
-              // Redis에 임시 보관된 토큰 정보 조회
-              String refreshToken = redisTemplate.opsForValue().get("unlink_token:" + userId);
-              String provider = redisTemplate.opsForValue().get("unlink_provider:" + userId);
+    private String generateUniqueProviderId() {
+        String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        SecureRandom random = new SecureRandom();
+        String generatedId;
 
-              switch (provider) {
-                  case "GOOGLE":
-                      googleUnlink(refreshToken);
-                      break;
-                  case "APPLE":
-                      appleUnlink(refreshToken);
-                      break;
-                  default:
-                      log.warn("유저 {}는 소셜 로그인 유저가 아닙니다.", userId);
-              }
+        do {
+            StringBuilder sb = new StringBuilder(50);
+            for (int i = 0; i < 50; i++) {
+                sb.append(characters.charAt(random.nextInt(characters.length())));
+            }
+            generatedId = sb.toString();
+        } while (userFacade.existsByProviderId(generatedId)); // DB에 이미 존재하는지 확인
 
-              // unlink 성공 시 DB에서 사용자 정보 삭제 및 저장해두었던 임시 RefreshToken 삭제
-              userFacade.deleteUserById(userId);
-              redisTemplate.delete("unlink_token:" + userId);
-              redisTemplate.delete("unlink_provider:" + userId);
-
-          } catch (Exception e) {
-              log.error("언링크 실패. 유저{}: {}", userId, e.getMessage(), e);
-          }
-        };
-    }
-
-    private void googleUnlink(String refreshToken) {
-        WebClient webClient = WebClient.builder().build();
-        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
-        formData.add("token", refreshToken);
-
-        webClient.post()
-                .uri("https://accounts.google.com/o/oauth2/revoke")
-                .body(BodyInserters.fromFormData(formData))
-                .retrieve()
-                .bodyToMono(Void.class)
-                .block();
-    }
-
-    private void appleUnlink(String refreshToken) {
-        String clientSecret = appleKeyService.makeClientSecretToken();
-
-        // revoke API에 전달할 폼 데이터
-        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
-        formData.add("client_id", appleKeyService.appleClientId);
-        formData.add("client_secret", clientSecret);
-        formData.add("token", refreshToken);
-        formData.add("token_type_hint", "refresh_token");
-
-        // Apple revoke api 호출
-        WebClient webClient = WebClient.builder().build();
-        webClient.post()
-                .uri("https://appleid.apple.com/auth/oauth2/v2/revoke")
-                .body(BodyInserters.fromFormData(formData))
-                .retrieve()
-                .bodyToMono(Void.class)
-                .block();
+        return generatedId;
     }
 
     private SocialLoginRes googleLogin(String providerToken, SocialLoginReq req) {

--- a/hilingual-domain/src/main/java/org/sopt/user/facade/UserFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/user/facade/UserFacade.java
@@ -33,4 +33,8 @@ public class UserFacade {
     public void deleteUserById(final long userId) {
         userRemover.deleteUserById(userId);
     }
+
+    public boolean existsByProviderId(final String providerId) {
+        return userRetriever.existsByProviderId(providerId);
+    }
 }

--- a/hilingual-domain/src/main/java/org/sopt/user/facade/UserRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/user/facade/UserRetriever.java
@@ -29,5 +29,9 @@ public class UserRetriever {
         return userRepository.findByIdWithLock(userId)
                 .orElseThrow(() -> new UserNotFoundException(UserCoreErrorCode.USER_NOT_FOUND));
     }
+
+    public boolean existsByProviderId(String providerId) {
+        return userRepository.existsByProviderId(providerId);
+    }
   
 }

--- a/hilingual-domain/src/main/java/org/sopt/user/repository/UserRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/user/repository/UserRepository.java
@@ -17,4 +17,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT u FROM User u WHERE u.id = :id")
     Optional<User> findByIdWithLock(@Param("id") Long userId);
+
+    boolean existsByProviderId(String providerId);
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #239 

## Work Description ✏️
- 언링크 작업이 불필요할 것 같아 언링크 없이 provider id를 자체 id로 수정
- 유저 정보 남겨둠(재사용은 불가함. 제약 대공사 이슈로 인해 이렇게 수정..)

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 회원탈퇴 API      |  <img width="421" height="467" alt="image" src="https://github.com/user-attachments/assets/2a28f5c8-5425-496c-8a30-0130efe52d42" /> |
| 숫자로만 이루어진 구글 provider id 토큰을 자체 id로 변경 | <img width="1115" height="95" alt="image" src="https://github.com/user-attachments/assets/4e5af1ac-6277-4dcf-8062-0b53b744686b" /> |

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A