### PR TITLE
[docs] #332 CLAUDE.md 파일 추가

### DIFF
--- a/.agents/skills/migration/SKILL.md
+++ b/.agents/skills/migration/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: migration
+description: Flyway 마이그레이션 파일 생성
+---
+
+# Flyway Migration Skill
+
+## 절차
+1. `hilingual-api/src/main/resources/db/migration/` 폴더 탐색
+2. 현재 가장 높은 버전 번호 확인
+3. `V{n+1}__{description}.sql` 형식으로 파일 생성
+4. `ddl-auto: validate` 환경 기준으로 SQL 작성
+5. 롤백 불가능한 작업(DROP, TRUNCATE 등)은 반드시 경고
+
+## 규칙
+- 파일명은 snake_case 사용
+- 한 파일에 하나의 논리적 변경만
+- 컬럼 추가 시 DEFAULT 값 고려
+- 인덱스 추가 시 성능 영향 명시

--- a/.claude/commands/hilingual-pr.md
+++ b/.claude/commands/hilingual-pr.md
@@ -1,0 +1,17 @@
+---
+description: 하이링구얼 PR/이슈 작성
+---
+
+$ARGUMENTS 에 대한 PR과 이슈를 작성해줘.
+
+이슈 형식:
+## What is this issue? 🛠️
+## Progress 🏃‍♀️
+- [ ]
+
+PR 형식:
+## Related issue 🛠
+## Work Description ✏️
+## Screenshot 📸
+## Uncompleted Tasks 😅
+## To Reviewers 📢

--- a/.claude/commands/hilingual-review.md
+++ b/.claude/commands/hilingual-review.md
@@ -1,0 +1,15 @@
+---
+description: 하이링구얼 기준 코드 리뷰
+---
+
+아래 기준으로 현재 변경사항을 리뷰해줘:
+- Controller → Service → Facade → Repository 계층 준수
+- @Transactional 범위 적절한가
+- N+1 쿼리 발생 가능성
+- ErrorCode 기반 예외 처리
+- @UserId 인증 방식 준수
+- Redis 캐시 정합성
+- API 스펙 변경 여부
+- JWT/Spring Security 영향
+- 401/403/500 응답 매핑 적절성
+- DTO 변경 시 클라이언트 영향

--- a/.claude/commands/hilingual-test.md
+++ b/.claude/commands/hilingual-test.md
@@ -1,0 +1,10 @@
+---
+description: 하이링구얼 테스트 코드 작성
+---
+
+$ARGUMENTS 에 대한 테스트를 작성해줘:
+- JUnit5 + Mockito 사용
+- 상황에 따라 Service/Facade/Retriever/Saver/Updater 단위로 적절히 선택
+- 성공 케이스 + 실패 케이스(예외) 모두 작성
+- given/when/then 패턴 준수
+- 테스트 메서드명은 한국어로

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,5 +20,8 @@
       "Bash(rm -rf *)",
       "Bash(sudo *)"
     ]
-  }
+  },
+  "disabledMcpServers": [
+    "plugin:everything-claude-code:playwright"
+  ]
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,8 +20,5 @@
       "Bash(rm -rf *)",
       "Bash(sudo *)"
     ]
-  },
-  "disabledMcpServers": [
-    "plugin:everything-claude-code:playwright"
-  ]
+  }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,11 +5,20 @@
       "Bash(./gradlew build -x test)",
       "Bash(./gradlew test*)",
       "Bash(./gradlew clean*)",
