### PR TITLE
[fix] #273  단어 상세조회 로직 개선 : 북마크 스냅샷 우선 조회, 원본 조회 fallback 적용

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/voca/dto/res/VocaDetailResponse.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/voca/dto/res/VocaDetailResponse.java
@@ -1,6 +1,8 @@
 package org.sopt.controller.voca.dto.res;
 
 import org.sopt.recommend.domain.Recommend;
+import org.sopt.voca.domain.Voca;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -12,6 +14,7 @@ public record VocaDetailResponse(
         String writtenFrom,
         Boolean isBookmarked
 ) {
+    // Recommend 기반
     public static VocaDetailResponse of(Recommend r, String writtenFrom, boolean isBookmarked) {
         return new VocaDetailResponse(
                 r.getId(),
@@ -19,6 +22,18 @@ public record VocaDetailResponse(
                 parsePhraseTypes(r.getPhraseType()),
                 r.getExplanation(),
                 writtenFrom,
+                isBookmarked
+        );
+    }
+
+    // Voca 스냅샷 기반
+    public static VocaDetailResponse ofSnapshot(Voca v, boolean isBookmarked) {
+        return new VocaDetailResponse(
+                v.getRecommendId(),
+                v.getPhrase(),
+                parsePhraseTypes(v.getPhraseType()),
+                v.getExplanation(),
+                v.getWrittenFrom(),
                 isBookmarked
         );
     }

--- a/hilingual-api/src/main/java/org/sopt/controller/voca/service/VocaService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/voca/service/VocaService.java
@@ -3,7 +3,6 @@ package org.sopt.controller.voca.service;
 import lombok.RequiredArgsConstructor;
 import org.sopt.controller.voca.dto.res.VocaDetailResponse;
 import org.sopt.recommend.domain.Recommend;
-import org.sopt.recommend.facade.RecommendRetriever;
 import org.sopt.voca.dto.VocaListRes;
 import org.sopt.controller.voca.dto.res.VocaSearchListResponse;
 import org.sopt.recommend.facade.RecommendFacade;
@@ -23,7 +22,6 @@ public class VocaService {
     private final RecommendFacade recommendFacade;
     private final VocaFacade vocaFacade;
 
-
     // 단어장 목록 조회
     public VocaListRes getVocaList(final Long userId, final int sort) {
         return vocaRetriever.findGroupedVoca(userId, sort);
@@ -36,15 +34,14 @@ public class VocaService {
     }
 
     // 특정 단어 세부 조회
-    public VocaDetailResponse getVocaDetails(final Long userId, final Long phraseId) {
-        final Recommend recommend = recommendFacade.findByIdWithDiary(phraseId);
-
-        // 1) 북마크 여부
-        final boolean isBookmarked = vocaFacade.existsByUserIdAndRecommendId(userId, phraseId);
-
-        // 2) writtenFrom 생성
-        final String writtenFrom = buildWrittenFrom(userId, recommend, isBookmarked);
-        return VocaDetailResponse.of(recommend, writtenFrom, isBookmarked);
+    public VocaDetailResponse getVocaDetails(Long userId, Long recommendId) {
+        return vocaFacade.findOptionalByUserIdAndRecommendId(userId, recommendId)
+                .map(v -> VocaDetailResponse.ofSnapshot(v, true))
+                .orElseGet(() -> {
+                    Recommend recommend = recommendFacade.findByIdWithDiary(recommendId);
+                    String writtenFrom = buildWrittenFrom(userId, recommend, false);
+                    return VocaDetailResponse.of(recommend, writtenFrom, false);
+                });
     }
 
     private String buildWrittenFrom(Long userId, Recommend rec, boolean isBookmarked) {


### PR DESCRIPTION
## Related issue 🛠
- closed #273 

## Work Description ✏️
- Voca 상세조회 로직 변경
  - 북마크(Voca) 존재 시 → 스냅샷 기반으로 상세 응답 반환 (작성자 탈퇴/비공개 무관하게 조회 가능)
  - 북마크 해제 상태→ Recommend 원본 조회 (작성자 탈퇴/삭제 시 NotFound 발생 -> 클라 처리)
- VocaDetailResponse 팩토리 메서드 2개 분리 (of, ofSnapshot)

## Screenshot 📸
N/A

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A