### PR TITLE
[fix] #267 프로필 이미지 있을 경우 실제 image url 잘 내려주도록 수정

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/feed/service/FeedService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/feed/service/FeedService.java
@@ -69,7 +69,7 @@ public class FeedService {
                     null,
                     null,
                     null,
-                    bindProfileImageIfPresent(userId, userProfile.getProfileImg())
+                    bindProfileImageByOwner(targetUserId, userProfile.getProfileImg())
             );
         }
 
@@ -86,16 +86,15 @@ public class FeedService {
                 followRelation.getIsFollowing(),
                 followRelation.getIsFollowed(),
                 isBlocked,
-                bindProfileImageIfPresent(userId, userProfile.getProfileImg())
+                bindProfileImageByOwner(targetUserId, userProfile.getProfileImg())
         );
     }
 
-    private String bindProfileImageIfPresent(Long viewerUserId, String raw) {
-        // DB 기본 이미지 = " " → 그대로 반환
-        if (" ".equals(raw)) {
-            return " ";
-        }
-        return s3Service.bindProfileImage(viewerUserId, raw);
+    private String bindProfileImageByOwner(Long ownerUserId, String raw) {
+
+        if (" ".equals(raw)) return " ";
+        if (raw.startsWith("https://")) return raw;
+        return s3Service.bindProfileImage(ownerUserId, raw);
     }
 
     public SharedDiaryListRes getSharedDiaries(Long targetUserId) {


### PR DESCRIPTION
## Related issue 🛠
- closed #267 

## Work Description ✏️
- 프로필 이미지 CDN 바인딩 로직 수정
  - 기본 이미지 `" "`인 경우 CDN 붙이지 않도록 처리
  - 실제 프로필 이미지는 **소유자 userId + fileKey** 기준으로 CDN URL 생성되도록 변경
- 잘못된 userId(viewer 기준)로 URL을 바인딩하던 문제 해결

## Screenshot 📸
N/A

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A