### PR TITLE
[fix] 단어장 검색 시 정렬 A-Z로 고정

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/voca/service/VocaService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/voca/service/VocaService.java
@@ -11,7 +11,10 @@ import org.sopt.voca.facade.VocaFacade;
 import org.sopt.voca.facade.VocaRetriever;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 
 @Service
 @Transactional(readOnly = true)
@@ -30,6 +33,10 @@ public class VocaService {
     // 단어장 검색
     public VocaSearchListResponse searchVocaList(final Long userId, final String keyword) {
         final List<Voca> vocas = vocaRetriever.findStartsWithVoca(userId, keyword);
+
+        // ✅ 검색 시 무조건 A–Z
+        vocas.sort(Comparator.comparing(v -> v.getPhrase().toLowerCase(Locale.ROOT)));
+
         return VocaSearchListResponse.from(vocas);
     }
 

--- a/hilingual-domain/src/main/java/org/sopt/voca/repository/VocaRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/voca/repository/VocaRepository.java
@@ -48,7 +48,7 @@ public interface VocaRepository extends JpaRepository<Voca, Long> {
         SELECT v FROM Voca v
         WHERE v.user.id = :userId
           AND LOWER(v.phrase) LIKE LOWER(CONCAT(:keyword, '%'))
-        ORDER BY LOWER(SUBSTRING(v.phrase, LENGTH(:keyword) + 1))
+        ORDER BY LOWER(v.phrase) ASC
     """)
     List<Voca> findAllByUserIdAndPhraseStartsWith(@Param("userId") Long userId,
                                                   @Param("keyword") String keyword);


### PR DESCRIPTION
## Related issue 🛠
- closed #278 

## Work Description ✏️
- 단어장 검색시에는 A-Z로만 조회
