### PR TITLE
[fix] #309 같은 날짜 일기 중복 저장 요청 race condition 방지

### DIFF
--- a/hilingual-api/src/main/resources/db/migration/V2__add_unique_diary_user_written_date.sql
+++ b/hilingual-api/src/main/resources/db/migration/V2__add_unique_diary_user_written_date.sql
@@ -1,0 +1,5 @@
+-- V2__add_diary_unique_user_written_date.sql
+
+ALTER TABLE diary
+    ADD CONSTRAINT uk_diary_user_written_date
+        UNIQUE (user_id, written_date);

--- a/hilingual-domain/src/main/java/org/sopt/diary/domain/Diary.java
+++ b/hilingual-domain/src/main/java/org/sopt/diary/domain/Diary.java
@@ -19,7 +19,15 @@ import java.util.List;
 import static org.sopt.diary.domain.DiaryTableConstants.*;
 
 @Entity
-@Table(name = DiaryTableConstants.TABLE_DIARY)
+@Table(
+        name = DiaryTableConstants.TABLE_DIARY,
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = UK_DIARY_USER_WRITTEN_DATE,
+                        columnNames = {COLUMN_USER_ID, COLUMN_WRITTEN_DATE}
+                )
+        }
+)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter

--- a/hilingual-domain/src/main/java/org/sopt/diary/domain/DiaryTableConstants.java
+++ b/hilingual-domain/src/main/java/org/sopt/diary/domain/DiaryTableConstants.java
@@ -2,6 +2,8 @@ package org.sopt.diary.domain;
 
 public class DiaryTableConstants {
     public static final String TABLE_DIARY = "diary";
+    public static final String UK_DIARY_USER_WRITTEN_DATE = "uk_diary_user_written_date";
+
     public static final String COLUMN_ID = "id";
     public static final String COLUMN_ORIGINAL_TEXT = "original_text";
     public static final String COLUMN_REWRITE_TEXT = "rewrite_text";

--- a/hilingual-domain/src/main/java/org/sopt/diary/facade/DiarySaver.java
+++ b/hilingual-domain/src/main/java/org/sopt/diary/facade/DiarySaver.java
@@ -2,10 +2,14 @@ package org.sopt.diary.facade;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.diary.domain.Diary;
+import org.sopt.diary.domain.DiaryTableConstants;
+import org.sopt.diary.exception.DiaryAlreadyWrittenException;
+import org.sopt.diary.exception.DiaryCoreErrorCode;
 import org.sopt.diary.repository.DiaryRepository;
 import org.sopt.user.domain.User;
 import org.sopt.usercalendar.facade.UserCalendarFacade;
 import org.sopt.userprofile.facade.UserProfileFacade;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,14 +32,29 @@ public class DiarySaver {
             final String imageUrl,
             final LocalDate writtenDate
     ) {
-        Diary saved = diaryRepository.save(
-                Diary.create(user, originalText, rewriteText, imageUrl, writtenDate)
-        );
+        try {
+            Diary saved = diaryRepository.save(
+                    Diary.create(user, originalText, rewriteText, imageUrl, writtenDate)
+            );
 
-        userCalendarFacade.markWrittenDate(user, writtenDate);
-        userProfileFacade.incrementTotalDiariesAndRecalculateStreak(user.getId(), writtenDate);
+            userCalendarFacade.markWrittenDate(user, writtenDate);
+            userProfileFacade.incrementTotalDiariesAndRecalculateStreak(user.getId(), writtenDate);
 
-        return saved;
+            return saved;
+        } catch (DataIntegrityViolationException ex) {
+            if (isDuplicateDiaryKey(ex)) {
+                throw new DiaryAlreadyWrittenException(DiaryCoreErrorCode.ALREADY_WRITTEN_DIARY);
+            }
+            throw ex;
+        }
     }
 
+    private boolean isDuplicateDiaryKey(DataIntegrityViolationException ex) {
+        Throwable cause = ex.getMostSpecificCause();
+        String message = cause.getMessage();
+        if (message == null) {
+            return false;
+        }
+        return message.contains(DiaryTableConstants.UK_DIARY_USER_WRITTEN_DATE);
+    }
 }

--- a/hilingual-domain/src/main/java/org/sopt/feed/repository/FeedRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/feed/repository/FeedRepository.java
@@ -18,7 +18,7 @@ public interface FeedRepository extends JpaRepository<Diary, Long> {
      * - 차단한/차단당한 유저는 보이지 않음
      */
     @Query("""
-        SELECT
+        SELECT DISTINCT
             d.id AS diaryId,
             d.sharedTime AS sharedDate,
             d.isLiked AS likeCount,
@@ -54,7 +54,7 @@ public interface FeedRepository extends JpaRepository<Diary, Long> {
      * - 차단한/차단당한 유저는 보이지 않음
      */
     @Query("""
-        SELECT
+        SELECT DISTINCT
             d.id AS diaryId,
             d.sharedTime AS sharedDate,
             d.isLiked AS likeCount,


### PR DESCRIPTION
## Related issue 🛠
- closed #309 

## Work Description ✏️
- Flyway 마이그레이션 추가
  - V2__add_unique_diary_user_written_date.sql
  - diary(user_id, written_date) 조합에 유니크 제약(uk_diary_user_written_date) 생성
- 기존 dev/prod는 이미 baseline 적용된 상태 → V2만 정상 적용됨

- 같은 날짜 일기 중복 저장 요청 race condition 방지
  - Diary 엔티티에 @Table(uniqueConstraints=...)로 유니크 제약 선언 추가
  - DB 유니크 제약으로 race condition 상황에서도 확실하게 중복 저장 차단

- 동시 요청 시 두번째거 일기 저장하려 할 때 기존에 있던 예외 반환
  - "HttpStatus.CONFLICT, 40901, "해당 날짜에 이미 작성된 일기가 있습니다."
- 피드 조회 시 혹시나 발생하는 중복 저장된 일기 중 하나만 조회되도록 distinct 키워드 추가


## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
|        V2 마이그레이션 정상 작용 로그      | <img width="1283" height="193" alt="image" src="https://github.com/user-attachments/assets/f08efbee-4b8f-4b64-950f-a0a4b7d0226b" /> |

예전에 올린 Flyway 도입 PR에서 테스트한다고 만들었던 V2마이그레이션이 local에만 남아있어서, 지우고 다시 적용해서 v1,v2 둘 다 적용된 모습입니다.

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
- 기존에는 빠른 더블탭 / 재시도로 인해 같은 날짜 일기가 여러 개 생성되는 race condition 문제가 있었습니다.
- flyway V2 파일 작성했습니다.
- prod db에 있는 유저의 충돌 row 수동 삭제하겠습니다.