### PR TITLE
[fix] #245 단어장에 1000개 이상 저장 시도 시 예외 처리 추가

### DIFF
--- a/hilingual-domain/src/main/java/org/sopt/voca/exception/VocaCoreErrorCode.java
+++ b/hilingual-domain/src/main/java/org/sopt/voca/exception/VocaCoreErrorCode.java
@@ -10,6 +10,9 @@ public enum VocaCoreErrorCode implements ErrorCode {
     // 400
     INVALID_SAVED_ROOT_TYPE(HttpStatus.BAD_REQUEST, 40421, "올바르지 않은 저장 경로입니다."),
 
+    // 403
+    VOCA_LIMIT_EXCEEDED(HttpStatus.FORBIDDEN, 40304, "단어장은 최대 1000개까지만 저장할 수 있습니다."),
+
     // 404
     VOCA_NOT_FOUND(HttpStatus.NOT_FOUND, 40404, "phraseId에 해당하는 단어가 없습니다");
 

--- a/hilingual-domain/src/main/java/org/sopt/voca/exception/VocaLimitExceededException.java
+++ b/hilingual-domain/src/main/java/org/sopt/voca/exception/VocaLimitExceededException.java
@@ -1,0 +1,15 @@
+package org.sopt.voca.exception;
+
+import org.sopt.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class VocaLimitExceededException extends VocaCoreException{
+    public VocaLimitExceededException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.CONFLICT;
+    }
+}

--- a/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaSaver.java
+++ b/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaSaver.java
@@ -5,6 +5,8 @@ import org.sopt.recommend.domain.Recommend;
 import org.sopt.user.domain.User;
 import org.sopt.voca.domain.Voca;
 import org.sopt.voca.domain.VocaTableConstants;
+import org.sopt.voca.exception.VocaCoreErrorCode;
+import org.sopt.voca.exception.VocaLimitExceededException;
 import org.sopt.voca.repository.VocaRepository;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
@@ -18,9 +20,19 @@ public class VocaSaver {
 
     private final VocaRepository vocaRepository;
 
+    private static final int MAX_VOCA_PER_USER = 1000;
+
     @Transactional
     public void saveIfNotExists(final User user, final Recommend recommend) {
-        if (vocaRepository.existsByUserIdAndRecommendId(user.getId(), recommend.getId())) return;
+        final Long userId = user.getId();
+        final Long recommendId = recommend.getId();
+
+        if (vocaRepository.existsByUserIdAndRecommendId(userId, recommendId)) return;
+
+        long current = vocaRepository.countByUserId(userId);
+        if (current >= MAX_VOCA_PER_USER) {
+            throw new VocaLimitExceededException(VocaCoreErrorCode.VOCA_LIMIT_EXCEEDED);
+        }
 
         final boolean mine = recommend.getDiary().getUser().getId().equals(user.getId());
         final String writtenFrom = mine

--- a/hilingual-domain/src/main/java/org/sopt/voca/repository/VocaRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/voca/repository/VocaRepository.java
@@ -14,6 +14,9 @@ public interface VocaRepository extends JpaRepository<Voca, Long> {
     // 존재 여부 (user.id + recommendId)
     boolean existsByUserIdAndRecommendId(Long userId, Long recommendId);
 
+    // 유저별 voca 저장 갯수
+    long countByUserId(Long userId);
+
     // 북마크 해제
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""


### PR DESCRIPTION
## Related issue 🛠
- closed #245

## Work Description ✏️
- 유저별 Voca 저장 개수 제한 로직 추가 (최대 1000개까지 허용, 1001번째부터 예외 발생)
- 테스트는 2개부터 예외 발생하도록 함 (recommendId = 6,7 저장 시도: 6성공/7실패)

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
|   2개부터 예외 발생      | <img width="922" height="404" alt="image" src="https://github.com/user-attachments/assets/d2093c51-a948-40f9-a6ae-b828d4c645db" />

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A