### PR TITLE
[fix] #271 5차 전달된 API 수정사항 반영

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/diary/service/DiaryService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/diary/service/DiaryService.java
@@ -23,6 +23,7 @@ import org.sopt.recommend.domain.Recommend;
 import org.sopt.user.domain.User;
 import org.sopt.user.facade.UserFacade;
 import org.sopt.usercalendar.facade.UserCalendarFacade;
+import org.sopt.userprofile.facade.UserProfileFacade;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,6 +46,7 @@ public class DiaryService {
     private final RecommendService recommendService;
     private final DiaryDiffService diaryDiffService;
     private final UserCalendarFacade userCalendarFacade;
+    private final UserProfileFacade userProfileFacade;
 
     private final S3Service s3Service;
 
@@ -142,6 +144,7 @@ public class DiaryService {
 
         diaryFacade.deleteDiary(userId, diaryId);
         userCalendarFacade.markDeleted(userId, diary.getWrittenDate());
+        userProfileFacade.decrementTotalDiariesAndRecalculateStreak(userId, diary.getWrittenDate());
     }
 
     @Transactional

--- a/hilingual-api/src/main/java/org/sopt/controller/feed/dto/DiaryWriterProfileRes.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/feed/dto/DiaryWriterProfileRes.java
@@ -48,8 +48,8 @@ public record DiaryWriterProfileRes(
     ){
         static FeedDiary of(final Diary diary, final boolean isLikedByUser) {
             LocalDateTime now = LocalDateTime.now();
-            LocalDateTime createdAt = diary.getCreatedAt();
-            long minutesDiff = Duration.between(createdAt, now).toMinutes();
+            LocalDateTime sharedAt = diary.getSharedTime();
+            long minutesDiff = Duration.between(sharedAt, now).toMinutes();
 
             return new FeedDiary(
                     (minutesDiff < ONE_MINUTE) ? LESS_THAN_MINUTE : minutesDiff,

--- a/hilingual-domain/src/main/java/org/sopt/usercalendar/repository/UserCalendarRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/usercalendar/repository/UserCalendarRepository.java
@@ -16,7 +16,9 @@ public interface UserCalendarRepository extends JpaRepository<UserCalendar, Long
     /**
      * TODO : 추후 위에 두 User로 탐색하는 메서드 없애고, 아래 ID로 조회하는 메서드 사용하는 걸로 리팩하기!
      */
+    @Query("SELECT CASE WHEN EXISTS (SELECT 1 FROM UserCalendar uc WHERE uc.user = :user AND uc.date = :date AND uc.status != 'DELETED') THEN true ELSE false END")
     boolean existsByUserAndDate(User user, LocalDate date);
+
     Optional<UserCalendar> findByUserAndDate(User user, LocalDate date);
 
 //    boolean existsByUserIdAndDate(Long userId, LocalDate date);

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileFacade.java
@@ -84,4 +84,8 @@ public class UserProfileFacade {
         return userProfileUpdater.decrementFollowerCountByUserId(userId, updatedAt);
     }
 
+    public void decrementTotalDiariesAndRecalculateStreak(final long userId, final LocalDate deletedDate) {
+        userProfileUpdater.decrementTotalDiariesAndRecalculateStreak(userId, deletedDate);
+    }
+
 }

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileUpdater.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileUpdater.java
@@ -1,6 +1,7 @@
 package org.sopt.userprofile.facade;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.user.domain.User;
 import org.sopt.usercalendar.facade.UserCalendarFacade;
 import org.sopt.userprofile.domain.UserProfile;
 import org.sopt.userprofile.repository.UserProfileRepository;
@@ -23,7 +24,7 @@ public class UserProfileUpdater {
     private final UserProfileRetriever userProfileRetriever;
 
     /**
-     * 1. 일기 작성 시 totalDiaries 증가
+     * 일기 작성 시 totalDiaries 증가
      */
     @Transactional
     public void incrementTotalDiaries(Long userId) {
@@ -33,7 +34,61 @@ public class UserProfileUpdater {
     }
 
     /**
-     * 2. 일기를 쓴 순간에 호출 (streak 업데이트)
+     * 일기 삭제 시
+     * - totalDiaries 감소
+     * - streak 업데이트
+     */
+    @Transactional
+    public void decrementTotalDiariesAndRecalculateStreak(Long userId, LocalDate deletedDate) {
+        UserProfile profile = userProfileRetriever.findByUserId(userId);
+        profile.updateTotalDiaries(profile.getTotalDiaries() - 1);
+
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        LocalDate yesterday = today.minusDays(1);
+
+        int newStreak = profile.getStreak();
+
+        // 일기 삭제 시 streak 재계산
+        if (deletedDate.equals(today)) {
+            // 오늘 일기를 삭제한 경우: 어제까지의 streak 계산
+            boolean hasYesterday = userCalendarFacade.existsByUserAndDate(profile.getUser(), yesterday);
+            if (hasYesterday) {
+                // 어제까지의 연속 작성 일수를 다시 계산
+                newStreak = calculateStreakFromDate(profile.getUser(), yesterday);
+            } else {
+                // 어제도 일기가 없다면 streak 0으로 리셋
+                newStreak = 0;
+            }
+        } else if (deletedDate.equals(yesterday)) {
+            // 어제 일기를 삭제한 경우: 오늘부터 연속 작성 일수를 다시 계산
+            boolean hasToday = userCalendarFacade.existsByUserAndDate(profile.getUser(), today);
+            if (hasToday) {
+                // 오늘부터 연속 작성 일수를 다시 계산
+                newStreak = calculateStreakFromDate(profile.getUser(), today);
+            } else {
+                // 오늘도 일기가 없다면 streak 0으로 리셋
+                newStreak = 0;
+            }
+        }
+
+        profile.updateStreak(newStreak);
+        userProfileRepository.save(profile);
+    }
+
+    // 연속 작성 일수를 계산하는 헬퍼 메서드
+    private int calculateStreakFromDate(User user, LocalDate startDate) {
+        int streak = 0;
+        LocalDate currentDate = startDate;
+
+        while (userCalendarFacade.existsByUserAndDate(user, currentDate)) {
+            streak++;
+            currentDate = currentDate.minusDays(1);
+        }
+        return streak;
+    }
+
+    /**
+     * 일기를 쓴 순간에 호출 (streak 업데이트)
      */
     @Transactional
     public void updateStreakOnWrite(Long userId, LocalDate writtenDate) {
@@ -71,7 +126,7 @@ public class UserProfileUpdater {
     }
 
     /**
-     * 3. 매일 자정 → 최근 2일 작성 여부 검사 후 streak 리셋 or 유지
+     * 매일 자정 → 최근 2일 작성 여부 검사 후 streak 리셋 or 유지
      */
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     @Transactional


### PR DESCRIPTION
## Related issue 🛠
- closed #271 

## Work Description ✏️
- 게시된 일기 작성자 프로필 조회 API createdAt 계산 -> sharedTime으로 변경
- 일기 삭제하기 API streak, total diary 재계산 로직 구현

## Screenshot 📸
N/A

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A