### PR TITLE
[feat] #247 공지 생성 API 구현

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/admin/api/AdminController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/admin/api/AdminController.java
@@ -1,0 +1,32 @@
+package org.sopt.controller.admin.api;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Response;
+import org.sopt.controller.admin.dto.NoticeCreateReq;
+import org.sopt.controller.admin.dto.NoticeCreateRes;
+import org.sopt.controller.admin.service.AdminNoticeService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin")
+public class AdminController {
+
+    private final AdminNoticeService adminNoticeService;
+
+    @PostMapping("/notices")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<NoticeCreateRes> create(
+            @Valid @RequestBody NoticeCreateReq req
+    ) {
+        return ResponseEntity.ok(adminNoticeService.create(req));
+    }
+
+}
+

--- a/hilingual-api/src/main/java/org/sopt/controller/admin/dto/NoticeCreateReq.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/admin/dto/NoticeCreateReq.java
@@ -1,0 +1,11 @@
+package org.sopt.controller.admin.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record NoticeCreateReq(
+        @NotBlank String category,               // "SYSTEM", "MARKETING"
+        @NotBlank @Size(max = 100) String title,
+        @NotBlank String content
+) {
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/admin/dto/NoticeCreateRes.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/admin/dto/NoticeCreateRes.java
@@ -1,0 +1,9 @@
+package org.sopt.controller.admin.dto;
+
+public record NoticeCreateRes(Long noticeId) {
+
+    public static NoticeCreateRes of(Long id) {
+        return new NoticeCreateRes(id);
+    }
+
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/admin/exception/AdminApiErrorCode.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/admin/exception/AdminApiErrorCode.java
@@ -1,0 +1,28 @@
+package org.sopt.controller.admin.exception;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum AdminApiErrorCode implements ErrorCode {
+
+    // 400
+    INVALID_CATEGORY(HttpStatus.BAD_REQUEST, 40032, "유효하지 않은 공지 카테고리입니다."),
+
+    // 403
+    FORBIDDEN_ADMIN(HttpStatus.FORBIDDEN, 40305, "관리자 권한이 필요합니다.");
+
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() { return httpStatus; }
+
+    @Override
+    public int getCode() { return code; }
+
+    @Override
+    public String getMessage() { return message; }
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/admin/exception/AdminApiException.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/admin/exception/AdminApiException.java
@@ -1,0 +1,10 @@
+package org.sopt.controller.admin.exception;
+
+import org.sopt.exception.base.HilingualBaseException;
+import org.sopt.exception.code.ErrorCode;
+
+public abstract class AdminApiException extends HilingualBaseException {
+    public AdminApiException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/admin/exception/NoticeBadRequestException.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/admin/exception/NoticeBadRequestException.java
@@ -1,0 +1,15 @@
+package org.sopt.controller.admin.exception;
+
+import org.sopt.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class NoticeBadRequestException extends AdminApiException{
+    public NoticeBadRequestException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/admin/service/AdminNoticeService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/admin/service/AdminNoticeService.java
@@ -1,0 +1,38 @@
+package org.sopt.controller.admin.service;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.coyote.BadRequestException;
+import org.sopt.controller.admin.dto.NoticeCreateReq;
+import org.sopt.controller.admin.dto.NoticeCreateRes;
+import org.sopt.controller.admin.exception.AdminApiErrorCode;
+import org.sopt.controller.admin.exception.NoticeBadRequestException;
+import org.sopt.notice.domain.Notice;
+import org.sopt.notice.repository.NoticeRepository;
+import org.sopt.notice.type.Category;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Locale;
+
+@Service
+@RequiredArgsConstructor
+public class AdminNoticeService {
+
+    private final NoticeRepository noticeRepository;
+
+    @Transactional
+    @PreAuthorize("hasRole('ADMIN')")
+    public NoticeCreateRes create(NoticeCreateReq req) {
+        Category category;
+        try {
+            category = Category.valueOf(req.category().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new NoticeBadRequestException(AdminApiErrorCode.INVALID_CATEGORY);
+        }
+
+        Notice notice = Notice.create(category, req.title().trim(), req.content().trim());
+        Notice saved = noticeRepository.save(notice);
+        return NoticeCreateRes.of(saved.getId());
+    }
+}

--- a/hilingual-api/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
+++ b/hilingual-api/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
@@ -2,12 +2,15 @@ package org.sopt.exception;
 
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
+import org.sopt.controller.admin.exception.AdminApiErrorCode;
 import org.sopt.exception.base.HilingualBaseException;
 import org.sopt.dto.BaseResponseDto;
 import org.sopt.exception.code.ErrorCode;
 import org.sopt.exception.code.GlobalErrorCode;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -113,6 +116,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(GlobalErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
                 .body(BaseResponseDto.fail(GlobalErrorCode.INTERNAL_SERVER_ERROR));
+    }
+
+    @ExceptionHandler(AuthorizationDeniedException.class)
+    public ResponseEntity<BaseResponseDto<Void>> handleAuthorizationDenied(AuthorizationDeniedException e) {
+        log.warn("[AuthorizationDeniedException] {}", e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(BaseResponseDto.fail(AdminApiErrorCode.FORBIDDEN_ADMIN));
     }
 
 }

--- a/hilingual-domain/src/main/java/org/sopt/notice/domain/Notice.java
+++ b/hilingual-domain/src/main/java/org/sopt/notice/domain/Notice.java
@@ -31,9 +31,19 @@ public class Notice extends BaseTimeEntity {
     private String title;
 
     @Column(name = COLUMN_IS_ACTIVE, nullable = false)
-    private Boolean isActive;
+    private Boolean isActive; // 공지 내릴 때 사용
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = COLUMN_NOTICE_DETAIL_ID, nullable = false)
     private NoticeDetail noticeDetail;
+
+    public static Notice create(Category category, String title, String content) {
+        return new Notice(
+                null,
+                category,
+                title,
+                true,
+                NoticeDetail.create(content)
+        );
+    }
 }

--- a/hilingual-domain/src/main/java/org/sopt/notice/repository/NoticeRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/notice/repository/NoticeRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.notice.repository;
+
+import org.sopt.notice.domain.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+}

--- a/hilingual-domain/src/main/java/org/sopt/notice/type/Category.java
+++ b/hilingual-domain/src/main/java/org/sopt/notice/type/Category.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 @Getter
 @AllArgsConstructor
 public enum Category {
-    NOTIFICATION(1),
+    SYSTEM(1),
     MARKETING(2);
 
     private final int code;

--- a/hilingual-domain/src/main/java/org/sopt/noticedetail/domain/NoticeDetail.java
+++ b/hilingual-domain/src/main/java/org/sopt/noticedetail/domain/NoticeDetail.java
@@ -20,4 +20,8 @@ public class NoticeDetail {
 
     @Column(name = NoticeDetailTableConstants.COLUMN_CONTENT, nullable = false, columnDefinition = "TEXT")
     private String content;
+
+    public static NoticeDetail create(String content) {
+        return new NoticeDetail(null, content);
+    }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #247 

## Work Description ✏️
- Admin 권한으로 공지 생성 API 구현
- 공지 생성 시 category 문자열 → enum 변환 및 검증 처리
- Notice / NoticeDetail 엔티티 생성 및 cascade 저장 처리
- 잘못된 category 값일 경우 커스텀 예외(`NoticeBadRequestException`) 반환
- GlobalExceptionHandler에서 Authentication/Authorization 예외 처리 추가

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
|   Admin 권한으로 공지 생성 성공   | <img width="1880" height="990" alt="image" src="https://github.com/user-attachments/assets/3754c51d-4f51-46cf-92e7-3a385e534d9f" /> |
|   Admin 권한 없는 요청 시 403   | <img width="1862" height="1052" alt="image" src="https://github.com/user-attachments/assets/8fec4544-f2f1-47d3-8761-d68dc3c09a30" /> |

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A