### PR TITLE
[chore] #359 writtenDate 내려주는 것으로 변경

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/feed/dto/SharedDiaryListRes.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/feed/dto/SharedDiaryListRes.java
@@ -35,7 +35,7 @@ public record SharedDiaryListRes(
     public record SharedDiary(
             Long diaryId,
             Long sharedDate,
-            LocalDateTime createdAt,
+            String writtenDate,
             Integer likeCount,
             Boolean isLiked,
             String diaryImg,
@@ -49,7 +49,7 @@ public record SharedDiaryListRes(
             return new SharedDiary(
                     diary.getId(),
                     (minutesDiff < ONE_MINUTE) ? LESS_THAN_MINUTE : minutesDiff,
-                    diary.getCreatedAt(),
+                    diary.getWrittenDate().toString(),
                     diary.getIsLiked(),
                     isLikedByUser,
                     diaryImgUrl, // 변환된 URL 사용


### PR DESCRIPTION
## Related issue 🛠
- closed #359 

## Work Description ✏️
- API 명세 수정
- 피드 프로필 '공유한 일기' 확인 API의 createdAt 필드를 writtenDate 내려주는 것으로 변경

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 피드 프로필 ‘공유한 일기’ 확인 API    |  <img width="1235" height="1566" alt="image" src="https://github.com/user-attachments/assets/2c796446-8d81-4794-bbcc-8a6f3af5b5b5" /> |

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A