### PR TITLE
[feat] #344 Firebase Admin SDK 설정 및 FCM 발송 인프라 구현

### DIFF
--- a/hilingual-api/src/main/resources/application.yml
+++ b/hilingual-api/src/main/resources/application.yml
@@ -99,6 +99,10 @@ aws-property:
 openai:
   api-key: ${OPENAI_API_KEY}
 
+firebase:
+  enabled: ${FIREBASE_ENABLED:false}
+  service-account-path: ${FIREBASE_SERVICE_ACCOUNT_PATH:}
+
 ---
 
 spring:

--- a/hilingual-external/build.gradle
+++ b/hilingual-external/build.gradle
@@ -12,6 +12,12 @@ dependencies {
     implementation('org.springframework.cloud:spring-cloud-starter-openfeign:4.2.0') {
         exclude group: 'commons-fileupload', module: 'commons-fileupload'
     }
+
+    // Firebase Admin SDK (FCM만 사용 — 불필요한 모듈 제외)
+    implementation('com.google.firebase:firebase-admin:9.4.3') {
+        exclude group: 'com.google.cloud', module: 'google-cloud-storage'
+        exclude group: 'com.google.cloud', module: 'google-cloud-firestore'
+    }
 }
 
 bootJar { enabled = false }

--- a/hilingual-external/src/main/java/org/sopt/firebase/FCMClient.java
+++ b/hilingual-external/src/main/java/org/sopt/firebase/FCMClient.java
@@ -1,0 +1,60 @@
+package org.sopt.firebase;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.Notification;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.firebase.dto.FCMMessageRequest;
+import org.sopt.firebase.exception.FCMErrorCode;
+import org.sopt.firebase.exception.FCMException;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnBean(FirebaseMessaging.class)
+public class FCMClient {
+
+    private final FirebaseMessaging firebaseMessaging;
+
+    public void send(FCMMessageRequest request) {
+        Notification notification = Notification.builder()
+                .setTitle(request.title())
+                .setBody(request.body())
+                .build();
+
+        Message message = Message.builder()
+                .setToken(request.token())
+                .setNotification(notification)
+                .putAllData(request.data())
+                .build();
+
+        try {
+            String messageId = firebaseMessaging.send(message);
+            log.info("FCM 발송 성공: messageId={}, token={}", messageId, maskToken(request.token()));
+        } catch (FirebaseMessagingException e) {
+            // 토큰 만료·삭제·프로젝트 불일치 → 호출측에서 토큰 정리하도록 INVALID_TOKEN으로 분류
+            if (e.getMessagingErrorCode() == MessagingErrorCode.UNREGISTERED
+                    || e.getMessagingErrorCode() == MessagingErrorCode.INVALID_ARGUMENT
+                    || e.getMessagingErrorCode() == MessagingErrorCode.SENDER_ID_MISMATCH) {
+                log.warn("FCM 유효하지 않은 토큰: token={}", maskToken(request.token()));
+                throw new FCMException(FCMErrorCode.FCM_INVALID_TOKEN);
+            }
+            log.error("FCM 발송 실패: token={}, error={}", maskToken(request.token()), e.getMessage(), e);
+            throw new FCMException(FCMErrorCode.FCM_SEND_FAILED);
+        } catch (Exception e) {
+            // 네트워크 타임아웃, SDK 내부 오류 등 예상치 못한 예외를 FCMException으로 래핑
+            log.error("FCM 발송 중 예상치 못한 오류: token={}", maskToken(request.token()), e);
+            throw new FCMException(FCMErrorCode.FCM_SEND_FAILED);
+        }
+    }
+
+    private String maskToken(String token) {
+        if (token == null || token.length() < 10) return "***";
+        return token.substring(0, 6) + "..." + token.substring(token.length() - 4);
+    }
+}

