### PR TITLE
[fix] #377 사용자 검색 API에서 사용자 프로필 이미지 null로 내려가는 오류 해결

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/feed/service/FeedService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/feed/service/FeedService.java
@@ -179,7 +179,10 @@ public class FeedService {
         List<UserListRes.SearchUser> searchUserList = userList.stream()
                 .map(projection -> {
                     String originalImgUrl = projection.profileImg();
-                    String publicImgUrl = (originalImgUrl != null) ? s3Service.toPublicUrl(originalImgUrl) : " ";
+
+                    String publicImgUrl = (originalImgUrl != null && !originalImgUrl.trim().isEmpty())
+                            ? s3Service.toPublicUrl(originalImgUrl)
+                            : " ";
 
                     return new UserListRes.SearchUser(
                             projection.userId(),


### PR DESCRIPTION
## Related issue 🛠
- closed #377 

## Work Description ✏️
- 사용자 검색 API에서 사용자 프로필 이미지 null로 내려가는 오류 해결

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 사용자 검색 API | <img width="1261" height="1010" alt="image" src="https://github.com/user-attachments/assets/a0693ed2-86b0-471a-a034-98a81575bceb" /> |

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A