### PR TITLE
[hotfix] #374 iOS 심사용 소셜로그인 및 디바이스API 규정 완화 해제

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/auth/dto/SocialLoginReq.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/auth/dto/SocialLoginReq.java
@@ -40,14 +40,9 @@ public record SocialLoginReq(
             targetDeviceType = org.sopt.device.domain.type.DeviceType.valueOf(this.deviceType.name());
         }
 
-        // TODO 심사 이후 삭제(26.05.03)
-        String finalDeviceUuid = StringUtils.hasText(this.deviceUuid)
-                ? this.deviceUuid
-                : UUID.randomUUID().toString();
-
         return new DeviceInfo(
                 null,
-                finalDeviceUuid,
+                this.deviceUuid,
                 this.deviceName,
                 targetDeviceType,
                 this.osType,

--- a/hilingual-api/src/main/java/org/sopt/controller/auth/service/AuthService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/auth/service/AuthService.java
@@ -178,15 +178,10 @@ public class AuthService {
             user = userFacade.save(user);
         }
 
-        // TODO 심사 이후 삭제(26.05.03)
-        if(StringUtils.hasText(req.deviceUuid()) || req.provider().equals(AuthProvider.APPLE)) {
+        if(StringUtils.hasText(req.deviceUuid())) {
             DeviceInfo deviceInfo = req.toDeviceInfo();
             deviceFacade.upsertDevice(user.getId(), deviceInfo);
         }
-//        if(StringUtils.hasText(req.deviceUuid())) {
-//            DeviceInfo deviceInfo = req.toDeviceInfo();
-//            deviceFacade.upsertDevice(user.getId(), deviceInfo);
-//        }
 
         return tokenService.issueToken(req, user.getId(), user.getRegisterStatus());
     }

--- a/hilingual-api/src/main/java/org/sopt/controller/device/api/DeviceController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/device/api/DeviceController.java
@@ -23,22 +23,12 @@ import java.time.ZoneId;
 public class DeviceController {
     private final DeviceService deviceService;
 
-    // TODO 삭제 (2026.05.03)
-    private final UserFacade userFacade;
-
     @PutMapping("")
     public ResponseEntity<Void> putDeviceInfo(
             @UserId Long userId,
             @UserTimezone UserZone userZone,
             @RequestBody DeviceReq req
             ) {
-
-        // TODO 삭제 (2026.05.03)
-        User user = userFacade.getUserById(userId);
-        if(user.getProvider().equals("APPLE")) {
-            return ResponseEntity.ok().build();
-        }
-
         deviceService.updateDeviceInfo(userId, req, userZone.zoneId());
         return ResponseEntity.ok().build();
     }


### PR DESCRIPTION
## Related issue 🛠
- closed #374  

## Work Description ✏️
- device id nullable하게 했던 것 수정
- 애플 유저의 경우 device api가 항상 성공하도록 했던 것 수정

## Screenshot 📸
N/A

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A