### PR TITLE
[fix] #253 일기 비공개하기 API 호출 시 해당 일기 공감한 유저들 찾아서 LikedDiary DB에서 삭제해주는 로직 추가

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/diary/service/DiaryService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/diary/service/DiaryService.java
@@ -16,6 +16,7 @@ import org.sopt.diaryfeedback.domain.DiaryFeedback;
 import org.sopt.controller.diaryfeedback.service.DiaryFeedbackService;
 import org.sopt.diaryfeedback.diff.service.DiaryDiffService;
 import org.sopt.diaryfeedback.diff.prompt.DiaryFeedbackPrompt;
+import org.sopt.likeddiary.facade.LikedDiaryFacade;
 import org.sopt.openai.OpenAIService;
 import org.sopt.openai.dto.res.GptFeedbackResponse;
 import org.sopt.recommend.domain.Recommend;
@@ -37,6 +38,7 @@ public class DiaryService {
 
     private final UserFacade userFacade;
     private final DiaryFacade diaryFacade;
+    private final LikedDiaryFacade likedDiaryFacade;
     private final OpenAIService openAiService;
     private final DiaryFeedbackService diaryFeedbackService;
     private final RecommendService recommendService;
@@ -149,6 +151,8 @@ public class DiaryService {
     public void unpublishDiary(final Long userId, final Long diaryId) {
         diaryFacade.validateDiaryOwnership(userId, diaryId);
         diaryFacade.unpublish(userId, diaryId);
+
+        likedDiaryFacade.unlikeAllOfDiary(diaryId);
 
     }
 }

--- a/hilingual-domain/src/main/java/org/sopt/likeddiary/facade/LikedDiaryFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/likeddiary/facade/LikedDiaryFacade.java
@@ -41,4 +41,9 @@ public class LikedDiaryFacade {
         likedDiaryRemover.deleteByUserIdAndDiaryId(userId, diaryId);
     }
 
+    @Transactional
+    public void unlikeAllOfDiary(Long diaryId) {
+        likedDiaryRemover.deleteByDiaryId(diaryId);
+    }
+
 }

--- a/hilingual-domain/src/main/java/org/sopt/likeddiary/facade/LikedDiaryRemover.java
+++ b/hilingual-domain/src/main/java/org/sopt/likeddiary/facade/LikedDiaryRemover.java
@@ -11,8 +11,13 @@ public class LikedDiaryRemover {
     private final LikedDiaryRepository likedDiaryRepository;
 
     @Transactional
-    public void deleteByUserIdAndDiaryId(Long userId, Long diaryId) {
+    public void deleteByUserIdAndDiaryId(final long userId, final long diaryId) {
         likedDiaryRepository.deleteByUserIdAndDiaryId(userId, diaryId);
+    }
+
+    @Transactional
+    public void deleteByDiaryId(final long diaryId){
+        likedDiaryRepository.deleteByDiaryId(diaryId);
     }
 
 }

--- a/hilingual-domain/src/main/java/org/sopt/likeddiary/repository/LikedDiaryRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/likeddiary/repository/LikedDiaryRepository.java
@@ -2,6 +2,7 @@ package org.sopt.likeddiary.repository;
 
 import org.sopt.likeddiary.domain.LikedDiary;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -38,5 +39,11 @@ public interface LikedDiaryRepository extends JpaRepository<LikedDiary, Long> {
 
     // 해제
     void deleteByUserIdAndDiaryId(Long userId, Long diaryId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete from LikedDiary ld where ld.diary.id = :diaryId
+            """)
+    void deleteByDiaryId(@Param("diaryId") Long diaryId);
 
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #253 

## Work Description ✏️
- unpublishDiary 메서드에서 다이어리 비공개 처리 시 LikedDiaryFacade 호출 추가
  - 해당 다이어리를 공감한 모든 LikedDiary 레코드를 일괄 삭제하도록 로직 반영
  - deleteByDiaryId(Long diaryId) 메서드 추가하여 특정 다이어리에 대한 공감 row 삭제

## Screenshot 📸
N/A

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A