### PR TITLE
[fix] #283 streak 계산 로직 분기별로 다시 설정

### DIFF
--- a/hilingual-domain/src/main/java/org/sopt/usercalendar/facade/UserCalendarFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/usercalendar/facade/UserCalendarFacade.java
@@ -6,6 +6,8 @@ import org.sopt.user.domain.User;
 import org.sopt.usercalendar.domain.UserCalendar;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.sopt.usercalendar.domain.WriteStatus;
+
 
 import java.time.LocalDate;
 import java.util.List;
@@ -52,6 +54,22 @@ public class UserCalendarFacade {
 
     public Optional<UserCalendar> findByUserIdAndDate(final long userId, final LocalDate date) {
         return userCalendarRetriever.findByUserIdAndDate(userId, date);
+    }
+
+    public WriteStatus getStatus(User user, LocalDate date) {
+        return userCalendarRetriever.findByUserAndDate(user, date)
+                .map(UserCalendar::getStatus)
+                .orElse(WriteStatus.NONE);
+    }
+
+    public WriteStatus getStatusByUserIdAndDate(long userId, LocalDate date) {
+        return userCalendarRetriever.findByUserIdAndDate(userId, date)
+                .map(UserCalendar::getStatus)
+                .orElse(WriteStatus.NONE);
+    }
+
+    public boolean isWritten(User user, LocalDate date) {
+        return getStatus(user, date) == WriteStatus.WRITTEN;
     }
 
 }

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileUpdater.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileUpdater.java
@@ -2,13 +2,14 @@ package org.sopt.userprofile.facade;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.user.domain.User;
+import org.sopt.usercalendar.domain.WriteStatus;
 import org.sopt.usercalendar.facade.UserCalendarFacade;
 import org.sopt.userprofile.domain.UserProfile;
 import org.sopt.userprofile.repository.UserProfileRepository;
