### PR TITLE
[fix] #293 ADMIN 컨트롤러들 모두 인증 사용하지 않도록 변경

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/admin/api/AdminController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/admin/api/AdminController.java
@@ -16,7 +16,6 @@ public class AdminController {
 
     private final AdminNoticeService adminNoticeService;
 
-    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/notices")
     public ResponseEntity<NoticeCreateRes> create(
             @Valid @RequestBody NoticeCreateReq req
@@ -24,7 +23,6 @@ public class AdminController {
         return ResponseEntity.ok(adminNoticeService.create(req));
     }
 
-    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/notices/{noticeId}/delivery")
     public ResponseEntity<Void> deliver(
             @PathVariable Long noticeId
@@ -32,5 +30,6 @@ public class AdminController {
         adminNoticeService.deliver(noticeId);
         return ResponseEntity.ok().build();
     }
+
 }
 

--- a/hilingual-api/src/main/java/org/sopt/controller/admin/service/AdminNoticeService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/admin/service/AdminNoticeService.java
@@ -41,7 +41,6 @@ public class AdminNoticeService {
     private static final int BATCH_SIZE = 500;
 
     @Transactional
-    @PreAuthorize("hasRole('ADMIN')")
     public NoticeCreateRes create(NoticeCreateReq req) {
         Category category;
         try {
@@ -56,7 +55,6 @@ public class AdminNoticeService {
     }
 
     @Transactional
-    @PreAuthorize("hasRole('ADMIN')")
     public void deliver(Long noticeId) {
         // 공지 확인
         Notice notice = noticeRepository.findById(noticeId)

--- a/hilingual-auth/src/main/java/org/sopt/jwt/auth/web/JwtAuthenticationFilter.java
+++ b/hilingual-auth/src/main/java/org/sopt/jwt/auth/web/JwtAuthenticationFilter.java
@@ -40,7 +40,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/api/v1/auth/verify",
             "/test/jwt/token/issue",
             "/api/v1/auth/login",
-            "/api/v1/users/profile/check"
+            "/api/v1/users/profile/check",
+            "/api/v1/admin/notices",
+            "/api/v1/admin/notices/{noticeId}/delivery"
     );
 
     @Override

--- a/hilingual-auth/src/main/java/org/sopt/jwt/support/AuthConstants.java
+++ b/hilingual-auth/src/main/java/org/sopt/jwt/support/AuthConstants.java
@@ -17,7 +17,9 @@ public class AuthConstants {
             "/api/v1/auth/login",
             "/api/v1/users/reissue",
             "/api/v1/auth/verify",
-            "/api/v1/users/profile/check"
+            "/api/v1/users/profile/check",
+            "/api/v1/admin/notices",
+            "/api/v1/admin/notices/{noticeId}/delivery"
     };
 
     private AuthConstants() {


### PR DESCRIPTION
## Related issue 🛠
- closed #293 

## Work Description ✏️
- SecurityConfig 에서 POST /api/v1/admin/notices, POST /api/v1/admin/notices/{noticeId}/delivery 경로를 permitAll() 처리하여 인증 없이 접근 가능하도록 변경
- JwtAuthenticationFilter 의 shouldNotFilter 메서드에서 ADMIN 엔드포인트는 필터 스킵하도록 로직 추가

-> ADMIN 컨트롤러 엔드포인트 호출 시 Bearer Token 없이도 동작합니다.

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
|       공지 생성 API      | <img width="860" height="479" alt="image" src="https://github.com/user-attachments/assets/bbc68583-1293-435f-9230-18e2c8c5e847" /> |
| 공지 발송 API | <img width="858" height="471" alt="image" src="https://github.com/user-attachments/assets/ffde7b2a-f3dd-40fe-8844-c9141afe3b54" /> |

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A