### PR TITLE
[feat] #248 공지 발송 API 구현

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/admin/api/AdminController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/admin/api/AdminController.java
@@ -2,16 +2,12 @@ package org.sopt.controller.admin.api;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.Response;
 import org.sopt.controller.admin.dto.NoticeCreateReq;
 import org.sopt.controller.admin.dto.NoticeCreateRes;
 import org.sopt.controller.admin.service.AdminNoticeService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,13 +16,21 @@ public class AdminController {
 
     private final AdminNoticeService adminNoticeService;
 
-    @PostMapping("/notices")
     @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/notices")
     public ResponseEntity<NoticeCreateRes> create(
             @Valid @RequestBody NoticeCreateReq req
     ) {
         return ResponseEntity.ok(adminNoticeService.create(req));
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/notices/{noticeId}/delivery")
+    public ResponseEntity<Void> deliver(
+            @PathVariable Long noticeId
+    ) {
+        adminNoticeService.deliver(noticeId);
+        return ResponseEntity.ok().build();
+    }
 }
 

--- a/hilingual-api/src/main/java/org/sopt/controller/admin/service/AdminNoticeService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/admin/service/AdminNoticeService.java
@@ -1,18 +1,32 @@
 package org.sopt.controller.admin.service;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.BadRequestException;
+import org.sopt.alarmpreference.repository.AlarmPreferenceRepository;
+import org.sopt.alarmpreference.type.AlarmType;
 import org.sopt.controller.admin.dto.NoticeCreateReq;
 import org.sopt.controller.admin.dto.NoticeCreateRes;
 import org.sopt.controller.admin.exception.AdminApiErrorCode;
 import org.sopt.controller.admin.exception.NoticeBadRequestException;
 import org.sopt.notice.domain.Notice;
+import org.sopt.notice.exception.NoticeCoreErrorCode;
+import org.sopt.notice.exception.NoticeInactiveException;
 import org.sopt.notice.repository.NoticeRepository;
 import org.sopt.notice.type.Category;
+import org.sopt.noticedelivery.domain.NoticeDelivery;
+import org.sopt.noticedelivery.domain.NoticeDeliveryTableConstants;
+import org.sopt.noticedelivery.exception.NoticeAlreadyDeliveredException;
+import org.sopt.noticedelivery.exception.NoticeDeliveryCoreErrorCode;
+import org.sopt.noticedelivery.exception.NoticeNotFoundException;
+import org.sopt.noticedelivery.repository.NoticeDeliveryRepository;
+import org.sopt.user.domain.User;
+import org.sopt.user.repository.UserRepository;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Locale;
 
 @Service
@@ -20,6 +34,11 @@ import java.util.Locale;
 public class AdminNoticeService {
 
     private final NoticeRepository noticeRepository;
+    private final UserRepository userRepository;
+    private final AlarmPreferenceRepository alarmPreferenceRepository;
+    private final NoticeDeliveryRepository noticeDeliveryRepository;
+
+    private static final int BATCH_SIZE = 500;
 
     @Transactional
     @PreAuthorize("hasRole('ADMIN')")
@@ -35,4 +54,57 @@ public class AdminNoticeService {
         Notice saved = noticeRepository.save(notice);
         return NoticeCreateRes.of(saved.getId());
     }
+
+    @Transactional
+    @PreAuthorize("hasRole('ADMIN')")
+    public void deliver(Long noticeId) {
+        // 공지 확인
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new NoticeNotFoundException(NoticeCoreErrorCode.NOTICE_NOT_FOUND));
+
+        // 비활성 공지면 발송 X
+        if (Boolean.FALSE.equals(notice.getIsActive())) {
+            throw new NoticeInactiveException(NoticeCoreErrorCode.NOTICE_INACTIVE);
+        }
+
+        // 이미 발송된 공지는 재발송 X
+        if (noticeDeliveryRepository.existsByNoticeId(noticeId)) {
+            throw new NoticeAlreadyDeliveredException(NoticeDeliveryCoreErrorCode.NOTICE_ALREADY_DELIVERED);
+        }
+
+        // 발송 대상 유저 식별
+        List<Long> targetUserIds = switch (notice.getCategory()) {
+            case SYSTEM -> userRepository.findAllActiveUserIds();
+            case MARKETING -> alarmPreferenceRepository.findEnabledUserIdsByType(AlarmType.MARKETING);
+        };
+
+        if (targetUserIds.isEmpty()) {
+            return; // 발송 대상 없음 → 바로 종료
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+
+        for (int i = 0; i < targetUserIds.size(); i += BATCH_SIZE) {
+            int end = Math.min(i + BATCH_SIZE, targetUserIds.size());
+            List<Long> batch = targetUserIds.subList(i, end);
+
+            List<NoticeDelivery> rows = batch.stream()
+                    .map(uid -> NoticeDelivery.create(notice, User.ref(uid), now))
+                    .toList();
+
+            try {
+                noticeDeliveryRepository.saveAll(rows);
+            } catch (DataIntegrityViolationException e) {
+                if (isUniqueViolation(e, NoticeDeliveryTableConstants.UK_NOTICE_DELIVERY_NOTICE_USER)) continue;
+                throw e;
+            }
+        }
+    }
+
+    private boolean isUniqueViolation(DataIntegrityViolationException e, String constraintName) {
+        Throwable cause = e.getMostSpecificCause();
+        String msg = (cause != null ? cause.getMessage() : null);
+        return msg != null && msg.contains(constraintName);
+    }
+
 }

--- a/hilingual-domain/src/main/java/org/sopt/alarmpreference/repository/AlarmPreferenceRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/alarmpreference/repository/AlarmPreferenceRepository.java
@@ -3,6 +3,7 @@ package org.sopt.alarmpreference.repository;
 import org.sopt.alarmpreference.domain.AlarmPreference;
 import org.sopt.alarmpreference.type.AlarmType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,5 +15,15 @@ public interface AlarmPreferenceRepository extends JpaRepository<AlarmPreference
 
     // 특정 유저의 특정 알림 타입 설정을 조회
     Optional<AlarmPreference> findByUserIdAndAlarmType(Long userId, AlarmType alarmType);
+
+
+    // 특정 알림 타입이 '활성화'된 유저 id만 조회
+    @Query("""
+           select ap.user.id
+             from AlarmPreference ap
+            where ap.alarmType = :alarmType
+              and ap.isEnabled = true
+           """)
+    List<Long> findEnabledUserIdsByType(AlarmType alarmType);
 
 }

