### PR TITLE
[fix] #286 total_diaries 계산 방식 변경 (오류 해결)

### DIFF
--- a/hilingual-domain/src/main/java/org/sopt/usercalendar/facade/UserCalendarFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/usercalendar/facade/UserCalendarFacade.java
@@ -72,4 +72,8 @@ public class UserCalendarFacade {
         return getStatus(user, date) == WriteStatus.WRITTEN;
     }
 
+    public long countWritten(final Long userId) {
+        return userCalendarRetriever.countWrittenByUserId(userId);
+    }
+
 }

--- a/hilingual-domain/src/main/java/org/sopt/usercalendar/facade/UserCalendarRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/usercalendar/facade/UserCalendarRetriever.java
@@ -43,4 +43,8 @@ public class UserCalendarRetriever {
         return userCalendarRepository.findByUserIdAndDate(userId, date);
     }
 
+    public long countWrittenByUserId(Long userId) {
+        return userCalendarRepository.countWrittenByUserId(userId);
+    }
+
 }

--- a/hilingual-domain/src/main/java/org/sopt/usercalendar/repository/UserCalendarRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/usercalendar/repository/UserCalendarRepository.java
@@ -51,4 +51,12 @@ public interface UserCalendarRepository extends JpaRepository<UserCalendar, Long
     void deleteAllByUserId(Long userId);
 
     Optional<UserCalendar> findByUserIdAndDate(Long userId, LocalDate date);
+
+
+    @Query("""
+    SELECT COUNT(uc) FROM UserCalendar uc
+    WHERE uc.user.id = :userId
+      AND uc.status  = org.sopt.usercalendar.domain.WriteStatus.WRITTEN
+""")
+    long countWrittenByUserId(@Param("userId") Long userId);
 }

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileUpdater.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileUpdater.java
@@ -30,8 +30,8 @@ public class UserProfileUpdater {
     @Transactional
     public void incrementTotalDiariesAndRecalculateStreak(Long userId, LocalDate writtenDate) {
         UserProfile profile = userProfileRetriever.findByUserId(userId);
-        profile.updateTotalDiaries(profile.getTotalDiaries() + 1);
-        updateStreakOnWrite(userId, writtenDate);
+        updateStreakOnWrite(userId, writtenDate); // 캘린더 상태 기준으로 streak 반영
+        resyncTotal(profile);                     // WRITTEN 개수로 동기화
         userProfileRepository.save(profile);
     }
 
@@ -41,8 +41,8 @@ public class UserProfileUpdater {
     @Transactional
     public void decrementTotalDiariesAndRecalculateStreak(Long userId, LocalDate writtenDate) {
         UserProfile profile = userProfileRetriever.findByUserId(userId);
-        profile.updateTotalDiaries(profile.getTotalDiaries() - 1);
-        updateStreakOnDelete(userId, writtenDate);
+        updateStreakOnDelete(userId, writtenDate); // 삭제 규칙대로 streak 반영
+        resyncTotal(profile);                      // WRITTEN 개수로 동기화
         userProfileRepository.save(profile);
     }
 
@@ -200,6 +200,11 @@ public class UserProfileUpdater {
             // (15 O, 16 X) 또는 (15 O, 16 O) → 유지
         }
         userProfileRepository.saveAll(all);
+    }
+
+    private void resyncTotal(UserProfile profile) {
+        long cnt = userCalendarFacade.countWritten(profile.getUser().getId());
+        profile.updateTotalDiaries((int) cnt);
     }
 
 


### PR DESCRIPTION
## Related issue 🛠
- closed #286 

## Work Description ✏️
- `total_diaries`가 **음수로 표시**되는 사례가 보고됨.
- 원인(추정 및 재현):
- 과거 로직이 증감 방식(+1/–1)에 의존 →  **실제 캘린더 상태와 분리**되어 음수/과증가 가능.
- - **증감 제거 → 사실값 동기화 방식**으로 교체
  - `UserCalendar`의 `WRITTEN` 건수를 매번 **COUNT**하여 `UserProfile.totalDiaries`를 **재동기화(resync)**
  - 작성/삭제 흐름에서 `streak` 업데이트 후 **항상 resync**

