### PR TITLE
[fix] streak, remainingTime에 타임존이 적용되지 않는 오류 수정

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/device/api/DeviceController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/device/api/DeviceController.java
@@ -5,6 +5,7 @@ import org.sopt.annotation.UserTimezone;
 import org.sopt.controller.device.dto.DeviceReq;
 import org.sopt.controller.device.service.DeviceService;
 import org.sopt.jwt.annotation.UserId;
+import org.sopt.web.UserZone;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,10 +23,10 @@ public class DeviceController {
     @PutMapping("")
     public ResponseEntity<Void> putDeviceInfo(
             @UserId Long userId,
-            @UserTimezone ZoneId userZone,
+            @UserTimezone UserZone userZone,
             @RequestBody DeviceReq req
             ) {
-        deviceService.updateDeviceInfo(userId, req, userZone);
+        deviceService.updateDeviceInfo(userId, req, userZone.zoneId());
         return ResponseEntity.ok().build();
     }
 }

--- a/hilingual-api/src/main/java/org/sopt/controller/diary/api/DiaryController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/diary/api/DiaryController.java
@@ -10,6 +10,7 @@ import org.sopt.diaryfeedback.diff.dto.DiaryDetailsRes;
 import org.sopt.controller.diary.dto.DiaryRes;
 import org.sopt.controller.diary.service.DiaryService;
 import org.sopt.jwt.annotation.UserId;
