### PR TITLE
[fix] #349 회원 탈퇴 시 알림 타입 및 공지도 삭제되도록 DB 제약 조건 설정

### DIFF
--- a/hilingual-api/src/main/resources/db/migration/V8__alter_alarm_notice_constraint.sql
+++ b/hilingual-api/src/main/resources/db/migration/V8__alter_alarm_notice_constraint.sql
@@ -1,0 +1,7 @@
+ALTER TABLE alarm_preference DROP CONSTRAINT alarm_preference_user_id_fkey;
+ALTER TABLE alarm_preference ADD CONSTRAINT alarm_preference_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
+
+ALTER TABLE notice_delivery DROP CONSTRAINT IF EXISTS notice_delivery_user_id_fkey;
+ALTER TABLE notice_delivery ADD CONSTRAINT notice_delivery_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;


### PR DESCRIPTION
## Related issue 🛠
- closed #349 

## Work Description ✏️
-  회원 탈퇴 시 알림 타입 및 공지도 삭제되도록 DB 제약 조건을 설정했습니다.

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
|        ex. 게시글 전체 조회 API      | <캡처 이미지 첨부> |
| ex. 게시글 전체 조회(페이지 넘어간 경우 404) | <캡처 이미지 첨부> |

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
앞으로 새로운 API 만들 때 탈퇴 로직이 잘 작동하는지, 제약 조건이 올바르게 설정되어 있는지 확인하는 절차가 꼭 필요할 것 같습니다~!