### PR TITLE
[fix] #265 단어 상세조회 시 단어 저장경로가 올바르지 않게 오는 문제 수정

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/voca/dto/res/VocaDetailResponse.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/voca/dto/res/VocaDetailResponse.java
@@ -12,25 +12,19 @@ public record VocaDetailResponse(
         String writtenFrom,
         Boolean isBookmarked
 ) {
-
-    public static VocaDetailResponse of(Recommend r, boolean isBookmarked) {
+    public static VocaDetailResponse of(Recommend r, String writtenFrom, boolean isBookmarked) {
         return new VocaDetailResponse(
                 r.getId(),
                 r.getPhrase(),
                 parsePhraseTypes(r.getPhraseType()),
                 r.getExplanation(),
-                r.getReason(),
+                writtenFrom,
                 isBookmarked
         );
     }
 
-    private static List<String> parsePhraseTypes(String phraseTypeRaw) {
-        if (phraseTypeRaw == null || phraseTypeRaw.isBlank()) {
-            return List.of();
-        }
-        return Arrays.stream(phraseTypeRaw.split(","))
-                .map(String::trim)
-                .filter(s -> !s.isEmpty())
-                .toList();
+    private static List<String> parsePhraseTypes(String raw) {
+        if (raw == null || raw.isBlank()) return List.of();
+        return Arrays.stream(raw.split(",")).map(String::trim).filter(s -> !s.isEmpty()).toList();
     }
 }

--- a/hilingual-api/src/main/java/org/sopt/controller/voca/service/VocaService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/voca/service/VocaService.java
@@ -22,7 +22,6 @@ public class VocaService {
     private final VocaRetriever vocaRetriever;
     private final RecommendFacade recommendFacade;
     private final VocaFacade vocaFacade;
-    private final RecommendRetriever recommendRetriever;
 
 
     // 단어장 목록 조회
@@ -39,8 +38,38 @@ public class VocaService {
     // 특정 단어 세부 조회
     public VocaDetailResponse getVocaDetails(final Long userId, final Long phraseId) {
         final Recommend recommend = recommendFacade.findByIdWithDiary(phraseId);
+
+        // 1) 북마크 여부
         final boolean isBookmarked = vocaFacade.existsByUserIdAndRecommendId(userId, phraseId);
-        return VocaDetailResponse.of(recommend, isBookmarked);
+
+        // 2) writtenFrom 생성
+        final String writtenFrom = buildWrittenFrom(userId, recommend, isBookmarked);
+        return VocaDetailResponse.of(recommend, writtenFrom, isBookmarked);
     }
 
+    private String buildWrittenFrom(Long userId, Recommend rec, boolean isBookmarked) {
+        if (isBookmarked) {
+            return vocaFacade.findOptionalByUserIdAndRecommendId(userId, rec.getId())
+                    .map(v -> {
+                        return switch (v.getSavedRoot()) {
+                            case FEED    -> "피드에서 저장됨";
+                            case MY      -> v.getWrittenFrom();
+                            case UNKNOWN -> "알 수 없는 출처";
+                        };
+                    })
+                    .orElseGet(() -> fallbackFromRecommend(userId, rec));
+        }
+        // 북마크 해제 상태: Recommend 출처로 유추
+        return fallbackFromRecommend(userId, rec);
+    }
+
+    private String fallbackFromRecommend(Long userId, Recommend rec) {
+        Long ownerId = rec.getDiary().getUser().getId();
+        if (ownerId.equals(userId)) {
+            var date = rec.getDiary().getWrittenDate();
+            var fmt  = java.time.format.DateTimeFormatter.ofPattern("yy.MM.dd");
+            return date.format(fmt) + " 일기에서 저장됨";
+        }
+        return "피드에서 저장됨";
+    }
 }

--- a/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaFacade.java
@@ -1,7 +1,10 @@
 package org.sopt.voca.facade;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.voca.domain.Voca;
 import org.springframework.stereotype.Component;
+
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -11,6 +14,10 @@ public class VocaFacade {
 
     public boolean existsByUserIdAndRecommendId(final Long userId, final Long recommendId) {
         return vocaRetriever.existsByUserIdAndRecommendId(userId, recommendId);
+    }
+
+    public Optional<Voca> findOptionalByUserIdAndRecommendId(final Long userId, final Long recommendId) {
+        return vocaRetriever.findOptionalByUserIdAndRecommendId(userId, recommendId);
     }
 
 }

--- a/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/voca/facade/VocaRetriever.java
@@ -7,6 +7,7 @@ import org.sopt.voca.repository.VocaRepository;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -32,5 +33,9 @@ public class VocaRetriever {
 
     public boolean existsByUserIdAndRecommendId(final Long userId, final Long recommendId) {
         return vocaRepository.existsByUserIdAndRecommendId(userId, recommendId);
+    }
+
+    public Optional<Voca> findOptionalByUserIdAndRecommendId(final Long userId, final Long recommendId) {
+        return vocaRepository.findByUserIdAndRecommendId(userId, recommendId);
     }
 }

--- a/hilingual-domain/src/main/java/org/sopt/voca/repository/VocaRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/voca/repository/VocaRepository.java
@@ -53,11 +53,5 @@ public interface VocaRepository extends JpaRepository<Voca, Long> {
     List<Voca> findAllByUserIdAndPhraseStartsWith(@Param("userId") Long userId,
                                                   @Param("keyword") String keyword);
 
-    // Voca 상세
-    @Query("""
-        SELECT v FROM Voca v
-        WHERE v.user.id = :userId AND v.recommendId = :phraseId
-    """)
-    Optional<Voca> findDetailByUserIdAndPhraseId(@Param("userId") Long userId,
-                                                 @Param("phraseId") Long phraseId);
+    Optional<Voca> findByUserIdAndRecommendId(Long userId, Long recommendId);
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #265

## Work Description ✏️
- 단어 상세 조회 로직 개선
  - Recommend 기반 조회로 변경
  - Voca 존재 여부를 통해 북마크 상태(`isBookmarked`) 판별
  - 북마크 상태 및 출처(`SavedRoot`)에 따라 writtenFrom 문구 분기 처리
    - 내 일기 → `yy.MM.dd 일기에서 저장됨`
    - 피드 → `피드에서 저장됨`

## Screenshot 📸
N/A

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A