+import org.sopt.web.UserZone;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,12 +27,12 @@ public class DiaryController {
     @PostMapping
     public ResponseEntity<DiaryRes> createDiary(
             @UserId Long userId,
-            @UserTimezone ZoneId userZone,
+            @UserTimezone UserZone userZone,
             @Valid @RequestBody CreateDiaryReq req
     ) {
         LocalDate writtenDate = LocalDate.parse(req.date());
         return ResponseEntity.ok(
-                diaryService.createDiaryWithFeedback(userId, req.originalText(), writtenDate, req.image(), userZone)
+                diaryService.createDiaryWithFeedback(userId, req.originalText(), writtenDate, req.image(), userZone.zoneId())
         );
     }
 

--- a/hilingual-api/src/main/java/org/sopt/controller/user/api/UserController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/api/UserController.java
@@ -10,6 +10,7 @@ import org.sopt.jwt.core.JwtTokenProvider;
 import org.sopt.jwt.auth.dto.ReissueTokensRes;
 import org.sopt.jwt.annotation.UserId;
 import org.sopt.user.type.NotificationTab;
+import org.sopt.web.UserZone;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -36,7 +37,7 @@ public class UserController {
     @GetMapping("/home/info")
     public ResponseEntity<HomeUserProfileRes> getUserProfile(
             @UserId Long userId,
-            @UserTimezone final ZoneId userZone
+            @UserTimezone final UserZone userZone
     ) {
         return ResponseEntity.ok(userService.getHomeUserInfo(userId));
     }

--- a/hilingual-api/src/main/java/org/sopt/controller/usercalendar/api/UserCalendarController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/usercalendar/api/UserCalendarController.java
@@ -10,6 +10,7 @@ import org.sopt.controller.usercalendar.exception.InvalidMonthException;
 import org.sopt.controller.usercalendar.exception.UserCalendarApiErrorCode;
 import org.sopt.controller.usercalendar.exception.UserCalendarInvalidDateFormatException;
 import org.sopt.controller.usercalendar.service.UserCalendarService;
+import org.sopt.web.UserZone;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -43,7 +44,7 @@ public class UserCalendarController {
     @GetMapping("/{date}/topic")
     public ResponseEntity<UserCalendarTopicRes> getTopicByDate(
             @UserId Long userId,
-            @UserTimezone final ZoneId userZone,
+            @UserTimezone final UserZone userZone,
             @PathVariable final String date
     ) {
         final LocalDate parsedDate;
@@ -54,7 +55,7 @@ public class UserCalendarController {
             throw new UserCalendarInvalidDateFormatException(UserCalendarApiErrorCode.INVALID_DATE_FORMAT);
         }
 
-        return ResponseEntity.ok(userCalendarService.getTopicByDate(userId, parsedDate, userZone));
+        return ResponseEntity.ok(userCalendarService.getTopicByDate(userId, parsedDate, userZone.zoneId()));
     }
 
     @GetMapping("/month")

--- a/hilingual-api/src/main/java/org/sopt/web/UserTimezoneArgumentResolver.java
+++ b/hilingual-api/src/main/java/org/sopt/web/UserTimezoneArgumentResolver.java
@@ -1,5 +1,6 @@
 package org.sopt.web;
 
+import lombok.extern.slf4j.Slf4j;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.sopt.annotation.UserTimezone;
 import org.sopt.context.TimezoneContextHolder;
@@ -9,18 +10,15 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
-import java.time.ZoneId;
 
+@Slf4j
 @Component
 public class UserTimezoneArgumentResolver implements HandlerMethodArgumentResolver {
 
-    // 어떤 파라미터에 이 Resolver를 적용할 것인지?
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        boolean hasAnnotation = parameter.hasParameterAnnotation(UserTimezone.class);
-        boolean isZoneIdType = ZoneId.class.isAssignableFrom(parameter.getParameterType());
-
-        return hasAnnotation && isZoneIdType;
+        return parameter.hasParameterAnnotation(UserTimezone.class) &&
+                UserZone.class.isAssignableFrom(parameter.getParameterType());
     }
 
     // 파라미터에 실제로 주입할 값
@@ -30,7 +28,6 @@ public class UserTimezoneArgumentResolver implements HandlerMethodArgumentResolv
                                   @NonNull NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) {
 
-        // Interceptor가 파싱해서 ThreadLocal에 넣어둔 타임존을 반환
-        return TimezoneContextHolder.getTimezone();
+        return new UserZone(TimezoneContextHolder.getTimezone());
     }
 }

--- a/hilingual-api/src/main/java/org/sopt/web/UserZone.java
+++ b/hilingual-api/src/main/java/org/sopt/web/UserZone.java
@@ -1,0 +1,5 @@
+package org.sopt.web;
+
+import java.time.ZoneId;
+
+public record UserZone(ZoneId zoneId) {}

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileUpdater.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileUpdater.java
@@ -24,8 +24,6 @@ public class UserProfileUpdater {
     private final UserCalendarFacade userCalendarFacade;
     private final UserProfileRepository userProfileRepository;
     private final UserProfileRetriever userProfileRetriever;
-    private final UserProfileFacade userProfileFacade;
-
     /**
      * 일기 작성 시 totalDiaries 증가 및 streak 재계산
      */

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileUpdater.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileUpdater.java
@@ -24,6 +24,7 @@ public class UserProfileUpdater {
     private final UserCalendarFacade userCalendarFacade;
     private final UserProfileRepository userProfileRepository;
     private final UserProfileRetriever userProfileRetriever;
+    private final UserProfileFacade userProfileFacade;
 
     /**
      * 일기 작성 시 totalDiaries 증가 및 streak 재계산
@@ -43,6 +44,7 @@ public class UserProfileUpdater {
         // 전달받은 유저의 로컬 타임존
         LocalDate today     = LocalDate.now(userZone); // D
         LocalDate yesterday = today.minusDays(1); // Y
+        LocalDate dayBeforeYesterday = today.minusDays(2);
 
         // 캘린더 사실값 조회
         WriteStatus yStatus = userCalendarFacade.getStatus(profile.getUser(), yesterday);
@@ -55,14 +57,19 @@ public class UserProfileUpdater {
                 // 어제부터의 연속을 사실값으로 재계산 후 +오늘
                 int base = calculateStreakFromDate(profile.getUser(), yesterday);
                 newStreak = base + 1;
-            } else {
-                // (NONE 또는 DELETED) → 오늘 단독은 즉시 1
-                newStreak = 1;
+            } else { // 어제 일기가 없는 경우
+                WriteStatus dbyStatus = userCalendarFacade.getStatus(profile.getUser(), dayBeforeYesterday);
+                if (dbyStatus == WriteStatus.WRITTEN) { // 그저께 일기가 있는 경우
+                    newStreak = calculateStreakFromDate(profile.getUser(), dayBeforeYesterday) ;
+                } else {
+                    // (NONE 또는 DELETED) → 오늘 단독은 즉시 1
+                    newStreak = 1;
+                }
             }
-        } else if (writtenDate.equals(yesterday)) {
-            // 어제 보충 시: 어제부터의 연속을 사실값으로 재계산
-            int base = calculateStreakFromDate(profile.getUser(), yesterday); // ≥1
-            newStreak = base + (dStatus == WriteStatus.WRITTEN ? 1 : 0);
+        } else if (writtenDate.equals(yesterday)) { // 어제 일기를 보충한 경우
+            // 어제부터의 연속을 사실값으로 재계산
+            int base = calculateStreakFromDate(profile.getUser(), yesterday);
+            newStreak = base + (dStatus == WriteStatus.WRITTEN ? 1 : 0); // 오늘 일기 작성되어 있다면 추가로 +1
         }
         // 그 외 날짜는 변화 없음
 
@@ -121,7 +128,8 @@ public class UserProfileUpdater {
         // 대상 유저들의 로컬 날짜 기준으로 스트릭 검사 및 갱신
         for (UserProfile profile : targetProfiles) {
             ZoneId userZone = ZoneId.of(profile.getUser().getPrimaryTimezone());
-            LocalDate today = LocalDate.now(userZone);
+
+            LocalDate today = LocalDate.ofInstant(truncatedNow, userZone);
             LocalDate yesterday = today.minusDays(1);
             LocalDate dayBeforeYesterday = today.minusDays(2);
 


### PR DESCRIPTION
## Related issue 🛠
- closed #363 

## Work Description ✏️
- Streak 로직 수정
- remainingTime 계산 시 타임존이 서버 측으로 전달되지 않는 오류 수정

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 한국(25일), 뉴욕(24일)일 때 타임존 뉴욕에서 25일 일기 주제 조회 API | <img width="924" height="869" alt="image" src="https://github.com/user-attachments/assets/e5975039-213f-4f70-828d-ab36b72b9580" /> |
| 한국(25일), 뉴욕(24일)일 때 타임존 한국에서 25일 일기 주제 조회 API  | <img width="1153" height="1102" alt="image" src="https://github.com/user-attachments/assets/d5caf439-6708-4b6a-ab30-efff20f4549e" /> |
| 한국(25일), 뉴욕(24일)일 때 타임존 뉴욕에서 24일 일기 주제 조회 API | <img width="1260" height="1207" alt="image" src="https://github.com/user-attachments/assets/53da8442-39cf-4e39-b8b2-e3f351ca16e4" /> |

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A