### PR TITLE
[fix] #349 회원탈퇴 불가한 오류 수정

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/auth/service/AuthService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/auth/service/AuthService.java
@@ -112,6 +112,7 @@ public class AuthService {
         blockFacade.deleteAllByUserId(userId); // Block 삭제
         followFacade.deleteAllByUserId(userId); // Follow 삭제
         alarmPreferenceFacade.deleteAllByUserId(userId); // AlarmPreference 삭제
+
         deviceFacade.deleteAllDevices(userId); // DeviceInfo 삭제
 
         userFacade.deleteUserById(userId); // user, userProfile, noticeDelivery 삭제

--- a/hilingual-domain/src/main/java/org/sopt/diary/facade/DiaryRemover.java
+++ b/hilingual-domain/src/main/java/org/sopt/diary/facade/DiaryRemover.java
@@ -2,6 +2,9 @@ package org.sopt.diary.facade;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.diary.repository.DiaryRepository;
+import org.sopt.diaryfeedback.repository.DiaryFeedbackRepository;
+import org.sopt.recommend.facade.RecommendFacade;
+import org.sopt.recommend.repository.RecommendRepository;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -9,8 +12,12 @@ import org.springframework.stereotype.Component;
 public class DiaryRemover {
 
     private final DiaryRepository diaryRepository;
+    private final RecommendRepository recommendRepository;
+    private final DiaryFeedbackRepository diaryFeedbackRepository;
 
     public void deleteAllByUserId(final Long userId) {
+        recommendRepository.deleteAllByUserId(userId);
+        diaryFeedbackRepository.deleteAllByUserId(userId);
         diaryRepository.deleteAllByUserId(userId);
     }
 

--- a/hilingual-domain/src/main/java/org/sopt/diary/repository/DiaryRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/diary/repository/DiaryRepository.java
@@ -3,6 +3,7 @@ package org.sopt.diary.repository;
 import org.sopt.diary.domain.Diary;
 import org.sopt.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -39,5 +40,7 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
            """)
     Optional<Diary> findDiaryWithDetailsById(@Param("diaryId") Long diaryId);
 
-    void deleteAllByUserId(Long userId);
+    @Modifying(clearAutomatically = true, flushAutomatically = true) // 중요!
+    @Query("delete from Diary d where d.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/hilingual-domain/src/main/java/org/sopt/diaryfeedback/repository/DiaryFeedbackRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/diaryfeedback/repository/DiaryFeedbackRepository.java
@@ -2,6 +2,8 @@ package org.sopt.diaryfeedback.repository;
 
 import org.sopt.diaryfeedback.domain.DiaryFeedback;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
@@ -9,4 +11,7 @@ public interface DiaryFeedbackRepository extends JpaRepository<DiaryFeedback, Lo
 
     List<DiaryFeedback> findByDiaryId(Long diaryId);
 
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from DiaryFeedback df where df.diary.user.id = :userId")
+    void deleteAllByUserId(Long userId);
 }

--- a/hilingual-domain/src/main/java/org/sopt/recommend/repository/RecommendRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/recommend/repository/RecommendRepository.java
@@ -3,6 +3,7 @@ package org.sopt.recommend.repository;
 import org.sopt.recommend.domain.Recommend;
 import org.sopt.recommend.dto.RecommendWithBookmarkDto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -35,4 +36,8 @@ public interface RecommendRepository extends JpaRepository<Recommend, Long> {
         where r.id = :id
     """)
     Optional<Recommend> findByIdWithDiary(@Param("id") Long id);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from Recommend r where r.diary.user.id = :userId")
+    void deleteAllByUserId(Long userId);
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #349 

## Work Description ✏️
- 회원탈퇴 불가한 오류 수정

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 회원탈퇴 API | <img width="1018" height="988" alt="image" src="https://github.com/user-attachments/assets/389f90e7-245e-4ba5-9c22-6411d3fceca6" /> |

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
일기 삭제 로직 삭제하면서 탈퇴를 위해 삭제해야 하는 로직까지 날아갔나봐요 후잉.