### PR TITLE
[fix] #269 Diary 삭제 시 LikedDiary 도 삭제되도록 수정

### DIFF
--- a/hilingual-domain/src/main/java/org/sopt/diary/domain/Diary.java
+++ b/hilingual-domain/src/main/java/org/sopt/diary/domain/Diary.java
@@ -7,11 +7,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt.common.config.BaseTimeEntity;
 import org.sopt.diaryfeedback.domain.DiaryFeedback;
+import org.sopt.likeddiary.domain.LikedDiary;
 import org.sopt.recommend.domain.Recommend;
 import org.sopt.user.domain.User;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.sopt.diary.domain.DiaryTableConstants.*;
@@ -59,6 +61,9 @@ public class Diary extends BaseTimeEntity {
     @OneToMany(mappedBy = "diary", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Recommend> recommends;
 
+    @OneToMany(mappedBy = "diary", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<LikedDiary> likes = new ArrayList<>();
+
     public void publish() {
         this.isPublic = true;
         this.sharedTime = LocalDateTime.now();
@@ -84,6 +89,7 @@ public class Diary extends BaseTimeEntity {
                 0,             // isLiked
                 null,
                 user,
+                null,
                 null,
                 null
         );


### PR DESCRIPTION
## Related issue 🛠
- closed #269

## Work Description ✏️
- `Diary` 엔티티에 `LikedDiary`와의 일대다 매핑 추가
  - `cascade = REMOVE`, `orphanRemoval = true` 적용
  - Diary 삭제 시 연관된 좋아요(`LikedDiary`)도 자동 삭제되도록 수정

## Screenshot 📸
N/A

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A