### PR TITLE
[fix] #349 알림 동의 유저가 회원탈퇴 불가한 오류 수정

### DIFF
--- a/hilingual-domain/src/main/java/org/sopt/alarmpreference/repository/AlarmPreferenceRepository.java
+++ b/hilingual-domain/src/main/java/org/sopt/alarmpreference/repository/AlarmPreferenceRepository.java
@@ -3,6 +3,7 @@ package org.sopt.alarmpreference.repository;
 import org.sopt.alarmpreference.domain.AlarmPreference;
 import org.sopt.alarmpreference.type.AlarmType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
@@ -26,6 +27,8 @@ public interface AlarmPreferenceRepository extends JpaRepository<AlarmPreference
            """)
     List<Long> findEnabledUserIdsByType(AlarmType alarmType);
 
+    @Modifying(clearAutomatically = true)
+    @Query("delete from AlarmPreference a where a.user.id = :userId")
     void deleteAllByUserId(Long userId);
 
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #349 

## Work Description ✏️
- 알림 동의 완료된 유저의 탈퇴가 안되는 오류를 해결했습니다.

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
|        ex. 게시글 전체 조회 API      | <캡처 이미지 첨부> |
| ex. 게시글 전체 조회(페이지 넘어간 경우 404) | <캡처 이미지 첨부> |

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A