--- a/hilingual-external/src/main/java/org/sopt/firebase/config/FirebaseConfig.java
+++ b/hilingual-external/src/main/java/org/sopt/firebase/config/FirebaseConfig.java
@@ -1,0 +1,51 @@
+package org.sopt.firebase.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+/**
+ * Firebase 초기화 설정.
+ * firebase.enabled=true일 때만 활성화되며, 비활성 시 FirebaseMessaging Bean이 생성되지 않아
+ * FCMClient(@ConditionalOnBean)도 함께 비활성화된다.
+ */
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "firebase", name = "enabled", havingValue = "true")
+public class FirebaseConfig {
+
+    private final FirebaseProperties firebaseProperties;
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging() throws IOException {
+        if (FirebaseApp.getApps().isEmpty()) {
+            // 심볼릭 링크 해소를 위해 canonical path로 정규화
+            File serviceAccountFile = new File(firebaseProperties.getServiceAccountPath()).getCanonicalFile();
+
+            if (!serviceAccountFile.exists()) {
+                log.error("Firebase 서비스 계정 파일이 존재하지 않습니다: path={}", serviceAccountFile.getPath());
+                throw new IllegalStateException("Firebase 서비스 계정 파일이 존재하지 않습니다.");
+            }
+
+            try (FileInputStream serviceAccount = new FileInputStream(serviceAccountFile)) {
+                FirebaseOptions options = FirebaseOptions.builder()
+                        .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                        .build();
+                FirebaseApp.initializeApp(options);
+                log.info("FirebaseApp 초기화 완료");
+            }
+        }
+        return FirebaseMessaging.getInstance();
+    }
+}

--- a/hilingual-external/src/main/java/org/sopt/firebase/config/FirebaseProperties.java
+++ b/hilingual-external/src/main/java/org/sopt/firebase/config/FirebaseProperties.java
@@ -1,0 +1,16 @@
+package org.sopt.firebase.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Setter
+@Getter
+@Configuration
+@ConfigurationProperties(prefix = "firebase")
+public class FirebaseProperties {
+
+    private boolean enabled = false;
+    private String serviceAccountPath;
+}

--- a/hilingual-external/src/main/java/org/sopt/firebase/dto/FCMMessageRequest.java
+++ b/hilingual-external/src/main/java/org/sopt/firebase/dto/FCMMessageRequest.java
@@ -1,0 +1,38 @@
+package org.sopt.firebase.dto;
+
+import java.util.Map;
+
+/**
+ * FCM 발송 요청 DTO.
+ * @param token  대상 디바이스의 FCM 토큰
+ * @param title  푸시 알림 제목
+ * @param body   푸시 알림 본문
+ * @param data   클라이언트 앱에서 사용할 커스텀 데이터 (딥링크 등)
+ */
+public record FCMMessageRequest(
+        String token,
+        String title,
+        String body,
+        Map<String, String> data
+) {
+    public FCMMessageRequest {
+        if (token == null || token.isBlank()) {
+            throw new IllegalArgumentException("FCM token must not be blank");
+        }
+        if (title == null || title.isBlank()) {
+            throw new IllegalArgumentException("title must not be blank");
+        }
+        if (body == null || body.isBlank()) {
+            throw new IllegalArgumentException("body must not be blank");
+        }
+        data = data != null ? Map.copyOf(data) : Map.of(); // 방어적 복사 — 외부 변경으로부터 보호
+    }
+
+    public static FCMMessageRequest of(String token, String title, String body) {
+        return new FCMMessageRequest(token, title, body, Map.of());
+    }
+
+    public static FCMMessageRequest of(String token, String title, String body, Map<String, String> data) {
+        return new FCMMessageRequest(token, title, body, data);
+    }
+}

--- a/hilingual-external/src/main/java/org/sopt/firebase/exception/FCMErrorCode.java
+++ b/hilingual-external/src/main/java/org/sopt/firebase/exception/FCMErrorCode.java
@@ -1,0 +1,34 @@
+package org.sopt.firebase.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.sopt.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum FCMErrorCode implements ErrorCode {
+
+    FCM_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 50011, "FCM 푸시 발송에 실패했습니다."),
+    FCM_INVALID_TOKEN(HttpStatus.BAD_REQUEST, 40041, "유효하지 않은 FCM 토큰입니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public int getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/hilingual-external/src/main/java/org/sopt/firebase/exception/FCMException.java
+++ b/hilingual-external/src/main/java/org/sopt/firebase/exception/FCMException.java
@@ -1,0 +1,21 @@
+package org.sopt.firebase.exception;
+
+import org.sopt.exception.base.HilingualBaseException;
+import org.sopt.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class FCMException extends HilingualBaseException {
+
+    public FCMException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return getErrorCode().getHttpStatus();
+    }
+
+    public boolean isInvalidToken() {
+        return getErrorCode() == FCMErrorCode.FCM_INVALID_TOKEN;
+    }
+}

