### PR TITLE
[refac] #301 디스코드 알림이 회원가입 완료 시 가도록 수정

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/auth/api/AuthController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/auth/api/AuthController.java
@@ -30,7 +30,6 @@ public class AuthController {
             @Valid @RequestBody SocialLoginReq req
     ) {
         SocialLoginRes res = authService.socialLogin(providerToken, req);
-        webhookService.sendNewUserNotification();
         return ResponseEntity.ok(res);
     }
 

--- a/hilingual-api/src/main/java/org/sopt/controller/discord/service/WebhookService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/discord/service/WebhookService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.user.domain.User;
 import org.sopt.user.facade.UserFacade;
 import org.sopt.userprofile.domain.UserProfile;
+import org.sopt.userprofile.facade.UserProfileFacade;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -23,19 +24,12 @@ public class WebhookService {
     @Value("${discord.webhook.url}")
     private String discordWebhookUrl;
 
-    private final UserFacade userFacade;
-
-    public void sendNewUserNotification() {
-        // 회원 수 조회
-        final long totalMembers = userFacade.count();
-
-        // 알림 메시지
-        String message = totalMembers + "번째 유저가 로그인했습니다!\n";
-        sendDiscordWebhook(message);
-    }
+    private final UserProfileFacade userProfileFacade;
 
     public void sendCompleteUserNotification(UserProfile userProfile) {
-        String message = userProfile.getNickname() + "회원님이 회원가입을 완료했습니다!\n";
+        final long totalMembers = userProfileFacade.count();
+
+        String message = "✏️하이링구얼 신규 회원✏️\n🔸닉네임 : " + userProfile.getNickname() + "\n🔸현재 가입 유저 수 : " + totalMembers + "명\n🔸플랫폼 : " + userProfile.getUser().getProvider();
         sendDiscordWebhook(message);
     }
 

--- a/hilingual-domain/src/main/java/org/sopt/user/facade/UserFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/user/facade/UserFacade.java
@@ -37,8 +37,4 @@ public class UserFacade {
     public boolean existsByProviderId(final String providerId) {
         return userRetriever.existsByProviderId(providerId);
     }
-
-    public long count() {
-        return userRetriever.count();
-    }
 }

--- a/hilingual-domain/src/main/java/org/sopt/user/facade/UserRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/user/facade/UserRetriever.java
@@ -34,7 +34,4 @@ public class UserRetriever {
         return userRepository.existsByProviderId(providerId);
     }
 
-    public long count() {
-        return userRepository.count();
-    }
 }

--- a/hilingual-domain/src/main/java/org/sopt/user/repository/UserRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/user/repository/UserRepository.java
@@ -35,6 +35,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
     // 탈퇴/삭제된 계정 제외 전체 유저 id
     @Query("select u.id from User u where u.isDeleted = false")
     List<Long> findAllActiveUserIds();
-
-    long count();
 }

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileFacade.java
@@ -50,6 +50,10 @@ public class UserProfileFacade {
         return userProfileRetriever.findUsersByNickname(userId, keyword, startKeyword);
     }
 
+    public long count() {
+        return userProfileRetriever.count();
+    }
+
     /**
     saver
      */

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileRetriever.java
@@ -41,4 +41,8 @@ public class UserProfileRetriever {
     public List<UserSearchProjection> findUsersByNickname(Long userId, String keyword, String startKeyword) {
         return userProfileRepository.searchUserListByKeyword(userId, keyword, startKeyword);
     }
+
+    public long count() {
+        return userProfileRepository.count();
+    }
 }

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/repository/UserProfileRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/repository/UserProfileRepository.java
@@ -97,4 +97,6 @@ public interface UserProfileRepository extends JpaRepository<UserProfile, Long> 
     @Modifying
     @Query("UPDATE UserProfile up SET up.followingCount = up.followingCount - 1 WHERE up.user.id IN (SELECT f.follower.id FROM Follow f WHERE f.followee.id = :userId)")
     void decreaseFollowingCountOfFollowers(@Param("userId") Long userId);
+
+    long count();
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #301 

## Work Description ✏️
- 소셜로그인 API에서 디스코드 알림 삭제
- 회원가입 알림 메세지 수정

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
|  회원가입 완료 시   | <img width="424" height="422" alt="image" src="https://github.com/user-attachments/assets/59fa3aa3-abaf-47a4-8b33-b9db8b6f6df8" /> |
| 디코 알림 | <img width="220" height="120" alt="image" src="https://github.com/user-attachments/assets/04ee7b8f-ab93-4fee-bd29-98ce55f9fdad" /> |


## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A