### PR TITLE
[fix] #288 운영 환경의 안정성을 위한 yml 파일 수정

### DIFF
--- a/hilingual-api/src/main/resources/application.yml
+++ b/hilingual-api/src/main/resources/application.yml
@@ -12,20 +12,17 @@ spring:
     password: ${DB_PW}
     driver-class-name: org.postgresql.Driver
 
-  servlet:
-    multipart:
-      enabled: true
-      max-file-size: 10MB
-      max-request-size: 10MB
-
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
-        show_sql: true
-        format_sql: true
+        show_sql: false
+        format_sql: false
         dialect: org.hibernate.dialect.PostgreSQLDialect
+  sql:
+    init:
+      mode: never
 
   security:
     oauth2:

--- a/hilingual-api/src/main/resources/application.yml
+++ b/hilingual-api/src/main/resources/application.yml
@@ -14,11 +14,11 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: ${DDL_OPTION}
     properties:
       hibernate:
-        show_sql: false
-        format_sql: false
+        show_sql: ${SHOW_SQL}
+        format_sql: ${FORMAT_SQL}
         dialect: org.hibernate.dialect.PostgreSQLDialect
   sql:
     init:


### PR DESCRIPTION
## Related issue 🛠
- closed #288 

## Work Description ✏️
- Presigned URL 기반 업로드로 전환하면서 spring.servlet.multipart 설정 제거
- 환경별 설정을 .env 파일로 분리
  - dev 환경:
    - spring.jpa.hibernate.ddl-auto=update
    - hibernate.show_sql/format_sql=true → 개발 시 SQL 로그 확인 가능
  - prod 환경:
    - spring.jpa.hibernate.ddl-auto=validate
    - hibernate.show_sql/format_sql=false → 운영 로그 최소화
- spring.sql.init.mode: never
  - → schema.sql, data.sql 자동 실행 차단
- **향후 마이그레이션 툴 도입 필요**
  - Flyway/Liquibase 도입해 DB 스키마 변경 이력을 안전하게 관리
  - prod 환경은 .env로 ddl-auto=validate 고정, 스키마 변경은 마이그레이션 스크립트 기반으로만 진행

## Uncompleted Tasks 😅
- Flyway/Liquibase 도입 

## To Reviewers 📢
- 이번 수정은 prod 환경에서 DB 스키마가 의도치 않게 변경, 삭제되는 문제를 예방하기 위한 최소한의 안전 조치입니다.
- prod 환경에서는 스키마가 자동 변경되지 않도록 ddl-auto=validate로 제한했고, dev/test에서는 개발 편의를 위해 update를 유지합니다.
- 마이그레이션 툴을 도입하면 prod 환경은 반드시 스크립트 기반으로만 스키마 변경을 진행할 예정입니다.
