### PR TITLE
[fix] #365 미래 일기 주제 조회 가능하도록 예외처리 삭제 및 다음날 streak까지 고려하도록 수정

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/user/api/UserController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/api/UserController.java
@@ -39,7 +39,7 @@ public class UserController {
             @UserId Long userId,
             @UserTimezone final UserZone userZone
     ) {
-        return ResponseEntity.ok(userService.getHomeUserInfo(userId));
+        return ResponseEntity.ok(userService.getHomeUserInfo(userId, userZone.zoneId()));
     }
 
     // 마이페이지

--- a/hilingual-api/src/main/java/org/sopt/controller/user/service/UserService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/user/service/UserService.java
@@ -14,12 +14,14 @@ import org.sopt.jwt.auth.dto.ReissueTokensRes;
 import org.sopt.user.domain.User;
 import org.sopt.user.facade.UserFacade;
 import org.sopt.userprofile.domain.UserProfile;
+import org.sopt.userprofile.facade.UserProfileFacade;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.sopt.noticedelivery.domain.NoticeDelivery;
 import org.sopt.noticedelivery.facade.NoticeDeliveryFacade;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 
@@ -34,6 +36,7 @@ public class UserService {
     private final FeedAlarmFacade feedAlarmFacade;
     private final AlarmPreferenceFacade alarmPreferenceFacade;
     private final S3Service s3Service;
+    private final UserProfileFacade userProfileFacade;
 
     public UserDefaultInfoRes getUserDefaultInfo(final long userId) {
         User user = userFacade.getUserById(userId);
@@ -46,9 +49,11 @@ public class UserService {
         );
     }
 
-    public HomeUserProfileRes getHomeUserInfo(final long userId) {
+    public HomeUserProfileRes getHomeUserInfo(final long userId, final ZoneId userZone) {
         User user = userFacade.getUserById(userId);
         UserProfile userProfile = user.getUserProfile();
+
+        userProfileFacade.syncStreak(userId, userZone);
 
         return HomeUserProfileRes.from(
                 userProfile,

--- a/hilingual-api/src/main/java/org/sopt/controller/usercalendar/service/UserCalendarService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/usercalendar/service/UserCalendarService.java
@@ -43,15 +43,6 @@ public class UserCalendarService {
     }
 
     public UserCalendarTopicRes getTopicByDate(final long userId, final LocalDate targetDate, final ZoneId userZone) {
-        // 1. 유저 타임존 기준의 현재 시점 계산
-        ZonedDateTime nowInUserZone = ZonedDateTime.now(userZone);
-        LocalDate today = nowInUserZone.toLocalDate();
-
-        // 2. 미래 날짜 검증
-        if (targetDate.isAfter(today)) {
-            throw new FutureDateNotAllowedException(UserCalendarApiErrorCode.FUTURE_DATE_NOT_ALLOWED);
-        }
-
         return topicFacade.findTopicByDate(userId, targetDate, userZone);
     }
 

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileFacade.java
@@ -92,4 +92,8 @@ public class UserProfileFacade {
     public void decreaseFollowingCountOfFollowers(final long userId) {
         userProfileUpdater.decreaseFollowingCountOfFollowers(userId);
     }
+
+    public void syncStreak(final long userId, final ZoneId userZone) {
+        userProfileUpdater.syncStreak(userId, userZone);
+    }
 }

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileUpdater.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileUpdater.java
@@ -40,6 +40,9 @@ public class UserProfileUpdater {
      * 일기를 쓴 순간에 호출 (streak 업데이트)
      */
     public void updateStreakOnWrite(UserProfile profile, LocalDate writtenDate, ZoneId userZone) {
+        // 일기 작성 시 타임존 변경된 경우 저장
+        profile.getUser().updatePrimaryTimezone(userZone.getId());
+
         // 전달받은 유저의 로컬 타임존
         LocalDate today     = LocalDate.now(userZone); // D
         LocalDate yesterday = today.minusDays(1); // 어제
@@ -151,15 +154,21 @@ public class UserProfileUpdater {
             WriteStatus y   = userCalendarFacade.getStatus(profile.getUser(), yesterday);
             WriteStatus dby = userCalendarFacade.getStatus(profile.getUser(), dayBeforeYesterday);
 
-            // 어제와 그제 모두 작성하지 않은 경우 스트릭 초기화
-            if (dby != WriteStatus.WRITTEN && y != WriteStatus.WRITTEN) {
-                profile.updateStreak(0);
+            // 48시간 유예기간이 끝나는 그저께가 기준
+            if (dby != WriteStatus.WRITTEN) {
+                // 그저께 작성하지 않은 경우 - 오늘부터 이어지는 미래 일기 탐색
+                int forwardStreak = calculateForwardStreakFromDate(profile.getUser(), today);
+
+                // 어제 작성하지 않은 경우
+                if (y != WriteStatus.WRITTEN) {
+                    // 오늘부터 이어지는 미래 일기만 남음
+                    profile.updateStreak(forwardStreak);
+                } else {
+                    // 어제는 씀 - 어제 + 오늘부터 이어지는 미래 일기
+                    profile.updateStreak(1 + forwardStreak);
+                }
             }
-            // (15일 X, 16일 O) -> 어제 작성했으므로 스트릭 1 (이 케이스는 updateStreakOnWrite에서 처리되나 안전하게 처리)
-            else if (dby != WriteStatus.WRITTEN) {
-                profile.updateStreak(1);
-            }
-            // 그 외 (연속 작성 중) -> 기존 스트릭 유지
+            // 그 외 (dby == WRITTEN) -> 유예기간이 아직 남아있거나 잘 쓰고 있는 상태. 기존 스트릭 안전하게 유지
         }
     }
 
@@ -167,7 +176,6 @@ public class UserProfileUpdater {
         long cnt = userCalendarFacade.countWritten(profile.getUser().getId());
         profile.updateTotalDiaries((int) cnt);
     }
-
 
     @Transactional
     public int updateProfileImgByUserId(final long userId, final String newImgUrl, final LocalDateTime updatedAt) {

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileUpdater.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileUpdater.java
@@ -6,6 +6,7 @@ import org.sopt.usercalendar.domain.WriteStatus;
 import org.sopt.usercalendar.facade.UserCalendarFacade;
 import org.sopt.userprofile.domain.UserProfile;
 import org.sopt.userprofile.repository.UserProfileRepository;
+import org.springframework.cglib.core.Local;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,33 +42,38 @@ public class UserProfileUpdater {
     public void updateStreakOnWrite(UserProfile profile, LocalDate writtenDate, ZoneId userZone) {
         // 전달받은 유저의 로컬 타임존
         LocalDate today     = LocalDate.now(userZone); // D
-        LocalDate yesterday = today.minusDays(1); // Y
-        LocalDate dayBeforeYesterday = today.minusDays(2);
+        LocalDate yesterday = today.minusDays(1); // 어제
+        LocalDate dayBeforeYesterday = today.minusDays(2); // 그저께
+        LocalDate tomorrow = today.plusDays(1); // 내일
 
         // 캘린더 사실값 조회
         WriteStatus yStatus = userCalendarFacade.getStatus(profile.getUser(), yesterday);
-        WriteStatus dStatus = userCalendarFacade.getStatus(profile.getUser(), today);
 
         int newStreak = profile.getStreak();
+        int forwardStreakFromTomorrow = calculateForwardStreakFromDate(profile.getUser(), tomorrow);
 
         if (writtenDate.equals(today)) {
             if (yStatus == WriteStatus.WRITTEN) {
                 // 어제부터의 연속을 사실값으로 재계산 후 +오늘
                 int base = calculateStreakFromDate(profile.getUser(), yesterday);
-                newStreak = base + 1;
+                newStreak = base + 1 + forwardStreakFromTomorrow;
             } else { // 어제 일기가 없는 경우
                 WriteStatus dbyStatus = userCalendarFacade.getStatus(profile.getUser(), dayBeforeYesterday);
                 if (dbyStatus == WriteStatus.WRITTEN) { // 그저께 일기가 있는 경우
                     newStreak = calculateStreakFromDate(profile.getUser(), dayBeforeYesterday) ;
                 } else {
                     // (NONE 또는 DELETED) → 오늘 단독은 즉시 1
-                    newStreak = 1;
+                    newStreak = 1 + forwardStreakFromTomorrow;
                 }
             }
-        } else if (writtenDate.equals(yesterday)) { // 어제 일기를 보충한 경우
-            // 어제부터의 연속을 사실값으로 재계산
-            int base = calculateStreakFromDate(profile.getUser(), yesterday);
-            newStreak = base + (dStatus == WriteStatus.WRITTEN ? 1 : 0); // 오늘 일기 작성되어 있다면 추가로 +1
+        } else { // today가 아닌 과거의 어떤 날짜를 보충한 경우
+            // 어제부터의 과거
+            int pastStreak = calculateStreakFromDate(profile.getUser(), writtenDate.minusDays(1));
+
+            // 오늘부터 미래
+            int forwardStreakFromToday = calculateForwardStreakFromDate(profile.getUser(), writtenDate.plusDays(1));
+
+            newStreak = pastStreak + 1 + forwardStreakFromToday;
         }
         // 그 외 날짜는 변화 없음
 
@@ -82,6 +88,17 @@ public class UserProfileUpdater {
         while (userCalendarFacade.getStatus(user, cur) == WriteStatus.WRITTEN) {
             streak++;
             cur = cur.minusDays(1);
+        }
+        return streak;
+    }
+
+    // 특정 날짜부터 미래로 연속 작성 일수를 계산하는 헬퍼 메서드
+    private int calculateForwardStreakFromDate(User user, LocalDate startDate) {
+        int streak = 0;
+        LocalDate cur = startDate;
+        while (userCalendarFacade.getStatus(user, cur) == WriteStatus.WRITTEN) {
+            streak++;
+            cur = cur.plusDays(1);
         }
         return streak;
     }

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileUpdater.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileUpdater.java
@@ -178,6 +178,48 @@ public class UserProfileUpdater {
     }
 
     @Transactional
+    public void syncStreak(final long userId, ZoneId userZone) {
+        UserProfile profile = userProfileRetriever.findByUserId(userId);
+        profile.getUser().updatePrimaryTimezone(userZone.getId());
+
+        LocalDate today = LocalDate.now(userZone);
+        LocalDate yesterday = today.minusDays(1);
+        LocalDate dayBeforeYesterday = today.minusDays(2);
+        LocalDate tomorrow = today.plusDays(1);
+
+        WriteStatus dStatus = userCalendarFacade.getStatus(profile.getUser(), today);
+        WriteStatus yStatus = userCalendarFacade.getStatus(profile.getUser(), yesterday);
+        WriteStatus dbyStatus = userCalendarFacade.getStatus(profile.getUser(), dayBeforeYesterday);
+
+        int newStreak;
+
+        if (dStatus == WriteStatus.WRITTEN) { // 오늘 일기 쓴 경우
+            if (yStatus == WriteStatus.WRITTEN) { // 오늘 + 어제 쓴 경우
+                // 오늘O, 어제O -> 과거부터 오늘을 거쳐 내일까지의 모든 연속 합체
+                newStreak = calculateStreakFromDate(profile.getUser(), yesterday) + 1 + calculateForwardStreakFromDate(profile.getUser(), tomorrow);
+            } else if (dbyStatus == WriteStatus.WRITTEN) { // 오늘 + 그저께 쓴 경우 - 스트릭 유지
+                newStreak = calculateStreakFromDate(profile.getUser(), dayBeforeYesterday);
+            } else { // 오늘만 쓴 경우 - 새로 시작 + 내일 연결
+                newStreak = 1 + calculateForwardStreakFromDate(profile.getUser(), tomorrow);
+            }
+        } else if (yStatus == WriteStatus.WRITTEN) {
+            // 오늘X, 어제O - 어제까지의 연속성 유지
+            newStreak = calculateStreakFromDate(profile.getUser(), yesterday);
+        } else if (dbyStatus == WriteStatus.WRITTEN) {
+            // 오늘X, 어제X, 그저께O - 스트릭 유지
+            newStreak = calculateStreakFromDate(profile.getUser(), dayBeforeYesterday);
+        } else {
+            // 다 끊긴 경우 - 미래 체크
+            newStreak = calculateForwardStreakFromDate(profile.getUser(), tomorrow);
+        }
+
+        profile.updateStreak(newStreak);
+        resyncTotal(profile);
+        userProfileRepository.save(profile);
+    }
+
+
+    @Transactional
     public int updateProfileImgByUserId(final long userId, final String newImgUrl, final LocalDateTime updatedAt) {
         return userProfileRepository.updateProfileImgByUserId(userId, newImgUrl, updatedAt);
     }


### PR DESCRIPTION
## Related issue 🛠
- closed #365 

## Work Description ✏️
- 일기 주제 조회 API: 미래 일기 주제 조회 가능하도록 예외처리 삭제
- 기기 시간의 수동조작을 고려해 다음날 streak까지 고려하도록 수정
- 기본 정보 조회 API에서 헤더의 타임존 변경된 경우 streak 재계산해서 내려주도록 수정

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 작성되지 않은 일기 주제 조회 API(미래 날짜 조회) | <img width="1053" height="1165" alt="image" src="https://github.com/user-attachments/assets/657f7c3c-bcc9-4aa3-8e9c-7bec4aee0a27" /> |

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A