### PR TITLE
[add] #341 모임 자동화를 위한 ADMIN 토큰 처리 및 공유 일기 API 수정

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/config/JacksonConfig.java
+++ b/hilingual-api/src/main/java/org/sopt/config/JacksonConfig.java
@@ -1,0 +1,26 @@
+package org.sopt.config;
+
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.format.DateTimeFormatter;
+import java.util.TimeZone;
+
+@Configuration
+public class JacksonConfig {
+
+    private static final String DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer jacksonCustomizer() {
+        return builder -> {
+            builder.serializers(new LocalDateTimeSerializer(DateTimeFormatter.ofPattern(DATETIME_FORMAT)));
+            builder.featuresToDisable(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS);
+            builder.featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+            builder.timeZone("UTC");
+        };
+    }
+}

--- a/hilingual-api/src/main/java/org/sopt/controller/feed/dto/SharedDiaryListRes.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/feed/dto/SharedDiaryListRes.java
@@ -1,6 +1,7 @@
 package org.sopt.controller.feed.dto;
 
 
+import com.google.api.client.util.DateTime;
 import org.sopt.diary.domain.Diary;
 import org.sopt.userprofile.domain.UserProfile;
 
@@ -34,6 +35,7 @@ public record SharedDiaryListRes(
     public record SharedDiary(
             Long diaryId,
             Long sharedDate,
+            LocalDateTime createdAt,
             Integer likeCount,
             Boolean isLiked,
             String diaryImg,
@@ -47,6 +49,7 @@ public record SharedDiaryListRes(
             return new SharedDiary(
                     diary.getId(),
                     (minutesDiff < ONE_MINUTE) ? LESS_THAN_MINUTE : minutesDiff,
+                    diary.getCreatedAt(),
                     diary.getIsLiked(),
                     isLikedByUser,
                     diaryImgUrl, // 변환된 URL 사용

--- a/hilingual-api/src/main/java/org/sopt/controller/token/TokenService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/token/TokenService.java
@@ -5,9 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.context.TimezoneContextHolder;
 import org.sopt.controller.auth.dto.SocialLoginReq;
 import org.sopt.controller.auth.dto.SocialLoginRes;
-import org.sopt.exception.AuthErrorCode;
-import org.sopt.exception.InvalidTokenException;
-import org.sopt.exception.TokenNotFoundException;
+import org.sopt.exception.*;
 import org.sopt.jwt.auth.authentication.UserRole;
 import org.sopt.jwt.auth.domain.type.AuthProvider;
 import org.sopt.jwt.auth.domain.Token;
@@ -155,6 +153,12 @@ public class TokenService {
     @Transactional
     public void logout(final String accessToken) {
         Claims claims = getClaimsFromAccessToken(accessToken);
+        String type = claims.get(JwtClaimsKeys.TYPE, String.class);
+
+        // 관리자 토큰인 경우 로그아웃 불가
+        if ("ADMIN_STATIC".equals(type)) {
+            throw new InvalidAdminLogoutException(AuthErrorCode.INVALID_ADMIN_LOGOUT);
+        }
 
         // Claim 에서 정보 추출
         Long userId = claims.get(AuthConstants.USER_ID_CLAIM_NAME, Long.class);
@@ -168,6 +172,12 @@ public class TokenService {
     @Transactional
     public void leave(final String accessToken) {
         Claims claims = getClaimsFromAccessToken(accessToken);
+        String type = claims.get(JwtClaimsKeys.TYPE, String.class);
+
+        // 관리자 토큰인 경우 탈퇴 불가
+        if ("ADMIN_STATIC".equals(type)) {
+            throw new InvalidAdminLeaveException(AuthErrorCode.INVALID_ADMIN_LEAVE);
+        }
 
         // Claim 에서 정보 추출
         Long userId = claims.get(AuthConstants.USER_ID_CLAIM_NAME, Long.class);
@@ -182,7 +192,7 @@ public class TokenService {
         Claims claims = jwtTokenProvider.parseAndVerify(accessToken);
         final String type = claims.get(JwtClaimsKeys.TYPE, String.class);
 
-        if (!JwtClaimsKeys.ACCESS.equals(type)) {
+        if (!JwtClaimsKeys.ACCESS.equals(type) && !"ADMIN_STATIC".equals(type)) {
             throw new InvalidTokenException(AuthErrorCode.TYPE_ERROR_JWT_TOKEN);
         }
         return claims;

--- a/hilingual-api/src/main/resources/application-local.yml
+++ b/hilingual-api/src/main/resources/application-local.yml
@@ -49,6 +49,9 @@ spring:
     time-zone: UTC
     deserialization:
       fail-on-unknown-properties: true
+    serialization:
+      write-date-timestamps-as-nanoseconds: false
+      write-dates-as-timestamps: false
 
 apple:
   oauth:

--- a/hilingual-api/src/main/resources/application.yml
+++ b/hilingual-api/src/main/resources/application.yml
@@ -56,6 +56,9 @@ spring:
     time-zone: UTC
     deserialization:
       fail-on-unknown-properties: true
+    serialization:
+      write-dates-as-timestamps: false
+      write-date-timestamps-as-nanoseconds: false
 
 logging:
   file:

--- a/hilingual-api/src/main/resources/db/migration/V7__migrate_to_timestamptz.sql
+++ b/hilingual-api/src/main/resources/db/migration/V7__migrate_to_timestamptz.sql
@@ -1,0 +1,47 @@
+ALTER TABLE diary
+ALTER COLUMN created_at TYPE TIMESTAMPTZ
+        USING created_at AT TIME ZONE 'UTC';
+
+ALTER TABLE block
+ALTER COLUMN updated_at TYPE TIMESTAMPTZ
+        USING updated_at AT TIME ZONE 'UTC';
+
+ALTER TABLE device
+ALTER COLUMN updated_at TYPE TIMESTAMPTZ
+        USING updated_at AT TIME ZONE 'UTC';
+
+ALTER TABLE diary_feedback
+ALTER COLUMN updated_at TYPE TIMESTAMPTZ
+        USING updated_at AT TIME ZONE 'UTC';
+
+ALTER TABLE feed_alarm
+ALTER COLUMN updated_at TYPE TIMESTAMPTZ
+        USING updated_at AT TIME ZONE 'UTC';
+
+ALTER TABLE follow
+ALTER COLUMN updated_at TYPE TIMESTAMPTZ
+        USING updated_at AT TIME ZONE 'UTC';
+
+ALTER TABLE notice
+ALTER COLUMN updated_at TYPE TIMESTAMPTZ
+        USING updated_at AT TIME ZONE 'UTC';
+
+ALTER TABLE recommend
+ALTER COLUMN updated_at TYPE TIMESTAMPTZ
+        USING updated_at AT TIME ZONE 'UTC';
+
+ALTER TABLE user_calendar
+ALTER COLUMN updated_at TYPE TIMESTAMPTZ
+        USING updated_at AT TIME ZONE 'UTC';
+
+ALTER TABLE user_profile
+ALTER COLUMN updated_at TYPE TIMESTAMPTZ
+        USING updated_at AT TIME ZONE 'UTC';
+
+ALTER TABLE users
+ALTER COLUMN updated_at TYPE TIMESTAMPTZ
+        USING updated_at AT TIME ZONE 'UTC';
+
+ALTER TABLE voca
+ALTER COLUMN updated_at TYPE TIMESTAMPTZ
+        USING updated_at AT TIME ZONE 'UTC';

--- a/hilingual-auth/src/main/java/org/sopt/exception/AuthErrorCode.java
+++ b/hilingual-auth/src/main/java/org/sopt/exception/AuthErrorCode.java
@@ -16,6 +16,8 @@ public enum AuthErrorCode implements ErrorCode {
     UNSUPPORTED_JWT_TOKEN(HttpStatus.BAD_REQUEST, 40014, "지원하지 않는 형식의 토큰입니다."),
     INVALID_AUTH_HEADER(HttpStatus.BAD_REQUEST, 40023, "Authorization 헤더 형식이 잘못되었습니다."),
     INVALID_TOKEN_ID(HttpStatus.BAD_REQUEST, 40024, "잘못된 토큰 ID 형식입니다."),
+    INVALID_ADMIN_LOGOUT(HttpStatus.BAD_REQUEST, 40038, "어드민 계정은 로그아웃할 수 없습니다."),
+    INVALID_ADMIN_LEAVE(HttpStatus.BAD_REQUEST, 40039, "어드민 계정은 탈퇴할 수 없습니다."),
 
     // 401 Unauthorized
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 40100, "인증되지 않은 사용자입니다."),

--- a/hilingual-auth/src/main/java/org/sopt/exception/InvalidAdminLeaveException.java
+++ b/hilingual-auth/src/main/java/org/sopt/exception/InvalidAdminLeaveException.java
@@ -1,0 +1,15 @@
+package org.sopt.exception;
+
+import org.sopt.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class InvalidAdminLeaveException extends AuthBaseException{
+    public InvalidAdminLeaveException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/hilingual-auth/src/main/java/org/sopt/exception/InvalidAdminLogoutException.java
+++ b/hilingual-auth/src/main/java/org/sopt/exception/InvalidAdminLogoutException.java
@@ -1,0 +1,15 @@
+package org.sopt.exception;
+
+import org.sopt.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class InvalidAdminLogoutException extends AuthBaseException{
+    public InvalidAdminLogoutException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/hilingual-auth/src/main/java/org/sopt/jwt/auth/authentication/UserAuthenticationFactory.java
+++ b/hilingual-auth/src/main/java/org/sopt/jwt/auth/authentication/UserAuthenticationFactory.java
@@ -18,7 +18,7 @@ public class UserAuthenticationFactory {
     public void authenticateUser(Claims claims, HttpServletRequest request) {
         // AccessToken 만 통과
         String type = claims.get("type", String.class);
-        if (!"ACCESS_TOKEN".equals(type)) {
+        if (!"ACCESS_TOKEN".equals(type) && !"ADMIN_STATIC".equals(type)) {
             throw new BadCredentialsException("Access token required");
         }
 

--- a/hilingual-auth/src/main/java/org/sopt/jwt/auth/domain/type/AuthProvider.java
+++ b/hilingual-auth/src/main/java/org/sopt/jwt/auth/domain/type/AuthProvider.java
@@ -2,5 +2,6 @@ package org.sopt.jwt.auth.domain.type;
 
 public enum AuthProvider {
     GOOGLE,
-    APPLE
+    APPLE,
+    ADMIN
 }

--- a/hilingual-auth/src/main/java/org/sopt/jwt/auth/web/JwtAuthenticationFilter.java
+++ b/hilingual-auth/src/main/java/org/sopt/jwt/auth/web/JwtAuthenticationFilter.java
@@ -72,7 +72,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             Claims claims = jwtTokenProvider.parseAndVerify(token);
             String type = claims.get(JwtClaimsKeys.TYPE, String.class);
 
-            if (JwtClaimsKeys.ACCESS.equals(type)) {
+            if (JwtClaimsKeys.ACCESS.equals(type)|| "ADMIN_STATIC".equals(type)) {
                 if (log.isDebugEnabled()) {
                     log.debug("JWT parsed. sub={}, sid={}", claims.getSubject(), claims.get("sid"));
                 }


### PR DESCRIPTION
## Related issue 🛠
- closed #341 

## Work Description ✏️
- 만료 없는 Admin용 토큰 3개 생성 후 필터 통과 로직 구현
- 공유 일기 API의 response 값에 createdAt 필드 추가
- jacksonconfig 변경
- LocalDateTime으로 저장된 데이터를 전부 절대 시간인 Timestamp로 변경

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| ADMIN이 일반적인 API 사용하는 경우 | <img width="813" height="421" alt="image" src="https://github.com/user-attachments/assets/83101539-159f-4367-b482-31f28609a3ad" /> |
| ADMIN이 로그아웃 API 사용하는 경우 | <img width="915" height="570" alt="image" src="https://github.com/user-attachments/assets/870c0982-c811-46f0-a11b-f18fb0b27344" /> |
| ADMIN이 회원탈퇴 API 사용하는 경우 |<img width="799" height="330" alt="image" src="https://github.com/user-attachments/assets/fdd4b333-c634-4905-b54e-d69ab0cd536d" /> |
| 피드 프로필 ‘공유한 일기’ 확인 API | <img width="1221" height="871" alt="image" src="https://github.com/user-attachments/assets/20ed788a-b592-40e1-be61-f014e9c01f7c" /> |


## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
타임존 사일로에서 해야 할 작업을 일부 미리 할 수 있어서 오히려 좋아요