### PR TITLE
[feat] #330 QueryDSL 도입 및 예시 적용

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/feed/service/FeedService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/feed/service/FeedService.java
@@ -23,7 +23,7 @@ import org.sopt.likeddiary.facade.LikedDiaryFacade;
 import org.sopt.user.domain.User;
 import org.sopt.user.facade.UserFacade;
 import org.sopt.userprofile.domain.UserProfile;
-import org.sopt.userprofile.dto.UserSearchProjection;
+import org.sopt.userprofile.dto.UserSearchDto;
 import org.sopt.userprofile.facade.UserProfileFacade;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -174,19 +174,19 @@ public class FeedService {
         String likeKeyword = "%" + keyword + "%";
         String startKeyword = keyword + "%";
 
-        List<UserSearchProjection> userList = userProfileFacade.getUserListByNickname(userId, likeKeyword, startKeyword);
+        List<UserSearchDto> userList = userProfileFacade.getUserListByNickname(userId, likeKeyword, startKeyword);
 
         List<UserListRes.SearchUser> searchUserList = userList.stream()
                 .map(projection -> {
-                    String originalImgUrl = projection.getProfileImg();
+                    String originalImgUrl = projection.profileImg();
                     String publicImgUrl = (originalImgUrl != null) ? s3Service.toPublicUrl(originalImgUrl) : " ";
 
                     return new UserListRes.SearchUser(
-                            projection.getUserId(),
-                            (publicImgUrl != null) ? publicImgUrl : " ",
-                            projection.getNickname(),
-                            projection.getIsFollowing(),
-                            projection.getIsFollowed()
+                            projection.userId(),
+                            publicImgUrl,
+                            projection.nickname(),
+                            projection.isFollowing(),
+                            projection.isFollowed()
                     );
                 })
                 .toList();

--- a/hilingual-domain/build.gradle
+++ b/hilingual-domain/build.gradle
@@ -1,7 +1,29 @@
+def querydslDir = layout.buildDirectory.dir("generated/querydsl")
+
+sourceSets {
+    main.java.srcDirs += [querydslDir]
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(querydslDir)
+}
+
+tasks.named("clean").configure {
+    doLast {
+        delete(querydslDir)
+    }
+}
+
 dependencies {
     implementation project(":hilingual-external")
     implementation project(":hilingual-common")
     implementation project(":hilingual-auth")
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
     // database
     runtimeOnly 'org.postgresql:postgresql'

--- a/hilingual-domain/src/main/java/org/sopt/common/config/QueryDslConfig.java
+++ b/hilingual-domain/src/main/java/org/sopt/common/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package org.sopt.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/dto/UserSearchDto.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/dto/UserSearchDto.java
@@ -1,0 +1,10 @@
+package org.sopt.userprofile.dto;
+
+public record UserSearchDto(
+        Long userId,
+        String profileImg,
+        String nickname,
+        Boolean isFollowing,
+        Boolean isFollowed
+) {
+}

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/dto/UserSearchProjection.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/dto/UserSearchProjection.java
@@ -1,9 +1,0 @@
-package org.sopt.userprofile.dto;
-
-public interface UserSearchProjection {
-    Long getUserId();
-    String getProfileImg();
-    String getNickname();
-    Boolean getIsFollowing();
-    Boolean getIsFollowed();
-}

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileFacade.java
@@ -2,7 +2,7 @@ package org.sopt.userprofile.facade;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.userprofile.domain.UserProfile;
-import org.sopt.userprofile.dto.UserSearchProjection;
+import org.sopt.userprofile.dto.UserSearchDto;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
@@ -46,7 +46,7 @@ public class UserProfileFacade {
         return userProfileRetriever.isNicknameExists(nickname);
     }
 
-    public List<UserSearchProjection> getUserListByNickname(Long userId, String keyword, String startKeyword) {
+    public List<UserSearchDto> getUserListByNickname(Long userId, String keyword, String startKeyword) {
         return userProfileRetriever.findUsersByNickname(userId, keyword, startKeyword);
     }
 

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileRetriever.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileRetriever.java
@@ -2,9 +2,10 @@ package org.sopt.userprofile.facade;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.userprofile.domain.UserProfile;
-import org.sopt.userprofile.dto.UserSearchProjection;
+import org.sopt.userprofile.dto.UserSearchDto;
 import org.sopt.userprofile.exception.UserProfileNotFoundException;
 import org.sopt.userprofile.exception.UserProfileCoreErrorCode;
+import org.sopt.userprofile.repository.UserProfileQueryRepository;
 import org.sopt.userprofile.repository.UserProfileRepository;
 import org.springframework.stereotype.Component;
 
@@ -16,6 +17,7 @@ import java.util.Optional;
 public class UserProfileRetriever {
 
     private final UserProfileRepository userProfileRepository;
+    private final UserProfileQueryRepository userProfileQueryRepository;
 
     public UserProfile findByUserId(final Long userId) {
         return userProfileRepository.findByUserId(userId)
@@ -38,8 +40,8 @@ public class UserProfileRetriever {
         return userProfileRepository.existsByNickname(nickname);
     }
 
-    public List<UserSearchProjection> findUsersByNickname(Long userId, String keyword, String startKeyword) {
-        return userProfileRepository.searchUserListByKeyword(userId, keyword, startKeyword);
+    public List<UserSearchDto> findUsersByNickname(Long userId, String keyword, String startKeyword) {
+        return userProfileQueryRepository.searchUserListByKeyword(userId, keyword, startKeyword);
     }
 
     public long count() {

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/repository/UserProfileQueryRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/repository/UserProfileQueryRepository.java
@@ -1,0 +1,75 @@
+package org.sopt.userprofile.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.sopt.block.domain.QBlock;
+import org.sopt.follow.domain.QFollow;
+import org.sopt.userprofile.domain.QUserProfile;
+import org.sopt.userprofile.dto.UserSearchDto;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class UserProfileQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 닉네임 키워드에 해당하는 유저 목록을 조회한다.
+     * - 현재 유저 자신과 서로 차단 관계인 유저는 제외한다.
+     * - 검색어로 시작하는 닉네임을 우선 정렬하고, 이후 닉네임 오름차순으로 정렬한다.
+     * - 팔로우 여부(isFollowing, isFollowed)를 함께 조회한다.
+     */
+    public List<UserSearchDto> searchUserListByKeyword(Long currentUserId, String keyword, String startWithKeyword) {
+        QUserProfile up = QUserProfile.userProfile;
+        QFollow follow1 = new QFollow("follow1");
+        QFollow follow2 = new QFollow("follow2");
+        QBlock block1 = new QBlock("block1");
+        QBlock block2 = new QBlock("block2");
+
+        return queryFactory
+                .select(Projections.constructor(UserSearchDto.class,
+                        up.user.id,
+                        up.profileImg,
+                        up.nickname,
+                        JPAExpressions.selectOne()
+                                .from(follow1)
+                                .where(follow1.follower.id.eq(currentUserId)
+                                        .and(follow1.followee.id.eq(up.user.id)))
+                                .exists(),
+                        JPAExpressions.selectOne()
+                                .from(follow2)
+                                .where(follow2.follower.id.eq(up.user.id)
+                                        .and(follow2.followee.id.eq(currentUserId)))
+                                .exists()
+                ))
+                .from(up)
+                .where(
+                        up.user.id.ne(currentUserId),
+                        up.nickname.like(keyword),
+                        up.user.id.notIn(
+                                JPAExpressions.select(block1.blocked.id)
+                                        .from(block1)
+                                        .where(block1.blocker.id.eq(currentUserId))
+                        ),
+                        up.user.id.notIn(
+                                JPAExpressions.select(block2.blocker.id)
+                                        .from(block2)
+                                        .where(block2.blocked.id.eq(currentUserId))
+                        )
+                )
+                .orderBy(
+                        new CaseBuilder()
+                                .when(up.nickname.like(startWithKeyword)).then(0)
+                                .otherwise(1)
+                                .asc(),
+                        up.nickname.asc()
+                )
+                .fetch();
+    }
+}

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/repository/UserProfileRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/repository/UserProfileRepository.java
@@ -2,8 +2,6 @@ package org.sopt.userprofile.repository;
 
 import org.sopt.user.domain.User;
 import org.sopt.userprofile.domain.UserProfile;
-import org.sopt.userprofile.dto.UserSearchProjection;
-import org.springframework.cglib.core.Local;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -38,42 +36,6 @@ public interface UserProfileRepository extends JpaRepository<UserProfile, Long> 
             @Param("userId") Long userId,
             @Param("profileImg") String profileImg,
             @Param("updatedAt") LocalDateTime updatedAt
-    );
-
-    /*
-     * 검색 nickname에 해당하는 유저 리스트 검색
-     * - 차단한 or 차단당한 유저는 검색되지 않음
-     * - 앞단어가 일치하는 순서부터 중간 단어가 일치해도 표시
-     * isFollowing, isFollowed 값을 함께 response로 내려줄 것
-     */
-    @Query("""
-        SELECT
-            up.user.id AS userId,
-            up.profileImg AS profileImg,
-            up.nickname AS nickname,
-            CASE WHEN EXISTS (
-                SELECT 1 FROM Follow f WHERE f.follower.id = :currentUserId AND f.followee.id = up.user.id
-            ) THEN TRUE ELSE FALSE END AS isFollowing,
-            CASE WHEN EXISTS (
-                SELECT 1 FROM Follow f WHERE f.follower.id = up.user.id AND f.followee.id = :currentUserId
-            ) THEN TRUE ELSE FALSE END AS isFollowed
-        FROM UserProfile up
-        WHERE up.user.id != :currentUserId
-          AND up.nickname LIKE :keyword
-          AND up.user.id NOT IN (
-              SELECT b.blocked.id FROM Block b WHERE b.blocker.id = :currentUserId
-          )
-          AND up.user.id NOT IN (
-              SELECT b.blocker.id FROM Block b WHERE b.blocked.id = :currentUserId
-          )
-        ORDER BY
-            CASE WHEN up.nickname LIKE :startWithKeyword THEN 0 ELSE 1 END,
-            up.nickname
-        """)
-    List<UserSearchProjection> searchUserListByKeyword(
-            @Param("currentUserId") Long currentUserId,
-            @Param("keyword") String keyword,
-            @Param("startWithKeyword") String startWithKeyword
     );
 
     @Modifying(clearAutomatically = true)


### PR DESCRIPTION
## Related issue 🛠
- closed #330 

## Work Description ✏️
  - QueryDSL 설정 추가                    
    - `build.gradle`: querydsl-jpa 의존성 추가 및 QClass 생성 경로 설정 (Gradle 8.5 호환)                                                                                                                                          
    - `QueryDslConfig`: `JPAQueryFactory` 빈 등록                                                                                                                                                                                  
  - 유저 닉네임 검색에 QueryDSL 적용 (도입 예시)                                                                                                                                                                                   
    - `UserSearchProjection` (interface) → `UserSearchDto` (record) 로 교체                                                                                                                                                        
    - `UserProfileQueryRepository` 신규 생성: 조회 전용 QueryDSL 레포지토리 분리                                                                                                                                                   
    - `UserProfileRepository` 기존 JPQL 검색 메서드 제거                                                                                                                                                                           
    - `UserProfileRetriever`, `UserProfileFacade`, `FeedService` 호출 경로 수정   
 
## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 키워드 없이 검색(전체 유저 조회됨) | <img width="713" height="474" alt="image" src="https://github.com/user-attachments/assets/1dd27284-8db4-41c5-993d-5277d002cf85" /> |
| 자기 자신 검색(조회X) | <<img width="715" height="320" alt="image" src="https://github.com/user-attachments/assets/6fd812e0-16e7-4956-ad2e-3698ef93686e" /> |
|        없는 유저 키워드 검색      | <img width="714" height="321" alt="image" src="https://github.com/user-attachments/assets/8804cf6f-d915-4535-a92b-1bf797f95f5b" />|
| 키워드가 전부 일치하는 검색 | <img width="708" height="441" alt="image" src="https://github.com/user-attachments/assets/7ee75a13-cc6f-4d0d-b12b-a2b2454ee8f7" /> |
| 키워드 중간 포함값 검색 | <img width="718" height="472" alt="image" src="https://github.com/user-attachments/assets/6cdadb46-dc8d-4883-a324-ae2905a589d2" /> |

## Uncompleted Tasks 😅
QueryDSL 이 필요한 곳은 구현하면서 적절하게 리팩토링을 해보도록 합시다~!

## To Reviewers 📢
@HAJIEUN02 
- keyword가 빈 문자열일 경우 전체 유저가 조회되는 동작은 기존 코드와 동일합니다. 기존에도 이를 의도한 게 맞으셨는지 궁금합니다! 
- 기존과 비교하여 제가 잘못 수정한 부분이 있을지 스크린샷 동작 한 번만 검토 부탁드립니다! 