--- a/hilingual-external/src/test/java/org/sopt/firebase/FCMClientTest.java
+++ b/hilingual-external/src/test/java/org/sopt/firebase/FCMClientTest.java
@@ -1,0 +1,100 @@
+package org.sopt.firebase;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.firebase.dto.FCMMessageRequest;
+import org.sopt.firebase.exception.FCMException;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FCMClientTest {
+
+    @Mock
+    private FirebaseMessaging firebaseMessaging;
+
+    private FCMClient fcmClient;
+
+    @BeforeEach
+    void setUp() {
+        fcmClient = new FCMClient(firebaseMessaging);
+    }
+
+    @Test
+    @DisplayName("정상 발송 시 예외 없이 완료된다")
+    void send_success() throws FirebaseMessagingException {
+        when(firebaseMessaging.send(any(Message.class))).thenReturn("message-id-123");
+
+        FCMMessageRequest request = FCMMessageRequest.of("valid-fcm-token-1234567890", "제목", "내용");
+
+        assertThatCode(() -> fcmClient.send(request)).doesNotThrowAnyException();
+        verify(firebaseMessaging).send(any(Message.class));
+    }
+
+    @Test
+    @DisplayName("UNREGISTERED 토큰 시 FCMException(isInvalidToken=true) 발생")
+    void send_unregisteredToken_throwsInvalidToken() throws FirebaseMessagingException {
+        FirebaseMessagingException fme = mock(FirebaseMessagingException.class);
+        when(fme.getMessagingErrorCode()).thenReturn(MessagingErrorCode.UNREGISTERED);
+        when(firebaseMessaging.send(any(Message.class))).thenThrow(fme);
+
+        FCMMessageRequest request = FCMMessageRequest.of("expired-token-1234567890", "제목", "내용");
+
+        assertThatThrownBy(() -> fcmClient.send(request))
+                .isInstanceOf(FCMException.class)
+                .matches(e -> ((FCMException) e).isInvalidToken());
+    }
+
+    @Test
+    @DisplayName("SENDER_ID_MISMATCH 시에도 무효 토큰으로 처리된다")
+    void send_senderIdMismatch_throwsInvalidToken() throws FirebaseMessagingException {
+        FirebaseMessagingException fme = mock(FirebaseMessagingException.class);
+        when(fme.getMessagingErrorCode()).thenReturn(MessagingErrorCode.SENDER_ID_MISMATCH);
+        when(firebaseMessaging.send(any(Message.class))).thenThrow(fme);
+
+        FCMMessageRequest request = FCMMessageRequest.of("mismatch-token-1234567890", "제목", "내용");
+
+        assertThatThrownBy(() -> fcmClient.send(request))
+                .isInstanceOf(FCMException.class)
+                .matches(e -> ((FCMException) e).isInvalidToken());
+    }
+
+    @Test
+    @DisplayName("기타 Firebase 오류 시 FCMException(isInvalidToken=false) 발생")
+    void send_otherError_throwsSendFailed() throws FirebaseMessagingException {
+        FirebaseMessagingException fme = mock(FirebaseMessagingException.class);
+        when(fme.getMessagingErrorCode()).thenReturn(MessagingErrorCode.INTERNAL);
+        when(firebaseMessaging.send(any(Message.class))).thenThrow(fme);
+
+        FCMMessageRequest request = FCMMessageRequest.of("valid-token-1234567890ab", "제목", "내용");
+
+        assertThatThrownBy(() -> fcmClient.send(request))
+                .isInstanceOf(FCMException.class)
+                .matches(e -> !((FCMException) e).isInvalidToken());
+    }
+
+    @Test
+    @DisplayName("예상치 못한 RuntimeException도 FCMException으로 래핑된다")
+    void send_unexpectedException_wrappedAsFCMException() throws FirebaseMessagingException {
+        when(firebaseMessaging.send(any(Message.class))).thenThrow(new RuntimeException("네트워크 오류"));
+
+        FCMMessageRequest request = FCMMessageRequest.of("valid-token-1234567890ab", "제목", "내용");
+
+        assertThatThrownBy(() -> fcmClient.send(request))
+                .isInstanceOf(FCMException.class)
+                .matches(e -> !((FCMException) e).isInvalidToken());
+    }
+}