--- a/hilingual-domain/src/main/java/org/sopt/notice/exception/NoticeCoreErrorCode.java
+++ b/hilingual-domain/src/main/java/org/sopt/notice/exception/NoticeCoreErrorCode.java
@@ -8,7 +8,11 @@ import org.springframework.http.HttpStatus;
 public enum NoticeCoreErrorCode implements ErrorCode {
 
     // 400
-    INVALID_CATEGORY_TYPE(HttpStatus.BAD_REQUEST, 40020, "올바르지 않은 카테고리 타입입니다.")
+    INVALID_CATEGORY_TYPE(HttpStatus.BAD_REQUEST, 40020, "올바르지 않은 카테고리 타입입니다."),
+    NOTICE_INACTIVE(HttpStatus.BAD_REQUEST, 40033, "비활성화된 공지입니다."),
+
+    // 404
+    NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, 40410,"id에 해당하는 공지가 존재하지 않습니다.")
     ;
 
     public final HttpStatus httpStatus;

--- a/hilingual-domain/src/main/java/org/sopt/notice/exception/NoticeInactiveException.java
+++ b/hilingual-domain/src/main/java/org/sopt/notice/exception/NoticeInactiveException.java
@@ -1,0 +1,15 @@
+package org.sopt.notice.exception;
+
+import org.sopt.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class NoticeInactiveException extends NoticeCoreException{
+    public NoticeInactiveException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/hilingual-domain/src/main/java/org/sopt/noticedelivery/domain/NoticeDelivery.java
+++ b/hilingual-domain/src/main/java/org/sopt/noticedelivery/domain/NoticeDelivery.java
@@ -9,9 +9,21 @@ import org.sopt.notice.domain.Notice;
 import org.sopt.user.domain.User;
 
 import java.time.LocalDateTime;
+import static org.sopt.noticedelivery.domain.NoticeDeliveryTableConstants.*;
 
 @Entity
-@Table(name = NoticeDeliveryTableConstants.TABLE_NOTICE_DELIVERY)
+@Table(
+        name = NoticeDeliveryTableConstants.TABLE_NOTICE_DELIVERY,
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = UK_NOTICE_DELIVERY_NOTICE_USER,
+                        columnNames = {
+                                COLUMN_NOTICE_ID,
+                                COLUMN_USER_ID
+                        }
+                )
+        }
+)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -19,27 +31,31 @@ public class NoticeDelivery {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = NoticeDeliveryTableConstants.COLUMN_ID)
+    @Column(name = COLUMN_ID)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = NoticeDeliveryTableConstants.COLUMN_NOTICE_ID, nullable = false)
+    @JoinColumn(name = COLUMN_NOTICE_ID, nullable = false)
     private Notice notice;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = NoticeDeliveryTableConstants.COLUMN_USER_ID, nullable = false)