-import org.springframework.cglib.core.Local;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -52,78 +53,120 @@ public class UserProfileUpdater {
     public void updateStreakOnWrite(Long userId, LocalDate writtenDate) {
         UserProfile profile = userProfileRetriever.findByUserId(userId);
 
-        LocalDate today     = LocalDate.now(ZoneId.of("Asia/Seoul"));
-        LocalDate yesterday = today.minusDays(1);
+        final ZoneId KST = ZoneId.of("Asia/Seoul");
+        LocalDate today     = LocalDate.now(KST);   // D
+        LocalDate yesterday = today.minusDays(1);   // Y
 
         int newStreak = profile.getStreak();
 
-        boolean hasYesterday = userCalendarFacade.existsByUserAndDate(profile.getUser(), yesterday);
-        boolean hasToday = userCalendarFacade.existsByUserAndDate(profile.getUser(), today);
+        WriteStatus yStatus = userCalendarFacade.getStatus(profile.getUser(), yesterday);
+        WriteStatus dStatus = userCalendarFacade.getStatus(profile.getUser(), today);
 
         if (writtenDate.equals(today)) {
-            // 오늘 쓰는 순간 → 어제 썼다면 +1, 아니면 새로 시작
-            if (hasYesterday) {
-                newStreak++;
-            } else if (profile.getStreak() == 0) {
-                newStreak = 1; // 최초 작성이거나 작성 재개
-            }
+            // 오늘 작성
+            if (yStatus == WriteStatus.WRITTEN) {
+                newStreak += 1;                 // 정상 연결
+            } else if (yStatus == WriteStatus.DELETED) {
+                newStreak = 1;   // 하드 미싱 → 오늘 단독 확정 1
+            } // NONE이면 보충 가능 → 변화 없음
         } else if (writtenDate.equals(yesterday)) {
-            // 어제 보충 작성 → 무조건 +1
-            newStreak++;
-            // 오늘도 이미 쓰여 있으면 추가 +1
-            if (hasToday) {
-                newStreak++;
-            }
-            if (profile.getStreak() == 0) {
-                newStreak = 1; // 최초 작성이거나 작성 재개
+            // 어제 보충: +1, 오늘도 WRITTEN이면 +1 추가
+            newStreak += 1;
+            if (dStatus == WriteStatus.WRITTEN) {
+                newStreak += 1;
             }
         }
 
         profile.updateStreak(newStreak);
         userProfileRepository.save(profile);
     }
+
 
     /**
      * 일기를 삭제한 순간에 호출 (streak 업데이트)
+     * 규칙 요약:
+     *  - 어제(Y) 삭제: 오늘(D)이 있으면 즉시 1, 없으면 0
+     *  - 오늘(D) 삭제: 즉시 0 (즉시 단절)
+     *  - 그제(DBY) 삭제: 고정값 매핑
+     *      Y=O,D=O → 2 / Y=O,D=X → 1 / Y=X,D=O → 1 / Y=X,D=X → 0
+     *  - 그 이전(≤DBY-1) 삭제:
+     *      Y=O → calc(Y) + (D ? 1 : 0)
+     *      Y=X & D=O → min(현재 streak, calc(DBY))
+     *      Y=X & D=X → calc(DBY)
      */
+    @Transactional
     public void updateStreakOnDelete(Long userId, LocalDate writtenDate) {
         UserProfile profile = userProfileRetriever.findByUserId(userId);
 
-        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
-        LocalDate yesterday = today.minusDays(1);
-        LocalDate dayBeforeYesterday = today.minusDays(2);
+        final ZoneId KST = ZoneId.of("Asia/Seoul");
+        LocalDate today = LocalDate.now(KST);         // D (예: 17)
+        LocalDate yesterday = today.minusDays(1);     // Y (예: 16)
+        LocalDate dby = today.minusDays(2);           // DBY (예: 15)
+
+        WriteStatus dStatus = userCalendarFacade.getStatus(profile.getUser(), today);
+        WriteStatus yStatus = userCalendarFacade.getStatus(profile.getUser(), yesterday);
+
+        boolean dWritten = (dStatus == WriteStatus.WRITTEN);
+        boolean yWritten = (yStatus == WriteStatus.WRITTEN);
 
         int newStreak;
 
-        // 그저께까지의 streak을 정확히 계산
-        int streakUpToDayBeforeYesterday = calculateStreakFromDate(profile.getUser(), dayBeforeYesterday);
-
-        // 48시간 유예 기간을 고려하여 streak 업데이트
-        boolean hasYesterday = userCalendarFacade.existsByUserAndDate(profile.getUser(), yesterday);
-        boolean hasToday = userCalendarFacade.existsByUserAndDate(profile.getUser(), today);
-
-        if (hasYesterday && hasToday) {
-            newStreak = streakUpToDayBeforeYesterday + 2;
-        } else if (hasYesterday) {
-            newStreak = streakUpToDayBeforeYesterday + 1;
-        } else if (hasToday) {
-            newStreak = streakUpToDayBeforeYesterday;
-        } else {
+        if (writtenDate.equals(today)) {
+            // 오늘 삭제 → 즉시 단절
             newStreak = 0;
+
+        } else if (writtenDate.equals(yesterday)) {
+            // 어제 삭제 → 오늘 WRITTEN이면 1, 아니면 0
+            newStreak = dWritten ? 1 : 0;
+
+        } else if (writtenDate.equals(dby)) {
+            // 그제(DBY) 삭제: 고정값
+            if (yWritten && dWritten) {
+                newStreak = 2;
+            } else if (yWritten) {
+                newStreak = 1;
+            } else if (dWritten) {
+                newStreak = 1;
+            } else {
+                newStreak = 0;
+            }
+
+        } else if (writtenDate.isBefore(dby)) {
+            // 그 이전(≤DBY-1) 삭제 — 점진 하향, Y의 NONE/DELETED 구분
+            if (yWritten) {
+                int base = calculateStreakFromDate(profile.getUser(), yesterday);
+                newStreak = base + (dWritten ? 1 : 0);
+            } else {
+                if (yStatus == WriteStatus.DELETED) {
+                    // 어제가 하드 미싱이면 오늘 단독만 가능
+                    newStreak = dWritten ? 1 : 0;
+                } else { // yStatus == NONE (소프트 미싱)
+                    int baseFromDBY = calculateStreakFromDate(profile.getUser(), dby);
+                    int current = profile.getStreak();
+                    newStreak = Math.min(current, baseFromDBY);
+                }
+            }
+
+        } else {
+            // 미래 날짜 등 비정상 입력: 보수적 환산
+            int base = calculateStreakFromDate(profile.getUser(), yesterday);
+            newStreak = base + (dWritten ? 1 : 0);
         }
 
         profile.updateStreak(newStreak);
         userProfileRepository.save(profile);
     }
+
+
+
 
     // 특정 날짜부터 과거로 연속 작성 일수를 계산하는 헬퍼 메서드
     private int calculateStreakFromDate(User user, LocalDate startDate) {
         int streak = 0;
-        LocalDate currentDate = startDate;
-
-        while (userCalendarFacade.existsByUserAndDate(user, currentDate)) {
+        LocalDate cur = startDate;
+        while (userCalendarFacade.getStatus(user, cur) == WriteStatus.WRITTEN) {
             streak++;
-            currentDate = currentDate.minusDays(1);
+            cur = cur.minusDays(1);
         }
         return streak;
     }
@@ -135,21 +178,30 @@ public class UserProfileUpdater {
     @Transactional
     public void resetStreakIfBroken() {
         LocalDate today     = LocalDate.now(ZoneId.of("Asia/Seoul"));
-        LocalDate dayBefore = today.minusDays(2);
+        LocalDate yesterday = today.minusDays(1);
+        LocalDate dayBeforeYesterday = today.minusDays(2);
 
         List<UserProfile> all = userProfileRepository.findAll();
 
         for (UserProfile profile : all) {
-            // 그제 작성 여부 확인
-            boolean hasDayBefore = userCalendarFacade
-                    .existsByUserAndDate(profile.getUser(), dayBefore);
-            if (!hasDayBefore) {
-                // 그제 안 썼으면 streak 리셋
-                profile.updateStreak(0);
+            WriteStatus y   = userCalendarFacade.getStatus(profile.getUser(), yesterday);
+            WriteStatus dby = userCalendarFacade.getStatus(profile.getUser(), dayBeforeYesterday);
+
+            // (15 X, 16 O) → 1
+            if (dby != WriteStatus.WRITTEN && y == WriteStatus.WRITTEN) {
+                profile.updateStreak(1);
+                continue;
             }
+            // (15 X, 16 X) → 0
+            if (dby != WriteStatus.WRITTEN && y != WriteStatus.WRITTEN) {
+                profile.updateStreak(0);
+                continue;
+            }
+            // (15 O, 16 X) 또는 (15 O, 16 O) → 유지
         }
         userProfileRepository.saveAll(all);
     }
+
 
     @Transactional
     public int updateProfileImgByUserId(final long userId, final String newImgUrl, final LocalDateTime updatedAt) {


### PR DESCRIPTION
## Related issue 🛠
- closed #283 

## Work Description ✏️
-UserProfileUpdater.updateStreakOnWrite 수정
- UserProfileUpdater.updateStreakOnDelete 수정
- UserProfileUpdater.resetStreakIfBroken(자정 스케줄러) 수정
- calculateStreakFromDate
- >연속 계산을 WRITTEN만 카운트하도록 통일.
- UserCalendarFacade
- > getStatus(User, LocalDate) 추가/노출: NONE/WRITTEN/DELETED 직접 조회로 분기 정확도 향상.

