### PR TITLE
[refac] #361 글로벌 지원을 위한 API 수정사항 구현 및 내부로직 수정

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/diary/service/DiaryService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/diary/service/DiaryService.java
@@ -122,8 +122,7 @@ public class DiaryService {
 
         String imageUrl = s3Service.toPublicUrl(imageKey);
 
-        String date = diary.getWrittenDate()
-                .format(DateTimeFormatter.ofPattern("M월 d일 EEEE", Locale.KOREAN));
+        String date = String.valueOf(diary.getWrittenDate());
 
         List<DiaryDetailsRes.DiffRange> diffRanges = diaryDiffService.extractDiffRanges(originalText, rewriteText);
 

--- a/hilingual-api/src/main/java/org/sopt/controller/user/api/UserController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/api/UserController.java
@@ -38,7 +38,7 @@ public class UserController {
             @UserId Long userId,
             @UserTimezone final ZoneId userZone
     ) {
-        return ResponseEntity.ok(userService.getHomesUserInfo(userId));
+        return ResponseEntity.ok(userService.getHomeUserInfo(userId));
     }
 
     // 마이페이지

--- a/hilingual-api/src/main/java/org/sopt/controller/user/api/UserController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/api/UserController.java
@@ -3,6 +3,7 @@ package org.sopt.controller.user.api;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.sopt.alarmpreference.type.AlarmType;
+import org.sopt.annotation.UserTimezone;
 import org.sopt.controller.user.dto.*;
 import org.sopt.controller.user.service.UserService;
 import org.sopt.jwt.core.JwtTokenProvider;
@@ -12,6 +13,7 @@ import org.sopt.user.type.NotificationTab;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.ZoneId;
 import java.util.List;
 
 @RestController
@@ -33,9 +35,10 @@ public class UserController {
     // 홈
     @GetMapping("/home/info")
     public ResponseEntity<HomeUserProfileRes> getUserProfile(
-            @UserId Long userId
+            @UserId Long userId,
+            @UserTimezone final ZoneId userZone
     ) {
-        return ResponseEntity.ok(userService.getHomeUserInfo(userId));
+        return ResponseEntity.ok(userService.getHomesUserInfo(userId));
     }
 
     // 마이페이지

--- a/hilingual-api/src/main/java/org/sopt/controller/user/dto/FeedAlarmItemRes.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/dto/FeedAlarmItemRes.java
@@ -1,8 +1,11 @@
 package org.sopt.controller.user.dto;
 
+import com.google.api.client.util.DateTime;
 import org.sopt.feedalarm.domain.FeedAlarm;
 
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Date;
 
 public record FeedAlarmItemRes(
         Long noticeId,
@@ -10,7 +13,8 @@ public record FeedAlarmItemRes(
         String title,
         Long targetId,
         boolean isRead,
-        String publishedAt
+        String publishedAt,
+        LocalDateTime publishedAtUtc
 ) implements NotificationItemRes {
 
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
@@ -22,7 +26,8 @@ public record FeedAlarmItemRes(
                 a.getTitle(),
                 a.getTargetId(),
                 a.getReadAt() != null,
-                a.getCreatedAt().toLocalDate().format(DATE_FORMATTER)
+                a.getCreatedAt().toLocalDate().format(DATE_FORMATTER),
+                a.getCreatedAt()
         );
     }
 }

--- a/hilingual-api/src/main/java/org/sopt/controller/user/dto/NoticeDetailRes.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/dto/NoticeDetailRes.java
@@ -3,11 +3,13 @@ package org.sopt.controller.user.dto;
 import org.sopt.notice.domain.Notice;
 import org.sopt.noticedetail.domain.NoticeDetail;
 
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 public record NoticeDetailRes(
         String title,
         String createdAt,
+        LocalDateTime createdAtUtc,
         String content
 ) {
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
@@ -16,6 +18,7 @@ public record NoticeDetailRes(
         return new NoticeDetailRes(
                 notice.getTitle(),
                 notice.getCreatedAt().format(FORMATTER),
+                notice.getCreatedAt(),
                 detail.getContent()
         );
     }

--- a/hilingual-api/src/main/java/org/sopt/controller/user/dto/NoticeListItemRes.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/dto/NoticeListItemRes.java
@@ -2,6 +2,7 @@ package org.sopt.controller.user.dto;
 
 import org.sopt.noticedelivery.domain.NoticeDelivery;
 
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 public record NoticeListItemRes(
@@ -9,7 +10,8 @@ public record NoticeListItemRes(
         String category,
         String title,
         boolean isRead,
-        String publishedAt
+        String publishedAt,
+        LocalDateTime publishedAtUtc
 ) implements NotificationItemRes {
 
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
@@ -22,7 +24,8 @@ public record NoticeListItemRes(
                 notice.getCategory().name(),
                 notice.getTitle(),
                 d.getReadAt() != null,
-                notice.getCreatedAt().toLocalDate().format(DATE_FORMATTER)
+                notice.getCreatedAt().toLocalDate().format(DATE_FORMATTER),
+                notice.getCreatedAt()
         );
     }
 }

--- a/hilingual-api/src/main/java/org/sopt/controller/usercalendar/service/UserCalendarService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/usercalendar/service/UserCalendarService.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 @Service
@@ -41,11 +42,17 @@ public class UserCalendarService {
         }
     }
 
-    public UserCalendarTopicRes getTopicByDate(final long userId, final LocalDate date, final ZoneId userZone) {
-        if (date.isAfter(LocalDate.now(userZone))) {
+    public UserCalendarTopicRes getTopicByDate(final long userId, final LocalDate targetDate, final ZoneId userZone) {
+        // 1. 유저 타임존 기준의 현재 시점 계산
+        ZonedDateTime nowInUserZone = ZonedDateTime.now(userZone);
+        LocalDate today = nowInUserZone.toLocalDate();
+
+        // 2. 미래 날짜 검증
+        if (targetDate.isAfter(today)) {
             throw new FutureDateNotAllowedException(UserCalendarApiErrorCode.FUTURE_DATE_NOT_ALLOWED);
         }
-        return topicFacade.findTopicByDate(userId, date, userZone);
+
+        return topicFacade.findTopicByDate(userId, targetDate, userZone);
     }
 
     public UserCalendarMonthlyRes getWrittenDatesOfMonth(final Long userId, final int year, final int month) {

--- a/hilingual-api/src/main/java/org/sopt/controller/voca/dto/res/VocaDetailResponse.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/voca/dto/res/VocaDetailResponse.java
@@ -2,6 +2,7 @@ package org.sopt.controller.voca.dto.res;
 
 import org.sopt.recommend.domain.Recommend;
 import org.sopt.voca.domain.Voca;
+import org.sopt.voca.type.SavedRoot;
 
 import java.util.Arrays;
 import java.util.List;
@@ -12,28 +13,34 @@ public record VocaDetailResponse(
         List<String> phraseType,
         String explanation,
         String writtenFrom,
+        String writtenDate,
+        Integer savedRoot,
         Boolean isBookmarked
 ) {
     // Recommend 기반
-    public static VocaDetailResponse of(Recommend r, String writtenFrom, boolean isBookmarked) {
+    public static VocaDetailResponse of(Recommend r, String writtenFrom, String writtenDate, SavedRoot savedRoot, boolean isBookmarked) {
         return new VocaDetailResponse(
                 r.getId(),
                 r.getPhrase(),
                 parsePhraseTypes(r.getPhraseType()),
                 r.getExplanation(),
                 writtenFrom,
+                writtenDate,
+                savedRoot.getCode(),
                 isBookmarked
         );
     }
 
     // Voca 스냅샷 기반
-    public static VocaDetailResponse ofSnapshot(Voca v, boolean isBookmarked) {
+    public static VocaDetailResponse ofSnapshot(Voca v, String writtenDate, boolean isBookmarked) {
         return new VocaDetailResponse(
                 v.getRecommendId(),
                 v.getPhrase(),
                 parsePhraseTypes(v.getPhraseType()),
                 v.getExplanation(),
                 v.getWrittenFrom(),
+                writtenDate,
+                v.getSavedRoot().getCode(),
                 isBookmarked
         );
     }

--- a/hilingual-api/src/main/java/org/sopt/controller/voca/service/VocaService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/voca/service/VocaService.java
@@ -9,6 +9,7 @@ import org.sopt.recommend.facade.RecommendFacade;
 import org.sopt.voca.domain.Voca;
 import org.sopt.voca.facade.VocaFacade;
 import org.sopt.voca.facade.VocaRetriever;
+import org.sopt.voca.type.SavedRoot;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,12 +44,36 @@ public class VocaService {
     // 특정 단어 세부 조회
     public VocaDetailResponse getVocaDetails(Long userId, Long recommendId) {
         return vocaFacade.findOptionalByUserIdAndRecommendId(userId, recommendId)
-                .map(v -> VocaDetailResponse.ofSnapshot(v, true))
+                .map(v -> {
+                    // 북마크된 경우
+                    Recommend recommend = recommendFacade.findByIdWithDiary(v.getRecommendId());
+
+                    String writtenDate = null;
+                    if (v.getSavedRoot() == SavedRoot.MY) {
+                        writtenDate = recommend.getDiary().getWrittenDate().toString();
+                    }
+
+                    return VocaDetailResponse.ofSnapshot(v, writtenDate, true);                })
                 .orElseGet(() -> {
+                    // 북마크되지 않은 경우
                     Recommend recommend = recommendFacade.findByIdWithDiary(recommendId);
+
+                    SavedRoot root = determineSavedRoot(userId, recommend);
+
                     String writtenFrom = buildWrittenFrom(userId, recommend, false);
-                    return VocaDetailResponse.of(recommend, writtenFrom, false);
+
+                    String writtenDate = null;
+                    if (root == SavedRoot.MY) {
+                        writtenDate = recommend.getDiary().getWrittenDate().toString();
+                    }
+
+                    return VocaDetailResponse.of(recommend, writtenFrom, writtenDate, root, false);
                 });
+    }
+
+    private SavedRoot determineSavedRoot(Long userId, Recommend rec) {
+        Long ownerId = rec.getDiary().getUser().getId();
+        return ownerId.equals(userId) ? SavedRoot.MY : SavedRoot.FEED;
     }
 
     private String buildWrittenFrom(Long userId, Recommend rec, boolean isBookmarked) {

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileUpdater.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileUpdater.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 
 import java.time.*;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -88,12 +89,20 @@ public class UserProfileUpdater {
     @Scheduled(cron = "0 0,15,30,45 * * * *")
     @Transactional
     public void resetStreakIfBrokenGlobal() {
-        Instant now = Instant.now();
+        Instant rawNow = Instant.now();
+
+        // 스케줄러 지연 방어: 현재 시간을 가장 가까운 과거의 15분 단위로 내림 처리
+        // ex) 00:01:05 -> 00:00:00 / 00:16:20 -> 00:15:00
+        int currentMinute = rawNow.atZone(ZoneOffset.UTC).getMinute();
+        int targetMinute = (currentMinute / 15) * 15;
+
+        Instant truncatedNow = rawNow.truncatedTo(ChronoUnit.HOURS)
+                .plus(targetMinute, ChronoUnit.MINUTES);
 
         // 현재 자정을 맞이한 타임존만 추출
         Set<String> midnightZones = ZoneId.getAvailableZoneIds().stream()
                 .filter(zone -> {
-                    LocalTime localTime = LocalTime.ofInstant(now, ZoneId.of(zone));
+                    LocalTime localTime = LocalTime.ofInstant(truncatedNow, ZoneId.of(zone));
                     return localTime.getHour() == 0 && localTime.getMinute() == 0;
                 })
                 .collect(Collectors.toSet());


### PR DESCRIPTION
## Related issue 🛠
- closed #361 

## Work Description ✏️
- API 수정사항 구현
    - 알림 리스트 확인 API에서 publishedAtUtc 신설해 Datetime으로 응답
    - 공지사항 알림 상세보기 API에서 createdAtUtc 신설해 Datetime으로 응답
    - AI가 교정한 일기 확인 API에서 date를 2026-04-12 형태의 String으로 다른 응답과 통일
    - 특정 단어 세부내용 조회 API에서 writtenDate를 nullable하게 설정하고 String으로 응답 및 saved root신설
- 내부 로직 수정
    - 작성되지 않은 일기 주제 조회 API에서 헤더에 들어온 타임존+클라가 넣어주는 local date로 remainingTime 계산
    - streak 계산
    - 기본 정보 조회 API에서 타임존 검사
    - 일기 피드백 요청 API에서 타임존 검사

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 알림 리스트 확인 API |<img width="806" height="1067" alt="image" src="https://github.com/user-attachments/assets/86f5050c-5136-481f-b2b5-7f894379bbe1" /> |
| 공지사항 알림 상세보기 API | <img width="899" height="1102" alt="image" src="https://github.com/user-attachments/assets/352ece94-80cc-42ee-9f70-673a7d417588" /> |
| AI가 교정한 일기 확인 API | <img width="805" height="1078" alt="image" src="https://github.com/user-attachments/assets/7dae7fca-b082-4cf0-b571-151f3f83127a" /> |
| 특정 단어 세부내용 조회 API | <img width="897" height="1149" alt="image" src="https://github.com/user-attachments/assets/be586269-9d84-4d66-af1e-2f9f5930b7d4" /> |

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A