### PR TITLE
[hotfix] #372 iOS 심사용 소셜로그인 및 디바이스API 규정 완화

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/auth/dto/SocialLoginReq.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/auth/dto/SocialLoginReq.java
@@ -7,6 +7,8 @@ import org.sopt.jwt.auth.domain.type.AuthProvider;
 import org.sopt.jwt.auth.domain.type.DeviceType;
 import org.springframework.util.StringUtils;
 
+import java.util.UUID;
+
 public record SocialLoginReq(
         @NotNull AuthProvider provider,
         @NotNull UserRole role,
@@ -25,6 +27,10 @@ public record SocialLoginReq(
         String appVersion
 ) {
     public boolean hasValidDeviceIdentifier() {
+        if (this.provider == AuthProvider.APPLE) {
+            return true;
+        }
+
         return StringUtils.hasText(this.deviceUuid) || StringUtils.hasText(this.deviceName);
     }
 
@@ -34,9 +40,14 @@ public record SocialLoginReq(
             targetDeviceType = org.sopt.device.domain.type.DeviceType.valueOf(this.deviceType.name());
         }
 
+        // TODO 심사 이후 삭제(26.05.03)
+        String finalDeviceUuid = StringUtils.hasText(this.deviceUuid)
+                ? this.deviceUuid
+                : UUID.randomUUID().toString();
+
         return new DeviceInfo(
                 null,
-                this.deviceUuid,
+                finalDeviceUuid,
                 this.deviceName,
                 targetDeviceType,
                 this.osType,

--- a/hilingual-api/src/main/java/org/sopt/controller/auth/service/AuthService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/auth/service/AuthService.java
@@ -178,10 +178,15 @@ public class AuthService {
             user = userFacade.save(user);
         }
 
-        if(StringUtils.hasText(req.deviceUuid())) {
+        // TODO 심사 이후 삭제(26.05.03)
+        if(StringUtils.hasText(req.deviceUuid()) || req.provider().equals(AuthProvider.APPLE)) {
             DeviceInfo deviceInfo = req.toDeviceInfo();
             deviceFacade.upsertDevice(user.getId(), deviceInfo);
         }
+//        if(StringUtils.hasText(req.deviceUuid())) {
+//            DeviceInfo deviceInfo = req.toDeviceInfo();
+//            deviceFacade.upsertDevice(user.getId(), deviceInfo);
+//        }
 
         return tokenService.issueToken(req, user.getId(), user.getRegisterStatus());
     }

--- a/hilingual-api/src/main/java/org/sopt/controller/device/api/DeviceController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/device/api/DeviceController.java
@@ -5,6 +5,9 @@ import org.sopt.annotation.UserTimezone;
 import org.sopt.controller.device.dto.DeviceReq;
 import org.sopt.controller.device.service.DeviceService;
 import org.sopt.jwt.annotation.UserId;
+import org.sopt.jwt.auth.domain.type.AuthProvider;
+import org.sopt.user.domain.User;
+import org.sopt.user.facade.UserFacade;
 import org.sopt.web.UserZone;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -20,12 +23,22 @@ import java.time.ZoneId;
 public class DeviceController {
     private final DeviceService deviceService;
 
+    // TODO 삭제 (2026.05.03)
+    private final UserFacade userFacade;
+
     @PutMapping("")
     public ResponseEntity<Void> putDeviceInfo(
             @UserId Long userId,
             @UserTimezone UserZone userZone,
             @RequestBody DeviceReq req
             ) {
+
+        // TODO 삭제 (2026.05.03)
+        User user = userFacade.getUserById(userId);
+        if(user.getProvider().equals("APPLE")) {
+            return ResponseEntity.ok().build();
+        }
+
         deviceService.updateDeviceInfo(userId, req, userZone.zoneId());
         return ResponseEntity.ok().build();
     }


### PR DESCRIPTION
## Related issue 🛠
- closed #372 

## Work Description ✏️
- device id nullable하게
- 애플 유저의 경우 device api가 항상 성공하도록

## Screenshot 📸
N/A

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A