+    @JoinColumn(name = COLUMN_USER_ID, nullable = false)
     private User user;
 
-    @Column(name = NoticeDeliveryTableConstants.COLUMN_DELIVERED_AT, nullable = false)
+    @Column(name = COLUMN_DELIVERED_AT, nullable = false)
     private LocalDateTime deliveredAt;
 
-    @Column(name = NoticeDeliveryTableConstants.COLUMN_READ_AT)
+    @Column(name = COLUMN_READ_AT)
     private LocalDateTime readAt;
 
     public void markReadIfNeeded(LocalDateTime now) {
         if (this.readAt == null) {
             this.readAt = now;
         }
+    }
+
+    public static NoticeDelivery create(Notice notice, User user, LocalDateTime deliveredAt) {
+        return new NoticeDelivery(null, notice, user, deliveredAt, null);
     }
 
 }

--- a/hilingual-domain/src/main/java/org/sopt/noticedelivery/domain/NoticeDeliveryTableConstants.java
+++ b/hilingual-domain/src/main/java/org/sopt/noticedelivery/domain/NoticeDeliveryTableConstants.java
@@ -7,4 +7,7 @@ public class NoticeDeliveryTableConstants {
     public static final String COLUMN_USER_ID = "user_id";
     public static final String COLUMN_DELIVERED_AT = "delivered_at";
     public static final String COLUMN_READ_AT = "read_at";
+
+    // Unique Constraints
+    public static final String UK_NOTICE_DELIVERY_NOTICE_USER = "uk_notice_delivery_notice_user";
 }

--- a/hilingual-domain/src/main/java/org/sopt/noticedelivery/exception/NoticeAlreadyDeliveredException.java
+++ b/hilingual-domain/src/main/java/org/sopt/noticedelivery/exception/NoticeAlreadyDeliveredException.java
@@ -1,0 +1,15 @@
+package org.sopt.noticedelivery.exception;
+
+import org.sopt.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class NoticeAlreadyDeliveredException extends NoticeDeliveryCoreException{
+    public NoticeAlreadyDeliveredException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.CONFLICT;
+    }
+}

--- a/hilingual-domain/src/main/java/org/sopt/noticedelivery/exception/NoticeDeliveryCoreErrorCode.java
+++ b/hilingual-domain/src/main/java/org/sopt/noticedelivery/exception/NoticeDeliveryCoreErrorCode.java
@@ -5,8 +5,13 @@ import org.sopt.exception.code.ErrorCode;
 import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
-public enum NoticeDeliveryErrorCode implements ErrorCode {
-    NOTICE_DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, 40499, "해당 공지는 존재하지 않거나 이 유저에게 발송되지 않았습니다."),
+public enum NoticeDeliveryCoreErrorCode implements ErrorCode {
+
+    // 404
+    NOTICE_DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, 40411, "해당 공지는 존재하지 않거나 이 유저에게 발송되지 않았습니다."),
+
+    // 409
+    NOTICE_ALREADY_DELIVERED(HttpStatus.CONFLICT, 40905, "이미 발송된 공지입니다.");
     ;
 
     public final HttpStatus httpStatus;

--- a/hilingual-domain/src/main/java/org/sopt/noticedelivery/exception/NoticeNotFoundException.java
+++ b/hilingual-domain/src/main/java/org/sopt/noticedelivery/exception/NoticeNotFoundException.java
@@ -1,0 +1,15 @@
+package org.sopt.noticedelivery.exception;
+
+import org.sopt.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class NoticeNotFoundException extends NoticeDeliveryCoreException{
+    public NoticeNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.NOT_FOUND;
+    }
+}

--- a/hilingual-domain/src/main/java/org/sopt/noticedelivery/facade/NoticeDeliveryRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/noticedelivery/facade/NoticeDeliveryRetriever.java
@@ -2,7 +2,7 @@ package org.sopt.noticedelivery.facade;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.noticedelivery.domain.NoticeDelivery;
-import org.sopt.noticedelivery.exception.NoticeDeliveryErrorCode;
+import org.sopt.noticedelivery.exception.NoticeDeliveryCoreErrorCode;
 import org.sopt.noticedelivery.exception.NoticeDeliveryNoFoundException;
 import org.sopt.noticedelivery.repository.NoticeDeliveryRepository;
 import org.springframework.stereotype.Component;
