### PR TITLE
[fix] #367 회원탈퇴 오류 해결 및 작성한 미래 일기 조회 가능하도록 수정

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/usercalendar/service/UserCalendarService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/usercalendar/service/UserCalendarService.java
@@ -28,20 +28,11 @@ public class UserCalendarService {
     private final S3Service s3Service;
 
     public UserCalendarDiarySummaryRes getDiarySummary(final LocalDate date, final Long userId) {
-        validateNotFuture(date);
-
         final Diary diary = userCalendarFacade.findDiaryByDate(userId, date);
         final String diaryImgUrl = s3Service.toPublicUrl(diary.getImageUrl());
         return UserCalendarDiarySummaryRes.of(diary, diaryImgUrl);
 
     }
-
-    public static void validateNotFuture(LocalDate date) {
-        if (date.isAfter(LocalDate.now())) {
-            throw new FutureDateNotAllowedException(UserCalendarApiErrorCode.FUTURE_DATE_NOT_ALLOWED);
-        }
-    }
-
     public UserCalendarTopicRes getTopicByDate(final long userId, final LocalDate targetDate, final ZoneId userZone) {
         return topicFacade.findTopicByDate(userId, targetDate, userZone);
     }

--- a/hilingual-api/src/main/resources/db/migration/V9__update_liked_diary_cascade.sql
+++ b/hilingual-api/src/main/resources/db/migration/V9__update_liked_diary_cascade.sql
@@ -1,0 +1,15 @@
+ALTER TABLE liked_diary DROP CONSTRAINT liked_diary_diary_id_fkey;
+
+ALTER TABLE liked_diary
+    ADD CONSTRAINT liked_diary_diary_id_fkey
+    FOREIGN KEY (diary_id)
+    REFERENCES diary(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE liked_diary DROP CONSTRAINT liked_diary_user_id_fkey;
+
+ALTER TABLE liked_diary
+    ADD CONSTRAINT liked_diary_user_id_fkey
+    FOREIGN KEY (user_id)
+    REFERENCES users(id)
+    ON DELETE CASCADE;

--- a/hilingual-domain/src/main/java/org/sopt/likeddiary/domain/LikedDiary.java
+++ b/hilingual-domain/src/main/java/org/sopt/likeddiary/domain/LikedDiary.java
@@ -5,6 +5,8 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.sopt.common.config.BaseTimeEntity;
 import org.sopt.diary.domain.Diary;
 import org.sopt.user.domain.User;
@@ -33,10 +35,12 @@ public class LikedDiary extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = COLUMN_USER_ID, nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = COLUMN_DIARY_ID, nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Diary diary;
 
     public static LikedDiary create(User user, Diary diary) {


### PR DESCRIPTION
## Related issue 🛠
- closed #367 

## Work Description ✏️
- 회원탈퇴 오류 해결
- 작성한 미래 일기 조회 가능하도록 수정

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 탈퇴 | <img width="1200" height="1043" alt="image" src="https://github.com/user-attachments/assets/3c11c954-9454-4887-b4e7-ef9019404f26" /> |
| 미래 일기 조회 | <img width="1170" height="1144" alt="image" src="https://github.com/user-attachments/assets/98526de3-efa8-4028-9d28-10055474e6a6" /> |

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A