### PR TITLE
[refac] #335 멀티모듈 의존성 정리 및 코드 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 allprojects {
 
-    group = 'org.hilingual'
+    group = 'org.sopt'
     version = '1.0-SNAPSHOT'
 
     java {
@@ -38,7 +38,6 @@ subprojects {
     }
 
     dependencies {
-        testImplementation platform('org.junit:junit-bom:5.10.0')
         testImplementation 'org.junit.jupiter:junit-jupiter'
 
         // lombok
@@ -47,19 +46,6 @@ subprojects {
 
         // Test
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
-
-        // Spring Boot
-        implementation 'org.springframework.boot:spring-boot-starter-web'
-        implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-
-        // Validation
-        implementation 'org.springframework.boot:spring-boot-starter-validation'
-
-        // Monitoring
-        implementation 'org.springframework.boot:spring-boot-starter-actuator'
-        implementation 'io.micrometer:micrometer-registry-prometheus'
-
-
     }
 
     tasks.named("test") {

--- a/hilingual-api/build.gradle
+++ b/hilingual-api/build.gradle
@@ -19,14 +19,20 @@ dependencies {
     implementation project(':hilingual-auth')
     implementation project(':hilingual-external')
 
+    // Spring Boot
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // Monitoring
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
     // Configuration
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     // Dotenv
     implementation 'io.github.cdimascio:dotenv-java:3.2.0'
-
-    // Spring Actuator
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     // Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -34,10 +40,10 @@ dependencies {
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-
     // Open Feign
-    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.2.0'
+    implementation('org.springframework.cloud:spring-cloud-starter-openfeign:4.2.0') {
+        exclude group: 'commons-fileupload', module: 'commons-fileupload'
+    }
 
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/hilingual-api/src/main/java/org/sopt/HilingualApplication.java
+++ b/hilingual-api/src/main/java/org/sopt/HilingualApplication.java
@@ -6,12 +6,25 @@ import org.sopt.openai.OpenAIProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.sopt.jwt.auth.domain.TokenRepository;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
 @EnableScheduling
 @SpringBootApplication
+@EnableJpaRepositories(
+        basePackages = "org.sopt",
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = TokenRepository.class
+        )
+)
+@EnableRedisRepositories(basePackages = "org.sopt.jwt.auth.domain")
 @EnableConfigurationProperties({AWSProperties.class, OpenAIProperties.class})
 public class HilingualApplication {
     public static void main(String[] args) {

--- a/hilingual-api/src/main/java/org/sopt/controller/auth/dto/SocialLoginReq.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/auth/dto/SocialLoginReq.java
@@ -2,7 +2,7 @@ package org.sopt.controller.auth.dto;
 
 import jakarta.validation.constraints.NotNull;
 import org.sopt.device.dto.DeviceInfo;
-import org.sopt.jwt.auth.authentication.UserRole;
+import org.sopt.type.UserRole;
 import org.sopt.jwt.auth.domain.type.AuthProvider;
 import org.sopt.jwt.auth.domain.type.DeviceType;
 import org.springframework.util.StringUtils;

--- a/hilingual-api/src/main/java/org/sopt/controller/auth/service/AuthService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/auth/service/AuthService.java
@@ -25,7 +25,7 @@ import org.sopt.exception.UnAuthorizedException;
 import org.sopt.exception.code.GlobalErrorCode;
 import org.sopt.feedalarm.facade.FeedAlarmFacade;
 import org.sopt.follow.facade.FollowFacade;
-import org.sopt.jwt.auth.authentication.UserRole;
+import org.sopt.type.UserRole;
 import org.sopt.jwt.auth.domain.type.AuthProvider;
 import org.sopt.likeddiary.facade.LikedDiaryFacade;
 import org.sopt.user.domain.User;

--- a/hilingual-api/src/main/java/org/sopt/controller/test/dto/jwt/IssueTokenRequest.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/test/dto/jwt/IssueTokenRequest.java
@@ -1,7 +1,7 @@
 package org.sopt.controller.test.dto.jwt;
 
 import jakarta.validation.constraints.NotNull;
-import org.sopt.jwt.auth.authentication.UserRole;
+import org.sopt.type.UserRole;
 import org.sopt.jwt.auth.domain.type.AuthProvider;
 import org.sopt.jwt.auth.domain.type.DeviceType;
 

--- a/hilingual-api/src/main/java/org/sopt/controller/token/TokenService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/token/TokenService.java
@@ -7,7 +7,7 @@ import org.sopt.controller.auth.dto.SocialLoginRes;
 import org.sopt.exception.AuthErrorCode;
 import org.sopt.exception.InvalidTokenException;
 import org.sopt.exception.TokenNotFoundException;
-import org.sopt.jwt.auth.authentication.UserRole;
+import org.sopt.type.UserRole;
 import org.sopt.jwt.auth.domain.type.AuthProvider;
 import org.sopt.jwt.auth.domain.Token;
 import org.sopt.jwt.auth.domain.TokenRepository;

--- a/hilingual-auth/build.gradle
+++ b/hilingual-auth/build.gradle
@@ -1,6 +1,9 @@
 dependencies {
     implementation project(":hilingual-common")
 
+    // Spring Web (Servlet Filter)
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
@@ -10,7 +13,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // Open Feign
-    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.2.0'
+    implementation('org.springframework.cloud:spring-cloud-starter-openfeign:4.2.0') {
+        exclude group: 'commons-fileupload', module: 'commons-fileupload'
+    }
 
     // OAuth
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/hilingual-auth/src/main/java/org/sopt/jwt/auth/authentication/UserAuthentication.java
+++ b/hilingual-auth/src/main/java/org/sopt/jwt/auth/authentication/UserAuthentication.java
@@ -1,6 +1,7 @@
 package org.sopt.jwt.auth.authentication;
 
 import lombok.Getter;
+import org.sopt.type.UserRole;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 

--- a/hilingual-auth/src/main/java/org/sopt/jwt/auth/authentication/UserAuthenticationFactory.java
+++ b/hilingual-auth/src/main/java/org/sopt/jwt/auth/authentication/UserAuthenticationFactory.java
@@ -3,6 +3,7 @@ package org.sopt.jwt.auth.authentication;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
 import org.sopt.jwt.support.AuthConstants;
+import org.sopt.type.UserRole;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;

--- a/hilingual-auth/src/main/java/org/sopt/jwt/auth/domain/Token.java
+++ b/hilingual-auth/src/main/java/org/sopt/jwt/auth/domain/Token.java
@@ -1,6 +1,6 @@
 package org.sopt.jwt.auth.domain;
 
-import jakarta.persistence.Id;
+import org.springframework.data.annotation.Id;
 import lombok.*;
 import org.sopt.jwt.auth.domain.type.AuthProvider;
 import org.sopt.jwt.auth.domain.type.DeviceType;

--- a/hilingual-auth/src/main/java/org/sopt/jwt/core/JwtTokenProvider.java
+++ b/hilingual-auth/src/main/java/org/sopt/jwt/core/JwtTokenProvider.java
@@ -1,7 +1,6 @@
 package org.sopt.jwt.core;
 
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Header;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
@@ -10,7 +9,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.exception.*;
-import org.sopt.jwt.auth.authentication.UserRole;
+import org.sopt.type.UserRole;
 import org.sopt.jwt.auth.domain.type.AuthProvider;
 import org.sopt.jwt.support.AuthConstants;
 import org.springframework.beans.factory.InitializingBean;
@@ -60,7 +59,6 @@ public class JwtTokenProvider implements InitializingBean {
     ) {
         final Instant now = Instant.now();
         return Jwts.builder()
-                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
                 .subject(String.valueOf(userId))
                 .claim(AuthConstants.USER_ID_CLAIM_NAME, userId)
                 .claim(JwtClaimsKeys.ROLE, role.name())
@@ -83,7 +81,6 @@ public class JwtTokenProvider implements InitializingBean {
     ) {
         final Instant now = Instant.now();
         return Jwts.builder()
-                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
                 .subject(String.valueOf(userId))
                 .claim(AuthConstants.USER_ID_CLAIM_NAME, userId)
                 .claim(JwtClaimsKeys.PROVIDER, provider.name())

--- a/hilingual-common/build.gradle
+++ b/hilingual-common/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
-
-
+    // Spring Web (ResponseBodyAdvice, RestControllerAdvice)
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 }
 
 bootJar { enabled = false }

--- a/hilingual-common/src/main/java/org/sopt/type/UserRole.java
+++ b/hilingual-common/src/main/java/org/sopt/type/UserRole.java
@@ -1,4 +1,4 @@
-package org.sopt.jwt.auth.authentication;
+package org.sopt.type;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/hilingual-domain/build.gradle
+++ b/hilingual-domain/build.gradle
@@ -15,9 +15,16 @@ tasks.named("clean").configure {
 }
 
 dependencies {
-    implementation project(":hilingual-external")
     implementation project(":hilingual-common")
-    implementation project(":hilingual-auth")
+
+    // Spring Data JPA
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // Spring Web (HttpStatus used in exception codes)
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // Validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // QueryDSL
     implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
@@ -27,27 +34,6 @@ dependencies {
 
     // database
     runtimeOnly 'org.postgresql:postgresql'
-
-    // Bouncy Castle Provider
-    implementation 'org.bouncycastle:bcprov-jdk18on:1.81'
-    implementation 'org.bouncycastle:bcpkix-jdk18on:1.81'
-
-    // OAuth
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-    implementation 'com.google.oauth-client:google-oauth-client-java6:1.36.0'
-    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.36.0'
-    implementation 'com.google.api-client:google-api-client:2.4.0'
-
-    // JWT
-    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
-    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
-
-    // Webflux
-    implementation 'org.springframework.boot:spring-boot-starter-webflux'
-
-    // Redis
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 bootJar { enabled = false }

--- a/hilingual-domain/src/main/java/org/sopt/device/facade/DeviceFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/device/facade/DeviceFacade.java
@@ -1,6 +1,5 @@
 package org.sopt.device.facade;
 
-import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,7 +25,6 @@ public class DeviceFacade {
     private final DeviceRemover deviceRemover;
     private final DeviceSaver deviceSaver;
     private final UserFacade userFacade;
-    private final LogbackMetrics logbackMetrics;
 
     @Transactional
     public void upsertDevice(final long userId, final DeviceInfo deviceInfo) {

--- a/hilingual-domain/src/main/java/org/sopt/device/repository/DeviceRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/device/repository/DeviceRepository.java
@@ -1,6 +1,6 @@
 package org.sopt.device.repository;
 
-import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.repository.query.Param;
 import org.sopt.device.domain.Device;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;

--- a/hilingual-domain/src/main/java/org/sopt/user/domain/User.java
+++ b/hilingual-domain/src/main/java/org/sopt/user/domain/User.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 import org.sopt.common.config.BaseTimeEntity;
-import org.sopt.jwt.auth.authentication.UserRole;
+import org.sopt.type.UserRole;
 import org.sopt.noticedelivery.domain.NoticeDelivery;
 import org.sopt.user.type.RegisterStatus;
 import org.sopt.user.type.RegisterStatusConverter;

--- a/hilingual-external/build.gradle
+++ b/hilingual-external/build.gradle
@@ -1,12 +1,17 @@
 dependencies {
     implementation project(":hilingual-common")
 
-    // Multipart file
-    implementation("software.amazon.awssdk:bom:2.21.0")
-    implementation("software.amazon.awssdk:s3:2.21.0")
+    // Spring Web (Feign)
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // AWS SDK (BOM으로 버전 관리)
+    implementation platform("software.amazon.awssdk:bom:2.29.45")
+    implementation("software.amazon.awssdk:s3")
 
     // Open Feign
-    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.2.0'
+    implementation('org.springframework.cloud:spring-cloud-starter-openfeign:4.2.0') {
+        exclude group: 'commons-fileupload', module: 'commons-fileupload'
+    }
 }
 
 bootJar { enabled = false }


### PR DESCRIPTION
## Related issue 🛠
- closed #335 

## Work Description ✏️
- 멀티모듈 의존성 정리
    - 루트 build.gradle의 공통 의존성을 각 모듈로 분산 (각 모듈이 필요한 것만 선언)
    - hilingual-domain에서 hilingual-auth, hilingual-external 의존 제거
    - AWS SDK BOM 방식으로 전환 (2.21.0 → 2.29.45)

```
[변경 전]
  hilingual-api
  ├── hilingual-domain
  │   ├── hilingual-auth
  │   │   └── hilingual-common
  │   ├── hilingual-external
  │   │   └── hilingual-common
  │   └── hilingual-common
  ├── hilingual-auth
  │   └── hilingual-common
  ├── hilingual-external
  │   └── hilingual-common
  └── hilingual-common

[변경 후]
  hilingual-api
  ├── hilingual-domain
  │   └── hilingual-common
  ├── hilingual-auth
  │   └── hilingual-common
  ├── hilingual-external
  │   └── hilingual-common
  └── hilingual-common

```

  - UserRole을 hilingual-common 모듈로 이동
    - `org.sopt.jwt.auth.authentication.UserRole` → `org.sopt.type.UserRole`
    - domain 모듈이 auth 모듈에 의존하지 않아도 되도록 개선
  - JPA/Redis Repository 스캔 설정 개선
    - @EnableJpaRepositories 패키지 18개 하드코딩 → excludeFilters 방식으로 변경
    - 새 도메인 추가 시 HilingualApplication 수정 불필요
  - Token.java @Id import 수정
    - `jakarta.persistence.Id` → `org.springframework.data.annotation.Id` (Redis Repository에 맞는 어노테이션)
  - DeviceRepository @Param import 수정
    - `io.lettuce.core.dynamic.annotation.Param` → `org.springframework.data.repository.query.Param`
  - openfeign transitive 취약 의존성(commons-fileupload:1.5) exclude 처리
  - JwtTokenProvider deprecated setHeaderParam 제거
  - DeviceFacade 미사용 LogbackMetrics 필드 제거

## Screenshot 📸
N/A (리팩토링, 기능 변경 없음)



## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
  ⚠️ **auth 모듈 작업 중인 분 확인 필수**
- `UserRole` 클래스 위치가 변경되었습니다
  - 기존: `org.sopt.jwt.auth.authentication.UserRole`
  - 변경: `org.sopt.type.UserRole` (hilingual-common)
- import 경로 변경이 필요하니 최신 브랜치 pull 후 import 확인해주세요 hilingual-domain이 더 이상 hilingual-auth, hilingual-external에 의존하지 않습니다
- domain 모듈에서 JWT, OAuth, Redis 등 직접 사용 불가 (필요 시 api 모듈에서 처리)