### PR TITLE
[refac] #324 타임존에 따른 Streak 업데이트 로직 리팩토링

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/config/WebMvcConfig.java
+++ b/hilingual-api/src/main/java/org/sopt/config/WebMvcConfig.java
@@ -1,0 +1,30 @@
+package org.sopt.config;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.web.TimezoneInterceptor;
+import org.sopt.web.UserTimezoneArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final TimezoneInterceptor timezoneInterceptor;
+    private final UserTimezoneArgumentResolver userTimezoneArgumentResolver;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(timezoneInterceptor)
+                .addPathPatterns("/**");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(userTimezoneArgumentResolver);
+    }
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/auth/service/AuthService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/auth/service/AuthService.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.alarmpreference.facade.AlarmPreferenceFacade;
 import org.sopt.block.facade.BlockFacade;
+import org.sopt.context.TimezoneContextHolder;
 import org.sopt.controller.auth.util.ApplePublicKeyList;
 import org.sopt.controller.auth.dto.SocialLoginReq;
 import org.sopt.controller.auth.dto.SocialLoginRes;
@@ -67,6 +68,7 @@ public class AuthService {
     @Value("${spring.security.oauth2.client.registration.google.client-id}")
     private String googleClientId;
 
+    @Transactional
     public SocialLoginRes socialLogin(String providerToken, SocialLoginReq req) {
         if (providerToken == null || providerToken.length() < PROVIDER_TOKEN_MIN_LENGTH || req.role() != UserRole.USER) {
             throw new UnAuthorizedException(AuthErrorCode.UNAUTHORIZED);
@@ -156,6 +158,7 @@ public class AuthService {
         User user;
         Optional<User> optionalUser = userFacade.getByProviderAndProviderId(String.valueOf(req.provider()), providerId);
 
+        String currentZoneId = TimezoneContextHolder.getTimezone().getId();
         // 이미 유저가 존재하는 경우
         if(optionalUser.isPresent()) {
             user = optionalUser.get();
@@ -164,6 +167,9 @@ public class AuthService {
                 // 탈퇴한 회원인 경우 다시 회원 자격 복구
                 user.revertDeleteUser();
             }
+
+            user.setPrimaryTimezone(currentZoneId);
+
         } else {
             user = User.builder()
                     .provider(String.valueOf(req.provider()))
@@ -171,6 +177,7 @@ public class AuthService {
                     .notifyStatus(false)
                     .registerStatus(RegisterStatus.SOCIAL_LOGIN_COMPLETED)
                     .role(UserRole.USER)
+                    .primaryTimezone(currentZoneId)
                     .build();
 
             user = userFacade.save(user);

--- a/hilingual-api/src/main/java/org/sopt/controller/device/api/DeviceController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/device/api/DeviceController.java
@@ -1,6 +1,7 @@
 package org.sopt.controller.device.api;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.annotation.UserTimezone;
 import org.sopt.controller.device.dto.DeviceReq;
 import org.sopt.controller.device.service.DeviceService;
 import org.sopt.jwt.annotation.UserId;
@@ -9,6 +10,8 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.ZoneId;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,9 +22,10 @@ public class DeviceController {
     @PutMapping("")
     public ResponseEntity<Void> putDeviceInfo(
             @UserId Long userId,
+            @UserTimezone ZoneId userZone,
             @RequestBody DeviceReq req
             ) {
-        deviceService.updateDeviceInfo(userId, req);
+        deviceService.updateDeviceInfo(userId, req, userZone);
         return ResponseEntity.ok().build();
     }
 }

--- a/hilingual-api/src/main/java/org/sopt/controller/device/service/DeviceService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/device/service/DeviceService.java
@@ -7,22 +7,30 @@ import org.sopt.controller.device.exception.MissingDeviceIdentifierException;
 
 import org.sopt.device.dto.DeviceInfo;
 import org.sopt.device.facade.DeviceFacade;
+import org.sopt.user.domain.User;
+import org.sopt.user.facade.UserFacade;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
+
+import java.time.ZoneId;
 
 
 @Service
 @RequiredArgsConstructor
 public class DeviceService {
     private final DeviceFacade deviceFacade;
+    private final UserFacade userFacade;
 
     @Transactional
-    public void updateDeviceInfo(final long userId, final DeviceReq req) {
+    public void updateDeviceInfo(final long userId, final DeviceReq req, final ZoneId userZone) {
         if (!StringUtils.hasText(req.deviceUuid())) {
             throw new MissingDeviceIdentifierException(DeviceApiErrorCode.MISSING_DEVICE_IDENTIFIER);
         }
 
         DeviceInfo deviceInfo = req.toDeviceInfo();
+
+        User user = userFacade.getUserById(userId);
+        user.updatePrimaryTimezone(userZone.getId());
 
         deviceFacade.upsertDevice(userId, deviceInfo);
     }

--- a/hilingual-api/src/main/java/org/sopt/controller/diary/api/DiaryController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/diary/api/DiaryController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import org.sopt.annotation.UserTimezone;
 import org.sopt.controller.diary.dto.CreateDiaryReq;
 import org.sopt.diaryfeedback.diff.dto.DiaryDetailsRes;
 import org.sopt.controller.diary.dto.DiaryRes;
@@ -13,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,11 +26,12 @@ public class DiaryController {
     @PostMapping
     public ResponseEntity<DiaryRes> createDiary(
             @UserId Long userId,
+            @UserTimezone ZoneId userZone,
             @Valid @RequestBody CreateDiaryReq req
     ) {
         LocalDate writtenDate = LocalDate.parse(req.date());
         return ResponseEntity.ok(
-                diaryService.createDiaryWithFeedback(userId, req.originalText(), writtenDate, req.image())
+                diaryService.createDiaryWithFeedback(userId, req.originalText(), writtenDate, req.image(), userZone)
         );
     }
 
@@ -39,15 +42,6 @@ public class DiaryController {
             @PathVariable("diaryId") @NotNull @Min(1) Long diaryId
     ){
         return ResponseEntity.ok(diaryService.getDiaryDetails(userId, diaryId));
-    }
-
-    @DeleteMapping("/{diaryId}")
-    public ResponseEntity<Void> removeDiary(
-            @UserId Long userId,
-            @PathVariable("diaryId") @NotNull @Min(1) Long diaryId
-    ){
-        diaryService.removeDairy(userId, diaryId);
-        return ResponseEntity.ok().build();
     }
 
     @PatchMapping("/{diaryId}/publish")

--- a/hilingual-api/src/main/java/org/sopt/controller/diary/service/DiaryService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/diary/service/DiaryService.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Locale;
@@ -56,9 +57,12 @@ public class DiaryService {
             Long userId,
             String originalText,
             LocalDate writtenDate,
-            CreateDiaryReq.ImageRef imageRef
+            CreateDiaryReq.ImageRef imageRef,
+            ZoneId userZone
     ) {
         User user = userFacade.getUserById(userId);
+
+        user.setPrimaryTimezone(userZone.getId());
         diaryFacade.validateNotExists(user, writtenDate);
 
         String fileKey = bindDiaryImageIfPresent(userId, writtenDate, imageRef);
@@ -69,7 +73,8 @@ public class DiaryService {
                 originalText,
                 ai.rewriteText(),
                 fileKey,
-                writtenDate
+                writtenDate,
+                userZone
         );
 
         saveFeedbacks(diary, ai.feedbackList());
@@ -131,21 +136,6 @@ public class DiaryService {
                 .isPublished(diary.getIsPublic())
                 .isAdWatched(diary.getIsAdWatched())
                 .build();
-    }
-
-    @Transactional
-    public void removeDairy(final Long userId, final Long diaryId) {
-        diaryFacade.validateDiaryOwnership(userId, diaryId);
-        Diary diary = diaryFacade.getDiaryById(diaryId);
-
-        String imageKey = diary.getImageUrl();
-        if (imageKey != null && !imageKey.isBlank()) {
-            s3Service.deleteObject(imageKey);
-        }
-
-        diaryFacade.deleteDiary(userId, diaryId);
-        userCalendarFacade.markDeleted(userId, diary.getWrittenDate());
-        userProfileFacade.decrementTotalDiariesAndRecalculateStreak(userId, diary.getWrittenDate());
     }
 
     @Transactional

--- a/hilingual-api/src/main/java/org/sopt/controller/token/TokenService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/token/TokenService.java
@@ -2,6 +2,7 @@ package org.sopt.controller.token;
 
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
+import org.sopt.context.TimezoneContextHolder;
 import org.sopt.controller.auth.dto.SocialLoginReq;
 import org.sopt.controller.auth.dto.SocialLoginRes;
 import org.sopt.exception.AuthErrorCode;
@@ -17,6 +18,7 @@ import org.sopt.jwt.core.JwtTokenProvider;
 import org.sopt.jwt.core.TokenHasher;
 import org.sopt.jwt.core.TokenId;
 import org.sopt.jwt.support.AuthConstants;
+import org.sopt.user.domain.User;
 import org.sopt.user.facade.UserFacade;
 import org.sopt.user.type.RegisterStatus;
 import org.springframework.stereotype.Service;
@@ -56,7 +58,11 @@ public class TokenService {
         System.out.println("1. 토큰에서 뽑은 identifier: " + identifier); // Redis의 UUID와 똑같은지 확인
 
         AuthProvider provider = AuthProvider.valueOf(claims.get(JwtClaimsKeys.PROVIDER, String.class));
-        UserRole role = userFacade.getUserById(userId).getRole();
+
+        User user = userFacade.getUserById(userId);
+        UserRole role = user.getRole();
+        String currentZoneId = TimezoneContextHolder.getTimezone().getId();
+        user.setPrimaryTimezone(currentZoneId);
 
         // Redis 에서 토큰 정보 조회 & 해시 대조
         String tokenId = new TokenId(userId, identifier).toString();

--- a/hilingual-api/src/main/java/org/sopt/controller/usercalendar/api/UserCalendarController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/usercalendar/api/UserCalendarController.java
@@ -1,6 +1,7 @@
 package org.sopt.controller.usercalendar.api;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.annotation.UserTimezone;
 import org.sopt.jwt.annotation.UserId;
 import org.sopt.usercalendar.dto.UserCalendarDiarySummaryRes;
 import org.sopt.usercalendar.dto.UserCalendarMonthlyRes;
@@ -13,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
 
 @RestController
@@ -41,6 +43,7 @@ public class UserCalendarController {
     @GetMapping("/{date}/topic")
     public ResponseEntity<UserCalendarTopicRes> getTopicByDate(
             @UserId Long userId,
+            @UserTimezone final ZoneId userZone,
             @PathVariable final String date
     ) {
         final LocalDate parsedDate;
@@ -51,7 +54,7 @@ public class UserCalendarController {
             throw new UserCalendarInvalidDateFormatException(UserCalendarApiErrorCode.INVALID_DATE_FORMAT);
         }
 
-        return ResponseEntity.ok(userCalendarService.getTopicByDate(userId, parsedDate));
+        return ResponseEntity.ok(userCalendarService.getTopicByDate(userId, parsedDate, userZone));
     }
 
     @GetMapping("/month")

--- a/hilingual-api/src/main/java/org/sopt/controller/usercalendar/service/UserCalendarService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/usercalendar/service/UserCalendarService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 
 @Service
@@ -40,11 +41,11 @@ public class UserCalendarService {
         }
     }
 
-    public UserCalendarTopicRes getTopicByDate(final long userId, final LocalDate date) {
-        if (date.isAfter(LocalDate.now())) {
+    public UserCalendarTopicRes getTopicByDate(final long userId, final LocalDate date, final ZoneId userZone) {
+        if (date.isAfter(LocalDate.now(userZone))) {
             throw new FutureDateNotAllowedException(UserCalendarApiErrorCode.FUTURE_DATE_NOT_ALLOWED);
         }
-        return topicFacade.findTopicByDate(userId, date);
+        return topicFacade.findTopicByDate(userId, date, userZone);
     }
 
     public UserCalendarMonthlyRes getWrittenDatesOfMonth(final Long userId, final int year, final int month) {

--- a/hilingual-api/src/main/java/org/sopt/web/TimezoneInterceptor.java
+++ b/hilingual-api/src/main/java/org/sopt/web/TimezoneInterceptor.java
@@ -1,0 +1,31 @@
+package org.sopt.web;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.sopt.context.TimezoneContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class TimezoneInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull Object handler) {
+        String timezone = request.getHeader("X-Timezone");
+
+        if (StringUtils.hasText(timezone)) {
+            TimezoneContextHolder.setTimezone(timezone);
+        } else {
+            TimezoneContextHolder.setTimezone("Asia/Seoul"); // 헤더가 없을 경우
+        }
+
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull Object handler, Exception ex) {
+        TimezoneContextHolder.clear();
+    }
+}

--- a/hilingual-api/src/main/java/org/sopt/web/UserTimezoneArgumentResolver.java
+++ b/hilingual-api/src/main/java/org/sopt/web/UserTimezoneArgumentResolver.java
@@ -1,0 +1,36 @@
+package org.sopt.web;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.sopt.annotation.UserTimezone;
+import org.sopt.context.TimezoneContextHolder;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import java.time.ZoneId;
+
+@Component
+public class UserTimezoneArgumentResolver implements HandlerMethodArgumentResolver {
+
+    // 어떤 파라미터에 이 Resolver를 적용할 것인지?
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasAnnotation = parameter.hasParameterAnnotation(UserTimezone.class);
+        boolean isZoneIdType = ZoneId.class.isAssignableFrom(parameter.getParameterType());
+
+        return hasAnnotation && isZoneIdType;
+    }
+
+    // 파라미터에 실제로 주입할 값
+    @Override
+    public Object resolveArgument(@NonNull MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  @NonNull NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+
+        // Interceptor가 파싱해서 ThreadLocal에 넣어둔 타임존을 반환
+        return TimezoneContextHolder.getTimezone();
+    }
+}

--- a/hilingual-api/src/main/resources/db/migration/V5__add_users_primary_timezone.sql
+++ b/hilingual-api/src/main/resources/db/migration/V5__add_users_primary_timezone.sql
@@ -1,0 +1,9 @@
+ALTER TABLE users
+    ADD COLUMN primary_timezone VARCHAR(255) DEFAULT 'Asia/Seoul';
+
+UPDATE users
+SET primary_timezone = 'Asia/Seoul'
+WHERE primary_timezone IS NULL;
+
+ALTER TABLE users
+    ALTER COLUMN primary_timezone SET NOT NULL;

--- a/hilingual-common/src/main/java/org/sopt/annotation/UserTimezone.java
+++ b/hilingual-common/src/main/java/org/sopt/annotation/UserTimezone.java
@@ -1,0 +1,14 @@
+package org.sopt.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 컨트롤러에서 유저의 타임존(ZoneId)을 주입받기 위한 커스텀 어노테이션
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserTimezone {
+}

--- a/hilingual-common/src/main/java/org/sopt/context/TimezoneContextHolder.java
+++ b/hilingual-common/src/main/java/org/sopt/context/TimezoneContextHolder.java
@@ -1,0 +1,25 @@
+package org.sopt.context;
+
+import java.time.ZoneId;
+
+public class TimezoneContextHolder {
+    private static final ThreadLocal<ZoneId> TIMEZONE_HOLDER = new ThreadLocal<>();
+
+    private static final ZoneId DEFAULT_ZONE = ZoneId.of("Asia/Seoul");
+
+    public static void setTimezone(String timezoneId) {
+        try {
+            TIMEZONE_HOLDER.set(ZoneId.of(timezoneId));
+        } catch (Exception e) {
+            TIMEZONE_HOLDER.set(DEFAULT_ZONE); // 잘못된 값이 오면 기본값 사용
+        }
+    }
+
+    public static ZoneId getTimezone() {
+        return TIMEZONE_HOLDER.get() != null ? TIMEZONE_HOLDER.get() : DEFAULT_ZONE;
+    }
+
+    public static void clear() {
+        TIMEZONE_HOLDER.remove();
+    }
+}

--- a/hilingual-domain/src/main/java/org/sopt/diary/facade/DiaryFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/diary/facade/DiaryFacade.java
@@ -69,13 +69,6 @@ public class DiaryFacade {
         return diarySaver.save(user, originalText, rewriteText, imageUrl, writtenDate, userZone);
     }
 
-    /*
-     * Remover
-     */
-    @Transactional
-    public void deleteDiary(final long userId, final long diaryId) {
-        diaryRemover.deleteDiary(userId, diaryId);
-    }
 
     public void deleteAllByUserId(final long userId) {
         diaryRemover.deleteAllByUserId(userId);

--- a/hilingual-domain/src/main/java/org/sopt/diary/facade/DiaryFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/diary/facade/DiaryFacade.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 
 @Component
@@ -64,8 +65,8 @@ public class DiaryFacade {
      * Saver
      */
     @Transactional
-    public Diary saveDiary(User user, String originalText, String rewriteText, String imageUrl, LocalDate writtenDate) {
-        return diarySaver.save(user, originalText, rewriteText, imageUrl, writtenDate);
+    public Diary saveDiary(User user, String originalText, String rewriteText, String imageUrl, LocalDate writtenDate, ZoneId userZone) {
+        return diarySaver.save(user, originalText, rewriteText, imageUrl, writtenDate, userZone);
     }
 
     /*

--- a/hilingual-domain/src/main/java/org/sopt/diary/facade/DiaryRemover.java
+++ b/hilingual-domain/src/main/java/org/sopt/diary/facade/DiaryRemover.java
@@ -1,33 +1,14 @@
 package org.sopt.diary.facade;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.diary.domain.Diary;
-import org.sopt.diary.exception.DiaryCoreErrorCode;
-import org.sopt.diary.exception.DiaryForbiddenException;
-import org.sopt.diary.exception.DiaryNotFoundException;
 import org.sopt.diary.repository.DiaryRepository;
-import org.sopt.userprofile.facade.UserProfileFacade;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
 public class DiaryRemover {
 
     private final DiaryRepository diaryRepository;
-    private final UserProfileFacade userProfileFacade;
-
-    @Transactional
-    public void deleteDiary(final Long userId, final Long diaryId) {
-        Diary diary = diaryRepository.findById(diaryId)
-                .orElseThrow(() -> new DiaryNotFoundException(DiaryCoreErrorCode.DIARY_NOT_FOUND));
-
-        if (!diary.getUser().getId().equals(userId)) {
-            throw new DiaryForbiddenException(DiaryCoreErrorCode.DIARY_FORBIDDEN);
-        }
-        diaryRepository.delete(diary);
-        userProfileFacade.decrementTotalDiariesAndRecalculateStreak(userId, diary.getWrittenDate());
-    }
 
     public void deleteAllByUserId(final Long userId) {
         diaryRepository.deleteAllByUserId(userId);

--- a/hilingual-domain/src/main/java/org/sopt/diary/facade/DiarySaver.java
+++ b/hilingual-domain/src/main/java/org/sopt/diary/facade/DiarySaver.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 
 @Component
 @RequiredArgsConstructor
@@ -30,15 +31,16 @@ public class DiarySaver {
             final String originalText,
             final String rewriteText,
             final String imageUrl,
-            final LocalDate writtenDate
-    ) {
+            final LocalDate writtenDate,
+            final ZoneId userZone
+            ) {
         try {
             Diary saved = diaryRepository.save(
                     Diary.create(user, originalText, rewriteText, imageUrl, writtenDate)
             );
 
             userCalendarFacade.markWrittenDate(user, writtenDate);
-            userProfileFacade.incrementTotalDiariesAndRecalculateStreak(user.getId(), writtenDate);
+            userProfileFacade.incrementTotalDiariesAndRecalculateStreak(user.getId(), writtenDate, userZone);
 
             return saved;
         } catch (DataIntegrityViolationException ex) {

--- a/hilingual-domain/src/main/java/org/sopt/topic/facade/TopicFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/topic/facade/TopicFacade.java
@@ -10,9 +10,7 @@ import org.sopt.usercalendar.dto.UserCalendarTopicRes;
 import org.sopt.usercalendar.facade.UserCalendarFacade;
 import org.springframework.stereotype.Component;
 
-import java.time.Duration;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.*;
 import java.util.Optional;
 
 @Component
@@ -22,7 +20,7 @@ public class TopicFacade {
     private final TopicRetriever topicRetriever;
     private final UserCalendarFacade userCalendarFacade;
 
-    public UserCalendarTopicRes findTopicByDate(Long userId, LocalDate date) {
+    public UserCalendarTopicRes findTopicByDate(Long userId, LocalDate date, ZoneId userZone) {
         Optional<UserCalendar> userCalendar = userCalendarFacade.findByUserIdAndDate(userId, date);
         if (userCalendar.isPresent() && userCalendar.get().getStatus() == WriteStatus.DELETED) {
             return UserCalendarTopicRes.of(" ", " ", -1);
@@ -31,13 +29,13 @@ public class TopicFacade {
         final Topic topic = topicRetriever.findByDate(date)
                 .orElseThrow(() -> new UserCalendarTopicNotFoundException(UserCalendarCoreErrorCode.TOPIC_NOT_FOUND));
 
-        int remainingTime = calculateRemainingMinutesUntilDeadline(date);
+        int remainingTime = calculateRemainingMinutesUntilDeadline(date, userZone);
         return UserCalendarTopicRes.of(topic.getTopicKor(), topic.getTopicEn(), remainingTime);
     }
 
-    private int calculateRemainingMinutesUntilDeadline(LocalDate topicDate) {
-        final LocalDateTime now = LocalDateTime.now();
-        final LocalDateTime deadline = topicDate.plusDays(2).atStartOfDay();
+    private int calculateRemainingMinutesUntilDeadline(LocalDate topicDate, ZoneId userZone) {
+        final ZonedDateTime now = ZonedDateTime.now(userZone);
+        final ZonedDateTime deadline = topicDate.plusDays(2).atStartOfDay(userZone);
         long secondsRemaining = Duration.between(now, deadline).getSeconds();
 
         if (secondsRemaining <= 0) return 0;

--- a/hilingual-domain/src/main/java/org/sopt/user/domain/User.java
+++ b/hilingual-domain/src/main/java/org/sopt/user/domain/User.java
@@ -49,6 +49,9 @@ public class User extends BaseTimeEntity {
     @Column(name = COLUMN_REGISTER_STATUS, nullable = false)
     private RegisterStatus registerStatus = RegisterStatus.SOCIAL_LOGIN_COMPLETED;
 
+    @Column(name = COLUMN_PRIMARY_TIMEZONE, nullable = false)
+    private String primaryTimezone = "Asia/Seoul";
+
     @Column(name = COLUMN_IS_DELETED, nullable = false)
     @ColumnDefault("false")
     @Builder.Default
@@ -70,6 +73,12 @@ public class User extends BaseTimeEntity {
 
     public void updateRegisterStatus(final RegisterStatus registerStatus) {
         this.registerStatus = registerStatus;
+    }
+
+    public void updatePrimaryTimezone(String newTimezone) {
+        if (newTimezone != null && !this.primaryTimezone.equals(newTimezone)) {
+            this.primaryTimezone = newTimezone;
+        }
     }
 
     public void revertDeleteUser() {

--- a/hilingual-domain/src/main/java/org/sopt/user/domain/UserTableConstants.java
+++ b/hilingual-domain/src/main/java/org/sopt/user/domain/UserTableConstants.java
@@ -11,5 +11,6 @@ public class UserTableConstants {
     public static final String COLUMN_DELETED_AT = "deleted_at";
     public static final String COLUMN_NOTIFY_STATUS = "notify_status";
     public static final String COLUMN_REGISTER_STATUS = "register_status";
+    public static final String COLUMN_PRIMARY_TIMEZONE = "primary_timezone";
     public static final String COLUMN_USER = "user";
 }

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileFacade.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 
@@ -68,12 +69,8 @@ public class UserProfileFacade {
     /**
     updater
      */
-    public void incrementTotalDiariesAndRecalculateStreak(final long userId, final LocalDate writtenDate) {
-        userProfileUpdater.incrementTotalDiariesAndRecalculateStreak(userId, writtenDate);
-    }
-
-    public void decrementTotalDiariesAndRecalculateStreak(final long userId, final LocalDate writtenDate) {
-        userProfileUpdater.decrementTotalDiariesAndRecalculateStreak(userId, writtenDate);
+    public void incrementTotalDiariesAndRecalculateStreak(final long userId, final LocalDate writtenDate, final ZoneId userZone) {
+        userProfileUpdater.incrementTotalDiariesAndRecalculateStreak(userId, writtenDate, userZone);
     }
 
     public int updateProfileImgByUserId(final long userId, final String newImgUrl, final LocalDateTime updatedAt) {

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileUpdater.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileUpdater.java
@@ -36,17 +36,6 @@ public class UserProfileUpdater {
     }
 
     /**
-     * 일기 삭제 시 totalDiaries 감소 및 streak 재계산
-     */
-    @Transactional
-    public void decrementTotalDiariesAndRecalculateStreak(Long userId, LocalDate writtenDate) {
-        UserProfile profile = userProfileRetriever.findByUserId(userId);
-        updateStreakOnDelete(userId, writtenDate); // 삭제 규칙대로 streak 반영
-        resyncTotal(profile);                      // WRITTEN 개수로 동기화
-        userProfileRepository.save(profile);
-    }
-
-    /**
      * 일기를 쓴 순간에 호출 (streak 업데이트)
      */
     @Transactional
@@ -82,85 +71,6 @@ public class UserProfileUpdater {
         profile.updateStreak(newStreak);
         userProfileRepository.save(profile);
     }
-
-
-    /**
-     * 일기를 삭제한 순간에 호출 (streak 업데이트)
-     * 규칙 요약:
-     *  - 어제(Y) 삭제: 오늘(D)이 있으면 즉시 1, 없으면 0
-     *  - 오늘(D) 삭제: 즉시 0 (즉시 단절)
-     *  - 그제(DBY) 삭제: 고정값 매핑
-     *      Y=O,D=O → 2 / Y=O,D=X → 1 / Y=X,D=O → 1 / Y=X,D=X → 0
-     *  - 그 이전(≤DBY-1) 삭제:
-     *      Y=O → calc(Y) + (D ? 1 : 0)
-     *      Y=X & D=O → min(현재 streak, calc(DBY))
-     *      Y=X & D=X → calc(DBY)
-     */
-    @Transactional
-    public void updateStreakOnDelete(Long userId, LocalDate writtenDate) {
-        UserProfile profile = userProfileRetriever.findByUserId(userId);
-
-        final ZoneId KST = ZoneId.of("Asia/Seoul");
-        LocalDate today = LocalDate.now(KST);         // D (예: 17)
-        LocalDate yesterday = today.minusDays(1);     // Y (예: 16)
-        LocalDate dby = today.minusDays(2);           // DBY (예: 15)
-
-        WriteStatus dStatus = userCalendarFacade.getStatus(profile.getUser(), today);
-        WriteStatus yStatus = userCalendarFacade.getStatus(profile.getUser(), yesterday);
-
-        boolean dWritten = (dStatus == WriteStatus.WRITTEN);
-        boolean yWritten = (yStatus == WriteStatus.WRITTEN);
-
-        int newStreak;
-
-        if (writtenDate.equals(today)) {
-            // 오늘 삭제 → 즉시 단절
-            newStreak = 0;
-
-        } else if (writtenDate.equals(yesterday)) {
-            // 어제 삭제 → 오늘 WRITTEN이면 1, 아니면 0
-            newStreak = dWritten ? 1 : 0;
-
-        } else if (writtenDate.equals(dby)) {
-            // 그제(DBY) 삭제: 고정값
-            if (yWritten && dWritten) {
-                newStreak = 2;
-            } else if (yWritten) {
-                newStreak = 1;
-            } else if (dWritten) {
-                newStreak = 1;
-            } else {
-                newStreak = 0;
-            }
-
-        } else if (writtenDate.isBefore(dby)) {
-            // 그 이전(≤DBY-1) 삭제 — 점진 하향, Y의 NONE/DELETED 구분
-            if (yWritten) {
-                int base = calculateStreakFromDate(profile.getUser(), yesterday);
-                newStreak = base + (dWritten ? 1 : 0);
-            } else {
-                if (yStatus == WriteStatus.DELETED) {
-                    // 어제가 하드 미싱이면 오늘 단독만 가능
-                    newStreak = dWritten ? 1 : 0;
-                } else { // yStatus == NONE (소프트 미싱)
-                    int baseFromDBY = calculateStreakFromDate(profile.getUser(), dby);
-                    int current = profile.getStreak();
-                    newStreak = Math.min(current, baseFromDBY);
-                }
-            }
-
-        } else {
-            // 미래 날짜 등 비정상 입력: 보수적 환산
-            int base = calculateStreakFromDate(profile.getUser(), yesterday);
-            newStreak = base + (dWritten ? 1 : 0);
-        }
-
-        profile.updateStreak(newStreak);
-        userProfileRepository.save(profile);
-    }
-
-
-
 
     // 특정 날짜부터 과거로 연속 작성 일수를 계산하는 헬퍼 메서드
     private int calculateStreakFromDate(User user, LocalDate startDate) {

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileUpdater.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileUpdater.java
@@ -11,10 +11,10 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.*;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Component
@@ -28,9 +28,9 @@ public class UserProfileUpdater {
      * 일기 작성 시 totalDiaries 증가 및 streak 재계산
      */
     @Transactional
-    public void incrementTotalDiariesAndRecalculateStreak(Long userId, LocalDate writtenDate) {
+    public void incrementTotalDiariesAndRecalculateStreak(Long userId, LocalDate writtenDate, ZoneId userZone) {
         UserProfile profile = userProfileRetriever.findByUserId(userId);
-        updateStreakOnWrite(userId, writtenDate); // 캘린더 상태 기준으로 streak 반영
+        updateStreakOnWrite(profile, writtenDate, userZone); // 캘린더 상태 기준으로 streak 반영
         resyncTotal(profile);                     // WRITTEN 개수로 동기화
         userProfileRepository.save(profile);
     }
@@ -38,13 +38,10 @@ public class UserProfileUpdater {
     /**
      * 일기를 쓴 순간에 호출 (streak 업데이트)
      */
-    @Transactional
-    public void updateStreakOnWrite(Long userId, LocalDate writtenDate) {
-        UserProfile profile = userProfileRetriever.findByUserId(userId);
-
-        final ZoneId KST = ZoneId.of("Asia/Seoul");
-        LocalDate today     = LocalDate.now(KST);   // D
-        LocalDate yesterday = today.minusDays(1);   // Y
+    public void updateStreakOnWrite(UserProfile profile, LocalDate writtenDate, ZoneId userZone) {
+        // 전달받은 유저의 로컬 타임존
+        LocalDate today     = LocalDate.now(userZone); // D
+        LocalDate yesterday = today.minusDays(1); // Y
 
         // 캘린더 사실값 조회
         WriteStatus yStatus = userCalendarFacade.getStatus(profile.getUser(), yesterday);
@@ -68,8 +65,8 @@ public class UserProfileUpdater {
         }
         // 그 외 날짜는 변화 없음
 
+        // 객체 상태만 업데이트 (저장은 호출한 부모 메서드에서 처리)
         profile.updateStreak(newStreak);
-        userProfileRepository.save(profile);
     }
 
     // 특정 날짜부터 과거로 연속 작성 일수를 계산하는 헬퍼 메서드
@@ -84,34 +81,54 @@ public class UserProfileUpdater {
     }
 
     /**
-     * 매일 자정 → 최근 2일 작성 여부 검사 후 streak 리셋 or 유지
+     * [스케줄러]
+     * 매 15분마다 실행, 해당 시간에 자정을 맞이한 타임존 중
+     * 스트릭을 잃을 가능성이 있는(streak > 0) 유저만 검사
      */
-    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0,15,30,45 * * * *")
     @Transactional
-    public void resetStreakIfBroken() {
-        LocalDate today     = LocalDate.now(ZoneId.of("Asia/Seoul"));
-        LocalDate yesterday = today.minusDays(1);
-        LocalDate dayBeforeYesterday = today.minusDays(2);
+    public void resetStreakIfBrokenGlobal() {
+        Instant now = Instant.now();
 
-        List<UserProfile> all = userProfileRepository.findAll();
+        // 현재 자정을 맞이한 타임존만 추출
+        Set<String> midnightZones = ZoneId.getAvailableZoneIds().stream()
+                .filter(zone -> {
+                    LocalTime localTime = LocalTime.ofInstant(now, ZoneId.of(zone));
+                    return localTime.getHour() == 0 && localTime.getMinute() == 0;
+                })
+                .collect(Collectors.toSet());
 
-        for (UserProfile profile : all) {
+        if (midnightZones.isEmpty()) {
+            return;
+        }
+
+        // 해당 타임존이면서 스트릭이 1 이상인 대상만 조회 (streak 0인 대상은 조회할 필요 X)
+        List<UserProfile> targetProfiles = userProfileRepository.findTargetsForStreakReset(midnightZones, 0);
+
+        if (targetProfiles.isEmpty()) {
+            return;
+        }
+
+        // 대상 유저들의 로컬 날짜 기준으로 스트릭 검사 및 갱신
+        for (UserProfile profile : targetProfiles) {
+            ZoneId userZone = ZoneId.of(profile.getUser().getPrimaryTimezone());
+            LocalDate today = LocalDate.now(userZone);
+            LocalDate yesterday = today.minusDays(1);
+            LocalDate dayBeforeYesterday = today.minusDays(2);
+
             WriteStatus y   = userCalendarFacade.getStatus(profile.getUser(), yesterday);
             WriteStatus dby = userCalendarFacade.getStatus(profile.getUser(), dayBeforeYesterday);
 
-            // (15 X, 16 O) → 1
-            if (dby != WriteStatus.WRITTEN && y == WriteStatus.WRITTEN) {
-                profile.updateStreak(1);
-                continue;
-            }
-            // (15 X, 16 X) → 0
+            // 어제와 그제 모두 작성하지 않은 경우 스트릭 초기화
             if (dby != WriteStatus.WRITTEN && y != WriteStatus.WRITTEN) {
                 profile.updateStreak(0);
-                continue;
             }
-            // (15 O, 16 X) 또는 (15 O, 16 O) → 유지
+            // (15일 X, 16일 O) -> 어제 작성했으므로 스트릭 1 (이 케이스는 updateStreakOnWrite에서 처리되나 안전하게 처리)
+            else if (dby != WriteStatus.WRITTEN) {
+                profile.updateStreak(1);
+            }
+            // 그 외 (연속 작성 중) -> 기존 스트릭 유지
         }
-        userProfileRepository.saveAll(all);
     }
 
     private void resyncTotal(UserProfile profile) {

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/repository/UserProfileRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/repository/UserProfileRepository.java
@@ -3,7 +3,6 @@ package org.sopt.userprofile.repository;
 import org.sopt.user.domain.User;
 import org.sopt.userprofile.domain.UserProfile;
 import org.sopt.userprofile.dto.UserSearchProjection;
-import org.springframework.cglib.core.Local;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -12,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface UserProfileRepository extends JpaRepository<UserProfile, Long> {
     boolean existsByNickname(String nickname);
@@ -38,6 +38,21 @@ public interface UserProfileRepository extends JpaRepository<UserProfile, Long> 
             @Param("userId") Long userId,
             @Param("profileImg") String profileImg,
             @Param("updatedAt") LocalDateTime updatedAt
+    );
+
+    /*
+     * 스트릭 스케줄러용 최적화 쿼리
+     * 지정된 타임존 목록에 속해 있으면서, 스트릭이 0보다 큰 유저의 프로필만 User와 함께 페치 조인
+     */
+    @Query("""
+        SELECT up FROM UserProfile up
+        JOIN FETCH up.user u
+        WHERE u.primaryTimezone IN :timezones
+          AND up.streak > :streakThreshold
+    """)
+    List<UserProfile> findTargetsForStreakReset(
+            @Param("timezones") Set<String> timezones,
+            @Param("streakThreshold") int streakThreshold
     );
 
     /*


### PR DESCRIPTION
## Related issue 🛠
- closed #324 

## Work Description ✏️
- 자정마다 streak 업데이트 로직 타임존별로 처리
- 일기 작성 시 streak 업데이트 유저별 타임존에 맞추어 처리
- 모든 헤더에 Timezone을 받아오는 것으로 수정
- streak 조회 시 Timezone 고려(기본 정보 조회API)
- remainingTime 조회 시 Timezone 고려(작성되지 않은 일기 주제 조회API)

## Screenshot 📸
테스트 내용
- Asia/Seoul이었던 유저가 Header에 America/New York에서 일기 작성했을 때(헤더 정보)
- 기본 정보 조회API에서 America/New York 유저
- 기본 정보 조회API에서 Asia/Seoul 유저
- 작성되지 않은 일기 주제 조회 API에서 America/New York 유저
- 작성되지 않은 일기 주제 조회 API에서 Asia/Seoul 유저

## Uncompleted Tasks 😅
- [ ] 디바이스API 쏠 때 deviceName, deviceType, osType 미저장됨
- [ ] 디바이스API 헤더 우선 정책

## To Reviewers 📢
N/A