### PR TITLE
[fix] #260 북마크 해제 후에도 단어 상세조회가 가능하게 수정

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/voca/dto/res/VocaDetailResponse.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/voca/dto/res/VocaDetailResponse.java
@@ -1,6 +1,6 @@
 package org.sopt.controller.voca.dto.res;
 
-import org.sopt.voca.domain.Voca;
+import org.sopt.recommend.domain.Recommend;
 import java.util.Arrays;
 import java.util.List;
 
@@ -12,14 +12,15 @@ public record VocaDetailResponse(
         String writtenFrom,
         Boolean isBookmarked
 ) {
-    public static VocaDetailResponse from(final Voca v) {
+
+    public static VocaDetailResponse of(Recommend r, boolean isBookmarked) {
         return new VocaDetailResponse(
-                v.getRecommendId(),
-                v.getPhrase(),
-                parsePhraseTypes(v.getPhraseType()),
-                v.getExplanation(),
-                v.getWrittenFrom(),
-                true
+                r.getId(),
+                r.getPhrase(),
+                parsePhraseTypes(r.getPhraseType()),
+                r.getExplanation(),
+                r.getReason(),
+                isBookmarked
         );
     }
 

--- a/hilingual-api/src/main/java/org/sopt/controller/voca/service/VocaService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/voca/service/VocaService.java
@@ -2,6 +2,8 @@ package org.sopt.controller.voca.service;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.controller.voca.dto.res.VocaDetailResponse;
+import org.sopt.recommend.domain.Recommend;
+import org.sopt.recommend.facade.RecommendRetriever;
 import org.sopt.voca.dto.VocaListRes;
 import org.sopt.controller.voca.dto.res.VocaSearchListResponse;
 import org.sopt.recommend.facade.RecommendFacade;
@@ -20,6 +22,7 @@ public class VocaService {
     private final VocaRetriever vocaRetriever;
     private final RecommendFacade recommendFacade;
     private final VocaFacade vocaFacade;
+    private final RecommendRetriever recommendRetriever;
 
 
     // 단어장 목록 조회
@@ -35,8 +38,9 @@ public class VocaService {
 
     // 특정 단어 세부 조회
     public VocaDetailResponse getVocaDetails(final Long userId, final Long phraseId) {
-        final Voca voca = vocaFacade.findDetailByUserIdAndPhraseId(userId, phraseId);
-        return VocaDetailResponse.from(voca);
+        final Recommend recommend = recommendFacade.findByIdWithDiary(phraseId);
+        final boolean isBookmarked = vocaFacade.existsByUserIdAndRecommendId(userId, phraseId);
+        return VocaDetailResponse.of(recommend, isBookmarked);
     }
 
 }

--- a/hilingual-domain/src/main/java/org/sopt/recommend/facade/RecommendFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/recommend/facade/RecommendFacade.java
@@ -18,16 +18,16 @@ public class RecommendFacade {
         recommendSaver.save(recommend);
     }
 
-    public List<Recommend> findByDiaryId(final long diaryId) {
-        return recommendRetriever.findByDiaryId(diaryId);
-    }
-
     public Recommend findById(final long phraseId) {
         return recommendRetriever.findById(phraseId);
     }
 
     public List<RecommendWithBookmarkDto> findWithBookmarkFlag(final long userId, final long diaryId) {
         return recommendRetriever.findWithBookmarkFlag(userId, diaryId);
+    }
+
+    public Recommend findByIdWithDiary(final long phraseId) {
+        return recommendRetriever.findByIdWithDiary(phraseId);
     }
 
 }

--- a/hilingual-domain/src/main/java/org/sopt/recommend/facade/RecommendRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/recommend/facade/RecommendRetriever.java
@@ -16,10 +16,6 @@ public class RecommendRetriever {
 
     private final RecommendRepository recommendRepository;
 
-    public List<Recommend> findByDiaryId(final long diaryId){
-        return recommendRepository.findByDiaryId(diaryId);
-    }
-
     public Recommend findById(final long phraseId){
         return recommendRepository.findById(phraseId)
                 .orElseThrow(()-> new RecommendNotFoundException(RecommendCoreErrorCode.RECOMMEND_NOT_FOUND));
@@ -27,6 +23,12 @@ public class RecommendRetriever {
 
     public List<RecommendWithBookmarkDto> findWithBookmarkFlag(final long userId, final long diaryId) {
         return recommendRepository.findWithBookmarkFlag(userId, diaryId);
+    }
+
+    public Recommend findByIdWithDiary(final long phraseId) {
+        return recommendRepository.findByIdWithDiary(phraseId)
+                .orElseThrow(() ->
+                        new RecommendNotFoundException(RecommendCoreErrorCode.RECOMMEND_NOT_FOUND));
     }
 
 }

--- a/hilingual-domain/src/main/java/org/sopt/recommend/repository/RecommendRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/recommend/repository/RecommendRepository.java
@@ -7,10 +7,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface RecommendRepository extends JpaRepository<Recommend, Long> {
-
-    List<Recommend> findByDiaryId(Long diaryId);
 
     @Query("""
     select new org.sopt.recommend.dto.RecommendWithBookmarkDto(
@@ -29,4 +28,11 @@ public interface RecommendRepository extends JpaRepository<Recommend, Long> {
             @Param("userId") Long userId,
             @Param("diaryId") Long diaryId
     );
+
+    @Query("""
+        select r from Recommend r
+        join fetch r.diary d
+        where r.id = :id
+    """)
+    Optional<Recommend> findByIdWithDiary(@Param("id") Long id);
 }

--- a/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaFacade.java
@@ -1,7 +1,6 @@
 package org.sopt.voca.facade;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.voca.domain.Voca;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -10,8 +9,8 @@ public class VocaFacade {
 
     private final VocaRetriever vocaRetriever;
 
-    public Voca findDetailByUserIdAndPhraseId(Long userId, Long phraseId){
-        return vocaRetriever.findDetailByUserIdAndPhraseId(userId, phraseId);
+    public boolean existsByUserIdAndRecommendId(final Long userId, final Long recommendId) {
+        return vocaRetriever.existsByUserIdAndRecommendId(userId, recommendId);
     }
 
 }

--- a/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaRetriever.java
@@ -3,8 +3,6 @@ package org.sopt.voca.facade;
 import lombok.RequiredArgsConstructor;
 import org.sopt.voca.domain.Voca;
 import org.sopt.voca.dto.VocaListRes;
-import org.sopt.voca.exception.VocaCoreErrorCode;
-import org.sopt.voca.exception.VocaNotFoundException;
 import org.sopt.voca.repository.VocaRepository;
 import org.springframework.stereotype.Component;
 
@@ -32,8 +30,7 @@ public class VocaRetriever {
         return vocaRepository.findAllByUserIdAndPhraseStartsWith(userId, keyword);
     }
 
-    public Voca findDetailByUserIdAndPhraseId(final Long userId, final Long phraseId) {
-        return vocaRepository.findDetailByUserIdAndPhraseId(userId, phraseId)
-                .orElseThrow(() -> new VocaNotFoundException(VocaCoreErrorCode.VOCA_NOT_FOUND));
+    public boolean existsByUserIdAndRecommendId(final Long userId, final Long recommendId) {
+        return vocaRepository.existsByUserIdAndRecommendId(userId, recommendId);
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #260 

## Work Description ✏️
- 단어 상세 조회 시 `Recommend` 기준으로 조회하도록 수정
- `Voca` 존재 여부를 함께 확인하여 북마크 상태 반환
- `RecommendFacade`, `RecommendRetriever`에 `findByIdWithDiary` 메서드 추가
- `VocaFacade`, `VocaRetriever`에 `existsByUserIdAndRecommendId` 메서드 추가

## Screenshot 📸
N/A

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A