### PR TITLE
[fix] #257 일기 삭제할 시 해당 날짜의 status를 DELETED 로 표기

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/diary/service/DiaryService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/diary/service/DiaryService.java
@@ -22,6 +22,7 @@ import org.sopt.openai.dto.res.GptFeedbackResponse;
 import org.sopt.recommend.domain.Recommend;
 import org.sopt.user.domain.User;
 import org.sopt.user.facade.UserFacade;
+import org.sopt.usercalendar.facade.UserCalendarFacade;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,6 +44,7 @@ public class DiaryService {
     private final DiaryFeedbackService diaryFeedbackService;
     private final RecommendService recommendService;
     private final DiaryDiffService diaryDiffService;
+    private final UserCalendarFacade userCalendarFacade;
 
     private final S3Service s3Service;
 
@@ -139,6 +141,7 @@ public class DiaryService {
         }
 
         diaryFacade.deleteDiary(userId, diaryId);
+        userCalendarFacade.markDeleted(userId, diary.getWrittenDate());
     }
 
     @Transactional

--- a/hilingual-domain/src/main/java/org/sopt/usercalendar/facade/UserCalendarFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/usercalendar/facade/UserCalendarFacade.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.diary.domain.Diary;
 import org.sopt.user.domain.User;
 import org.sopt.usercalendar.domain.UserCalendar;
-import org.sopt.usercalendar.dto.UserCalendarDiarySummaryRes;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +16,7 @@ public class UserCalendarFacade {
 
     private final UserCalendarRetriever userCalendarRetriever;
     private final UserCalendarSaver userCalendarSaver;
+    private final UserCalendarUpdater userCalendarUpdater;
 
     @Transactional
     public void markWrittenDate(User user, LocalDate writtenDate) {
@@ -37,6 +37,11 @@ public class UserCalendarFacade {
 
     public boolean existsByUserAndDate(User user, LocalDate date) {
         return userCalendarRetriever.existsByUserAndDate(user, date);
+    }
+
+    @Transactional
+    public void markDeleted(final Long userId, final LocalDate date) {
+        userCalendarUpdater.markDeleted(userId, date);
     }
 
 }

--- a/hilingual-domain/src/main/java/org/sopt/usercalendar/facade/UserCalendarSaver.java
+++ b/hilingual-domain/src/main/java/org/sopt/usercalendar/facade/UserCalendarSaver.java
@@ -5,6 +5,7 @@ import org.sopt.user.domain.User;
 import org.sopt.usercalendar.domain.UserCalendar;
 import org.sopt.usercalendar.domain.WriteStatus;
 import org.sopt.usercalendar.repository.UserCalendarRepository;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
@@ -17,6 +18,11 @@ public class UserCalendarSaver {
 
     public void save(User user, LocalDate writtenDate) {
         UserCalendar newCalendar = UserCalendar.create(writtenDate, WriteStatus.WRITTEN, user);
-        userCalendarRepository.save(newCalendar);
+        try {
+            userCalendarRepository.save(newCalendar);
+        } catch (DataIntegrityViolationException e) {
+            // 동시성 피하기
+        }
     }
+
 }

--- a/hilingual-domain/src/main/java/org/sopt/usercalendar/facade/UserCalendarUpdater.java
+++ b/hilingual-domain/src/main/java/org/sopt/usercalendar/facade/UserCalendarUpdater.java
@@ -1,0 +1,24 @@
+package org.sopt.usercalendar.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.usercalendar.domain.WriteStatus;
+import org.sopt.usercalendar.repository.UserCalendarRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Component
+@RequiredArgsConstructor
+public class UserCalendarUpdater {
+
+    private final UserCalendarRepository userCalendarRepository;
+
+    @Transactional
+    public void markDeleted(Long userId, LocalDate date) {
+        userCalendarRepository.updateStatusByUserAndDate(
+                userId, date, WriteStatus.DELETED
+        );
+    }
+
+}

--- a/hilingual-domain/src/main/java/org/sopt/usercalendar/repository/UserCalendarRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/usercalendar/repository/UserCalendarRepository.java
@@ -2,7 +2,9 @@ package org.sopt.usercalendar.repository;
 
 import org.sopt.user.domain.User;
 import org.sopt.usercalendar.domain.UserCalendar;
+import org.sopt.usercalendar.domain.WriteStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import java.time.LocalDate;
@@ -32,4 +34,15 @@ public interface UserCalendarRepository extends JpaRepository<UserCalendar, Long
             @Param("year")   int  year,
             @Param("month")  int  month
     );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        update UserCalendar uc
+           set uc.status = :status
+         where uc.user.id = :userId
+           and uc.date = :date
+    """)
+    int updateStatusByUserAndDate(@Param("userId") Long userId,
+                                  @Param("date") LocalDate date,
+                                  @Param("status") WriteStatus status);
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #257 

## Work Description ✏️
- UserCalendarRepository
  - `updateStatusByUserAndDate` 메서드 추가
  - 기존 row 있을 때만 DELETED로 업데이트

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
|        일기 삭제하기 API 호출 성공     | <img width="770" height="211" alt="image" src="https://github.com/user-attachments/assets/3e25117a-56cd-45a3-981b-a9afa8fdd842" /> |

## Uncompleted Tasks 😅
해당 DELETE 필드 사용해서 일기 재작성 불가능하도록 수정 부탁드립니다!

## To Reviewers 📢
N/A