### PR TITLE
[chore] #312 update base image to eclipse-temurin 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk
 WORKDIR /
 COPY hilingual-api/build/libs/app.jar /app.jar
 EXPOSE 8080


### PR DESCRIPTION
## Related issue 🛠
- closed #312 

## Work Description ✏️
- Dockerfile 베이스 이미지 교체
  - `openjdk:17-jdk-slim` → `eclipse-temurin:17-jdk`

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
문제가 없으면 prod 반영 진행하겠습니다. prod 반영 전에 한 번 더 체크 필요합니다.