-      "Bash(./gradlew :hilingual-api:bootRun)"
+      "Bash(./gradlew :hilingual-api:bootRun)",
+      "Bash(./gradlew :hilingual-api:test*)",
+      "Bash(git status)",
+      "Bash(git diff *)",
+      "Bash(git log *)",
+      "Bash(git add *)"
     ],
     "deny": [
       "Read(./.env)",
-      "Read(./.env.*)"
+      "Read(./.env.*)",
+      "Read(./**/application-prod.yml)",
+      "Read(./**/application-secret*)",
+      "Bash(rm -rf *)",
+      "Bash(sudo *)"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./gradlew build)",
+      "Bash(./gradlew build -x test)",
+      "Bash(./gradlew test*)",
+      "Bash(./gradlew clean*)",
+      "Bash(./gradlew :hilingual-api:bootRun)"
+    ],
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.*)"
+    ]
+  }
+}

--- a/.claude/skills/migration/SKILL.md
+++ b/.claude/skills/migration/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: migration
+description: Flyway 마이그레이션 파일 생성
+---
+
+# Flyway Migration Skill
+
+## 절차
+1. `hilingual-api/src/main/resources/db/migration/` 폴더 탐색
+2. 현재 가장 높은 버전 번호 확인
+3. `V{n+1}__{description}.sql` 형식으로 파일 생성
+4. `ddl-auto: validate` 환경 기준으로 SQL 작성
+5. 롤백 불가능한 작업(DROP, TRUNCATE 등)은 반드시 경고
+
+## 규칙
+- 파일명은 snake_case 사용
+- 한 파일에 하나의 논리적 변경만
+- 컬럼 추가 시 DEFAULT 값 고려
+- 인덱스 추가 시 성능 영향 명시

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ data.sql
 
 
 nginx/includes/*.inc
+.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,163 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+---
+
+## Build & Run Commands
+
+- Build all modules: `./gradlew build`
+- Build without tests: `./gradlew build -x test`
+- Run app: `./gradlew :hilingual-api:bootRun`
+- Run all tests: `./gradlew test`
+- Module test:
+  - `./gradlew :hilingual-api:test`
+  - `./gradlew :hilingual-domain:test`
+- Single test:
+  - `./gradlew :hilingual-api:test --tests "org.sopt.controller.diary.DiaryServiceTest"`
+- Clean build: `./gradlew clean build`
+- Dependency health: `./gradlew buildHealth`
+
+---
+
+## Module Architecture
+
+hilingual-api → Controllers + Services  
+↓  
+hilingual-domain → Entities, Facade, Repository, QueryDSL  
+hilingual-auth → JWT, Security  
+hilingual-external → S3, OpenAI  
+hilingual-common → DTO, Exception, Response
+
+- Only `hilingual-api` produces bootJar
+
+---
+
+## Module Responsibilities
+
+- hilingual-api: Controller + Use-case Service
+- hilingual-domain: Entity + Facade + QueryDSL
+- hilingual-auth: JWT 인증
+- hilingual-external: 외부 연동
+- hilingual-common: 공통 DTO/Exception
+
+---
+
+## Key Patterns
+
+### Response
+
+- BaseResponseDto 사용
+- success / fail 패턴 유지
+
+### Exception
+
+- CoreException / ApiException 분리
+- ErrorCode 기반
+- GlobalExceptionHandler에서 처리
+
+### Facade
+
+- Service → Facade → Repository 구조
+- Service는 Repository 직접 접근 금지
+
+### Authentication
+
+- Controller: @UserId
+- Service: SecurityUtils.getCurrentUserId()
+
+---
+
+## Database
+
+- PostgreSQL + Flyway
+- db/migration
+- V{n}__{desc}.sql
+- local: create
+- prod: validate
+- blue/green: 8081 / 8082
+
+---
+
+## Environment
+
+.env 기반
+
+- DB_URL, DB_ID, DB_PW
+- SECRET_KEY, ACCESS_EXPIRATION
+- REDIS_HOST, REDIS_PORT
+- AWS_*, OPENAI_API_KEY
+
+---
+
+## Infrastructure
+
+- Docker Compose
+- Redis
+- Prometheus / Grafana
+- Micrometer
+
+---
+
+## Codex 작업 규칙
+
+- 한국어로 설명 + 결론 먼저
+- 코드 작성 전 구조 분석 필수
+- 기존 구조/패턴 유지
+- 새 구조 도입 시 이유 설명
+- 여러 파일 수정 시 이유 명시
+- 기존 코드 패턴과 다른 구현을 할 경우 반드시 이유를 설명한다
+- 추측으로 구현하지 말고, 불확실하면 먼저 질문한다
+
+---
+
+## 아키텍처 원칙
+
+- Controller → Service → Facade → Repository
+- Service는 Facade만 호출
+- 예외는 GlobalExceptionHandler
+- 401 / 403 / 500 구분
+
+---
+
+## API 설계 기준
+
+- BaseResponseDto 사용
+- Controller에 로직 금지
+- DTO 분리
+- API 변경 시 클라이언트 영향 설명
+
+---
+
+## 성능 기준
+
+- N+1 체크
+- Fetch 전략 고려
+- QueryDSL → QueryRepository
+- Redis 캐시 invalidation 고려
+
+---
+
+## 인증 규칙
+
+- @UserId 사용
+- Security Filter Chain 고려
+- 인증 실패 → 401
+
+---
+
+## 변경 전 체크리스트
+
+- [ ] @Transactional 적절한가?
+- [ ] N+1 문제 없는가?
+- [ ] Redis 정합성 유지되는가?
+- [ ] 클라이언트 영향 있는가?
+
+---
+
+## 금지사항
+
+- 라이브러리 임의 추가 금지
+- 엔티티 구조 대규모 변경 금지
+- API 스펙 임의 변경 금지
+- .env 직접 수정 금지  

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,99 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Run Commands
+
+```bash
+# Build all modules
+./gradlew build
+
+# Build without tests
+./gradlew build -x test
+
+# Run the application (hilingual-api module)
+./gradlew :hilingual-api:bootRun
+
+# Run all tests
+./gradlew test
+
+# Run tests for a specific module
+./gradlew :hilingual-api:test
+./gradlew :hilingual-domain:test
+
+# Run a single test class
+./gradlew :hilingual-api:test --tests "org.sopt.controller.diary.DiaryServiceTest"
+
+# Clean build
+./gradlew clean build
+
+# Check for unused dependencies
+./gradlew buildHealth
+```
+
+## Module Architecture
+
+This is a multi-module Spring Boot 3.4 / Java 17 project with a strict dependency hierarchy:
+
+```
+hilingual-api          ← Entry point: Controllers + Services (application layer)
+  ↓ depends on
+hilingual-domain       ← JPA entities, Facades, Repositories, QueryDSL
+hilingual-auth         ← JWT token handling, Spring Security filters
+hilingual-external     ← AWS S3, OpenAI (Feign client)
+hilingual-common       ← Shared DTOs, exception base classes, response envelope
+```
+
+Only `hilingual-api` produces a bootJar (`app.jar`). All other modules produce plain JARs.
+
+### Module Responsibilities
+
+- **hilingual-api**: HTTP layer only. `controller/<feature>/api/` for controllers, `controller/<feature>/service/` for use-case services that orchestrate domain facades. Each feature has its own `exception/` sub-package with `ApiErrorCode` and `ApiException`.
+- **hilingual-domain**: Domain entities live under `org/sopt/<aggregate>/domain/`. Each aggregate has a `facade/` that groups `Retriever`, `Saver`, `Remover`, `Updater` components. Repositories extend Spring Data JPA; QueryDSL queries go in separate `*QueryRepository` classes. QueryDSL Q-types are generated into `build/generated/querydsl`.
+- **hilingual-auth**: JWT `JwtTokenProvider`, `JwtAuthenticationFilter`, `UserAuthentication`, and Redis-backed `TokenRepository`. The `@UserId` annotation extracts the authenticated user ID in controllers.
+- **hilingual-external**: `S3Service` for pre-signed URL generation and file operations. `OpenAIService` via Feign client for GPT diary feedback.
+- **hilingual-common**: `BaseResponseDto<T>` response envelope (code + data + message). `HilingualBaseException` is the root for all domain exceptions. `ErrorCode` / `SuccessCode` interfaces with `GlobalErrorCode` / `GlobalSuccessCode` implementations.
+
+## Key Patterns
+
+### Response Format
+
+All API responses use `BaseResponseDto<T>`:
+```java
+BaseResponseDto.success(GlobalSuccessCode.SUCCESS, data)
+BaseResponseDto.fail(SomeErrorCode.NOT_FOUND)
+```
+
+### Exception Hierarchy
+
+- Domain exceptions: extend module-level `*CoreException` → `HilingualBaseException`
+- API exceptions: extend module-level `*ApiException` → `HilingualBaseException`
+- Error codes implement `ErrorCode` interface with `getCode()` and `getMessage()`
+- `GlobalExceptionHandler` in `hilingual-api` handles all exceptions centrally
+
+### Facade Pattern
+
+Facades (`@Component`) in `hilingual-domain` aggregate Retriever/Saver/Remover/Updater components. Services in `hilingual-api` call facades — they do not directly access repositories. Facades own `@Transactional` boundaries for write operations; services that span multiple facades coordinate transactions at the service level.
+
+### Authentication
+
+`@UserId Long userId` parameter injection is available in all controllers via the custom `UserId` resolver. The `SecurityUtils.getCurrentUserId()` utility can also be used within services.
+
+## Database & Migrations
+
+- PostgreSQL with Flyway migrations in `hilingual-api/src/main/resources/db/migration/`
+- Migration files follow `V{n}__{description}.sql` naming
+- `ddl-auto: validate` in production (non-local profiles) — schema changes require a migration file
+- `ddl-auto: create` in local profile — Flyway is disabled locally
+- Blue/green deployment via Spring profiles (`blue` port 8081, `green` port 8082)
+
+## Environment Variables
+
+All secrets come from a `.env` file (loaded via `dotenv-java`). Required variables:
+`DB_URL`, `DB_ID`, `DB_PW`, `SECRET_KEY`, `ACCESS_EXPIRATION`, `REFRESH_EXPIRATION`, `REDIS_HOST`, `REDIS_PORT`, `AWS_ACCESS_KEY`, `AWS_SECRET_KEY`, `AWS_REGION`, `AWS_BUCKET_NAME`, `AWS_CDN_DOMAIN`, `AWS_S3_FILE_KEY`, `OPENAI_API_KEY`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `NEW_USER_WEBHOOK`
+
+For local development: copy `.env.example` to `.env` and fill in values. Use `application-local.yml` profile.
+
+## Infrastructure
+
+Docker Compose runs blue/green Spring instances + Redis + Promtail (log shipping to Loki/Grafana). Monitoring via Prometheus (`/actuator/prometheus`) and Micrometer with histogram percentiles.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,3 +97,30 @@ For local development: copy `.env.example` to `.env` and fill in values. Use `ap
 ## Infrastructure
 
 Docker Compose runs blue/green Spring instances + Redis + Promtail (log shipping to Loki/Grafana). Monitoring via Prometheus (`/actuator/prometheus`) and Micrometer with histogram percentiles.
+
+## Claude 응답 규칙
+- 한국어로 설명, 결론 먼저
+- 코드 변경 전 현재 구조 파악 필수
+
+## 아키텍처 원칙
+- Controller → Service → Facade → Repository 엄격히 분리
+- Service는 Facade만 호출 (Repository 직접 접근 금지)
+- 예외는 각 기능별 exception/ 서브패키지에 ApiErrorCode/ApiException으로 정의
+- 모든 예외는 GlobalExceptionHandler에서 중앙 처리
+- 401(인증)/403(권한)/500(서버) 명확히 구분
+
+## 인증
+- 컨트롤러: @UserId Long userId 파라미터 사용
+- 서비스: SecurityUtils.getCurrentUserId() 사용
+
+## 변경 전 체크리스트
+- [ ] @Transactional 범위 적절한가?
+- [ ] N+1 쿼리 발생 가능성 있는가?
+- [ ] Redis 캐시 정합성 깨지지 않는가?
+- [ ] 클라이언트 API 스펙 영향 있는가?
+
+## 금지사항
+- 라이브러리 임의 추가 금지
+- 엔티티 구조 대규모 변경 금지
+- API 스펙 임의 변경 금지
+- .env 직접 수정 금지

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,125 +2,162 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+---
+
 ## Build & Run Commands
 
-```bash
-# Build all modules
-./gradlew build
+- Build all modules: `./gradlew build`
+- Build without tests: `./gradlew build -x test`
+- Run app: `./gradlew :hilingual-api:bootRun`
+- Run all tests: `./gradlew test`
+- Module test:
+  - `./gradlew :hilingual-api:test`
+  - `./gradlew :hilingual-domain:test`
+- Single test:
+  - `./gradlew :hilingual-api:test --tests "org.sopt.controller.diary.DiaryServiceTest"`
+- Clean build: `./gradlew clean build`
+- Dependency health: `./gradlew buildHealth`
 
-# Build without tests
-./gradlew build -x test
-
-# Run the application (hilingual-api module)
-./gradlew :hilingual-api:bootRun
-
-# Run all tests
-./gradlew test
-
-# Run tests for a specific module
-./gradlew :hilingual-api:test
-./gradlew :hilingual-domain:test
-
-# Run a single test class
-./gradlew :hilingual-api:test --tests "org.sopt.controller.diary.DiaryServiceTest"
-
-# Clean build
-./gradlew clean build
-
-# Check for unused dependencies
-./gradlew buildHealth
-```
+---
 
 ## Module Architecture
 
-This is a multi-module Spring Boot 3.4 / Java 17 project with a strict dependency hierarchy:
+hilingual-api → Controllers + Services  
+↓  
+hilingual-domain → Entities, Facade, Repository, QueryDSL  
+hilingual-auth → JWT, Security  
+hilingual-external → S3, OpenAI  
+hilingual-common → DTO, Exception, Response
 
-```
-hilingual-api          ← Entry point: Controllers + Services (application layer)
-  ↓ depends on
-hilingual-domain       ← JPA entities, Facades, Repositories, QueryDSL
-hilingual-auth         ← JWT token handling, Spring Security filters
-hilingual-external     ← AWS S3, OpenAI (Feign client)
-hilingual-common       ← Shared DTOs, exception base classes, response envelope
-```
+- Only `hilingual-api` produces bootJar
 
-Only `hilingual-api` produces a bootJar (`app.jar`). All other modules produce plain JARs.
+---
 
-### Module Responsibilities
+## Module Responsibilities
 
-- **hilingual-api**: HTTP layer only. `controller/<feature>/api/` for controllers, `controller/<feature>/service/` for use-case services that orchestrate domain facades. Each feature has its own `exception/` sub-package with `ApiErrorCode` and `ApiException`.
-- **hilingual-domain**: Domain entities live under `org/sopt/<aggregate>/domain/`. Each aggregate has a `facade/` that groups `Retriever`, `Saver`, `Remover`, `Updater` components. Repositories extend Spring Data JPA; QueryDSL queries go in separate `*QueryRepository` classes. QueryDSL Q-types are generated into `build/generated/querydsl`.
-- **hilingual-auth**: JWT `JwtTokenProvider`, `JwtAuthenticationFilter`, `UserAuthentication`, and Redis-backed `TokenRepository`. The `@UserId` annotation extracts the authenticated user ID in controllers.
-- **hilingual-external**: `S3Service` for pre-signed URL generation and file operations. `OpenAIService` via Feign client for GPT diary feedback.
-- **hilingual-common**: `BaseResponseDto<T>` response envelope (code + data + message). `HilingualBaseException` is the root for all domain exceptions. `ErrorCode` / `SuccessCode` interfaces with `GlobalErrorCode` / `GlobalSuccessCode` implementations.
+- hilingual-api: Controller + Use-case Service
+- hilingual-domain: Entity + Facade + QueryDSL
+- hilingual-auth: JWT 인증
+- hilingual-external: 외부 연동
+- hilingual-common: 공통 DTO/Exception
+
+---
 
 ## Key Patterns
 
-### Response Format
+### Response
 
-All API responses use `BaseResponseDto<T>`:
-```java
-BaseResponseDto.success(GlobalSuccessCode.SUCCESS, data)
-BaseResponseDto.fail(SomeErrorCode.NOT_FOUND)
-```
+- BaseResponseDto 사용
+- success / fail 패턴 유지
 
-### Exception Hierarchy
+### Exception
 
-- Domain exceptions: extend module-level `*CoreException` → `HilingualBaseException`
-- API exceptions: extend module-level `*ApiException` → `HilingualBaseException`
-- Error codes implement `ErrorCode` interface with `getCode()` and `getMessage()`
-- `GlobalExceptionHandler` in `hilingual-api` handles all exceptions centrally
+- CoreException / ApiException 분리
+- ErrorCode 기반
+- GlobalExceptionHandler에서 처리
 
-### Facade Pattern
+### Facade
 
-Facades (`@Component`) in `hilingual-domain` aggregate Retriever/Saver/Remover/Updater components. Services in `hilingual-api` call facades — they do not directly access repositories. Facades own `@Transactional` boundaries for write operations; services that span multiple facades coordinate transactions at the service level.
+- Service → Facade → Repository 구조
+- Service는 Repository 직접 접근 금지
 
 ### Authentication
 
-`@UserId Long userId` parameter injection is available in all controllers via the custom `UserId` resolver. The `SecurityUtils.getCurrentUserId()` utility can also be used within services.
+- Controller: @UserId
+- Service: SecurityUtils.getCurrentUserId()
 
-## Database & Migrations
+---
 
-- PostgreSQL with Flyway migrations in `hilingual-api/src/main/resources/db/migration/`
-- Migration files follow `V{n}__{description}.sql` naming
-- `ddl-auto: validate` in production (non-local profiles) — schema changes require a migration file
-- `ddl-auto: create` in local profile — Flyway is disabled locally
-- Blue/green deployment via Spring profiles (`blue` port 8081, `green` port 8082)
+## Database
 
-## Environment Variables
+- PostgreSQL + Flyway
+- db/migration
+- V{n}__{desc}.sql
+- local: create
+- prod: validate
+- blue/green: 8081 / 8082
 
-All secrets come from a `.env` file (loaded via `dotenv-java`). Required variables:
-`DB_URL`, `DB_ID`, `DB_PW`, `SECRET_KEY`, `ACCESS_EXPIRATION`, `REFRESH_EXPIRATION`, `REDIS_HOST`, `REDIS_PORT`, `AWS_ACCESS_KEY`, `AWS_SECRET_KEY`, `AWS_REGION`, `AWS_BUCKET_NAME`, `AWS_CDN_DOMAIN`, `AWS_S3_FILE_KEY`, `OPENAI_API_KEY`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `NEW_USER_WEBHOOK`
+---
 
-For local development: copy `.env.example` to `.env` and fill in values. Use `application-local.yml` profile.
+## Environment
+
+.env 기반
+
+- DB_URL, DB_ID, DB_PW
+- SECRET_KEY, ACCESS_EXPIRATION
+- REDIS_HOST, REDIS_PORT
+- AWS_*, OPENAI_API_KEY
+
+---
 
 ## Infrastructure
 
-Docker Compose runs blue/green Spring instances + Redis + Promtail (log shipping to Loki/Grafana). Monitoring via Prometheus (`/actuator/prometheus`) and Micrometer with histogram percentiles.
+- Docker Compose
+- Redis
+- Prometheus / Grafana
+- Micrometer
 
-## Claude 응답 규칙
-- 한국어로 설명, 결론 먼저
-- 코드 변경 전 현재 구조 파악 필수
+---
+
+## Claude 작업 규칙
+
+- 한국어로 설명 + 결론 먼저
+- 코드 작성 전 구조 분석 필수
+- 기존 구조/패턴 유지
+- 새 구조 도입 시 이유 설명
+- 여러 파일 수정 시 이유 명시
+- 기존 코드 패턴과 다른 구현을 할 경우 반드시 이유를 설명한다
+- 추측으로 구현하지 말고, 불확실하면 먼저 질문한다
+
+---
 
 ## 아키텍처 원칙
-- Controller → Service → Facade → Repository 엄격히 분리
-- Service는 Facade만 호출 (Repository 직접 접근 금지)
-- 예외는 각 기능별 exception/ 서브패키지에 ApiErrorCode/ApiException으로 정의
-- 모든 예외는 GlobalExceptionHandler에서 중앙 처리
-- 401(인증)/403(권한)/500(서버) 명확히 구분
 
-## 인증
-- 컨트롤러: @UserId Long userId 파라미터 사용
-- 서비스: SecurityUtils.getCurrentUserId() 사용
+- Controller → Service → Facade → Repository
+- Service는 Facade만 호출
+- 예외는 GlobalExceptionHandler
+- 401 / 403 / 500 구분
+
+---
+
+## API 설계 기준
+
+- BaseResponseDto 사용
+- Controller에 로직 금지
+- DTO 분리
+- API 변경 시 클라이언트 영향 설명
+
+---
+
+## 성능 기준
+
+- N+1 체크
+- Fetch 전략 고려
+- QueryDSL → QueryRepository
+- Redis 캐시 invalidation 고려
+
+---
+
+## 인증 규칙
+
+- @UserId 사용
+- Security Filter Chain 고려
+- 인증 실패 → 401
+
+---
 
 ## 변경 전 체크리스트
-- [ ] @Transactional 범위 적절한가?
-- [ ] N+1 쿼리 발생 가능성 있는가?
-- [ ] Redis 캐시 정합성 깨지지 않는가?
-- [ ] 클라이언트 API 스펙 영향 있는가?
+
+- [ ] @Transactional 적절한가?
+- [ ] N+1 문제 없는가?
+- [ ] Redis 정합성 유지되는가?
+- [ ] 클라이언트 영향 있는가?
+
+---
 
 ## 금지사항
+
 - 라이브러리 임의 추가 금지
 - 엔티티 구조 대규모 변경 금지
 - API 스펙 임의 변경 금지
-- .env 직접 수정 금지
+- .env 직접 수정 금지  


### PR DESCRIPTION
## Related issue 🛠
- closed #332

## Work Description ✏️
- CLAUDE.md 추가
  - 빌드 및 실행 명령어 정리
  - 멀티모듈 아키텍처 구조 문서화
  - 핵심 패턴 정리 (응답 형식, 예외 계층, Facade 패턴, 인증)
  - DB 마이그레이션 규칙 및 환경변수 목록 포함
  - 인프라 구성 (Docker, 모니터링) 정리
- `.claude/settings.json` 추가
  - Gradle 빌드/테스트/실행 명령어 허용 설정
  - .env 파일 접근 차단 설정

## Screenshot 📸
N/A

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
Claude Code 사용 시 자동으로 로드되어 프로젝트 컨텍스트를 유지하는 파일입니다.
팀원들도 Claude Code 사용 시 동일한 컨텍스트로 작업 가능합니다.