--- a/hilingual-external/src/test/java/org/sopt/firebase/FCMMessageRequestTest.java
+++ b/hilingual-external/src/test/java/org/sopt/firebase/FCMMessageRequestTest.java
@@ -1,0 +1,79 @@
+package org.sopt.firebase;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.sopt.firebase.dto.FCMMessageRequest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FCMMessageRequestTest {
+
+    @Test
+    @DisplayName("정상 생성 시 모든 필드가 올바르게 설정된다")
+    void create_success() {
+        FCMMessageRequest request = FCMMessageRequest.of("token123", "제목", "내용");
+
+        assertThat(request.token()).isEqualTo("token123");
+        assertThat(request.title()).isEqualTo("제목");
+        assertThat(request.body()).isEqualTo("내용");
+        assertThat(request.data()).isEmpty();
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"   "})
+    @DisplayName("token이 null, 빈 문자열, 공백이면 예외 발생")
+    void create_blankToken_throws(String token) {
+        assertThatThrownBy(() -> FCMMessageRequest.of(token, "제목", "내용"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("token");
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"   "})
+    @DisplayName("title이 null, 빈 문자열, 공백이면 예외 발생")
+    void create_blankTitle_throws(String title) {
+        assertThatThrownBy(() -> FCMMessageRequest.of("token123", title, "내용"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("title");
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"   "})
+    @DisplayName("body가 null, 빈 문자열, 공백이면 예외 발생")
+    void create_blankBody_throws(String body) {
+        assertThatThrownBy(() -> FCMMessageRequest.of("token123", "제목", body))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("body");
+    }
+
+    @Test
+    @DisplayName("data가 null이면 빈 Map으로 초기화된다")
+    void create_nullData_becomesEmptyMap() {
+        FCMMessageRequest request = new FCMMessageRequest("token123", "제목", "내용", null);
+
+        assertThat(request.data()).isNotNull().isEmpty();
+    }
+
+    @Test
+    @DisplayName("data는 방어적 복사되어 외부 변경의 영향을 받지 않는다")
+    void create_data_defensiveCopy() {
+        Map<String, String> original = new HashMap<>();
+        original.put("key", "value");
+
+        FCMMessageRequest request = FCMMessageRequest.of("token123", "제목", "내용", original);
+        original.put("newKey", "newValue"); // 원본 변경
+
+        assertThat(request.data()).hasSize(1); // 영향 없음
+        assertThat(request.data()).containsEntry("key", "value");
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #344  

 ## Work Description ✏️
  - Firebase Admin SDK 서버 연동
    - `firebase-admin:9.4.3` 의존성 추가
    - `firebase.enabled=true`일 때만 활성화되는 조건부 로딩 적용
    - 로컬/테스트 환경에서는 Firebase 없이 앱 정상 시작
  - FCM 발송 클라이언트 구현
    - 단건 메시지 발송 기능 (`FCMClient`)
    - 만료/무효 토큰 자동 판별 (UNREGISTERED, INVALID_ARGUMENT, SENDER_ID_MISMATCH)
    - 예외 처리 체계 (`FCMErrorCode`, `FCMException`)
  - 단위 테스트 17건 작성
    - FCMClient 발송/에러 시나리오 5건
    - FCMMessageRequest 입력 검증 12건

 ## Screenshot 📸
  N/A (API 엔드포인트 변경 없음)

 ## Uncompleted Tasks 😅
  N/A