@@ -18,7 +18,7 @@ public class NoticeDeliveryRetriever {
 
     public NoticeDelivery findByUserIdAndNoticeIdWithDetail(final long userId, final long noticeId){
         return noticeDeliveryRepository.findByUserIdAndNoticeIdWithDetail(userId, noticeId)
-                .orElseThrow(() -> new NoticeDeliveryNoFoundException(NoticeDeliveryErrorCode.NOTICE_DELIVERY_NOT_FOUND));
+                .orElseThrow(() -> new NoticeDeliveryNoFoundException(NoticeDeliveryCoreErrorCode.NOTICE_DELIVERY_NOT_FOUND));
     }
 
     @Transactional(readOnly = true)

--- a/hilingual-domain/src/main/java/org/sopt/noticedelivery/repository/NoticeDeliveryRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/noticedelivery/repository/NoticeDeliveryRepository.java
@@ -46,4 +46,7 @@ public interface NoticeDeliveryRepository extends JpaRepository<NoticeDelivery, 
           and r.rn > :limit
         """, nativeQuery = true)
     void deleteAllUsersBeyondLimit(@Param("limit") int limit);
+
+    // 전체 공지 재발송 여부 체크용
+    boolean existsByNoticeId(Long noticeId);
 }

--- a/hilingual-domain/src/main/java/org/sopt/user/domain/User.java
+++ b/hilingual-domain/src/main/java/org/sopt/user/domain/User.java
@@ -75,4 +75,10 @@ public class User extends BaseTimeEntity {
     public void revertDeleteUser() {
         this.isDeleted = false;
     }
+
+    public static User ref(Long id) {
+        User u = new User();
+        u.id = id;
+        return u;
+    }
 }

--- a/hilingual-domain/src/main/java/org/sopt/user/repository/UserRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/user/repository/UserRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -19,4 +20,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByIdWithLock(@Param("id") Long userId);
 
     boolean existsByProviderId(String providerId);
+
+    // 탈퇴/삭제된 계정 제외 전체 유저 id
+    @Query("select u.id from User u where u.isDeleted = false")
+    List<Long> findAllActiveUserIds();
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #248 

## Work Description ✏️
- 관리자 권한(ROLE_ADMIN)에서만 호출 가능하도록 설정.  ￼
- 발송 전 검증 로직:
  - 공지 존재 여부 확인 → 없으면 NoticeNotFoundException 발생.  ￼
  - 비활성 공지면 발송 불가 → NoticeInactiveException.  ￼
  - 이미 발송된 공지면 재발송 불가 → NoticeAlreadyDeliveredException.  ￼
- 대상 유저 집합 
  - SYSTEM : 탈퇴/삭제 제외 전체 활성 유저 ID 조회(UserRepository.findAllActiveUserIds)
  - MARKETING : 마케팅 알림 동의 유저 ID 조회(AlarmPreferenceRepository.findEnabledUserIdsByType)  ￼

## Screenshot 📸
| 설명 | 캡처 |
|:---:|:---:|
| (case1) 유저2(USER)의 현재 알림 상태 | <img width="1672" height="1076" alt="image" src="https://github.com/user-attachments/assets/b5b4ce92-3294-4525-a76b-3ea7529a3fb2" /> |
| ADMIN이 SYSTEM 공지 발송 | <img width="1628" height="880" alt="image" src="https://github.com/user-attachments/assets/446e8b65-6935-436c-9b9c-ff0446a58d13" /> |
| 마케팅이 false여도 system 공지는 항상 발송! | <img width="1648" height="1248" alt="image" src="https://github.com/user-attachments/assets/694b84ff-85fd-4999-8c9a-0875bb79330a" /> |
| ADMIN이 MARKETING 공지 발송 | <img width="1632" height="878" alt="image" src="https://github.com/user-attachments/assets/1bcb86cc-8e48-49d5-86c4-e7fe2a5590db" /> |
| 마케팅이 false 이므로 안받은거 확인 가능 | <img width="1648" height="1228" alt="image" src="https://github.com/user-attachments/assets/ca153b09-12d7-4181-a654-8e156373715a" /> |
| (case2) 유저2(USER)의 현재 알림 상태 | <img width="1634" height="1054" alt="image" src="https://github.com/user-attachments/assets/847b9aad-7683-4ee5-a56c-7ab63652f67a" /> |
| 마케팅이 true 이므로 받은거 확인 가능 | <img width="1644" height="1240" alt="image" src="https://github.com/user-attachments/assets/6036fff3-984f-4c6e-b221-6cf33e6f641e" /> |
| 이미 발송된 공지는 예외 | <img width="1636" height="918" alt="image" src="https://github.com/user-attachments/assets/2164befe-b2bc-40d0-8264-01e735460a52" /> |

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A