### PR TITLE
[feat] #380 FCM 푸시 알림 딥링크 페이로드 적용

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/feed/service/FeedService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/feed/service/FeedService.java
@@ -24,6 +24,7 @@ import org.sopt.user.domain.User;
 import org.sopt.user.facade.UserFacade;
 import org.sopt.userprofile.domain.UserProfile;
 import org.sopt.userprofile.dto.UserSearchDto;
+import org.sopt.controller.notification.service.FcmNotificationService;
 import org.sopt.userprofile.facade.UserProfileFacade;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -32,6 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.stream.Collectors;
 import java.util.HashSet;
 import java.util.List;
@@ -53,6 +55,7 @@ public class FeedService {
     private final S3Service s3Service;
     private final FeedAlarmFacade feedAlarmFacade;
     private final AlarmPreferenceFacade alarmPreferenceFacade;
+    private final FcmNotificationService fcmNotificationService;
 
     @Transactional(readOnly = true)
     public FeedProfileRes getFeedProfile(Long userId, Long targetUserId) {
@@ -321,6 +324,9 @@ public class FeedService {
             if (alarmPreferenceFacade.isEnabled(diary.getUser().getId(), AlarmType.FEED)) {
                 // 같은 다이어리/같은 액터의 중복 알림 방지 로직은 Facade 내부에서 처리
                 feedAlarmFacade.createLikeDiaryAlarm(diary, user);
+                String dateStr = diary.getWrittenDate().format(DateTimeFormatter.ofPattern("M월 d일"));
+                String body = user.getUserProfile().getNickname() + "님이 당신의 " + dateStr + " 일기에 공감했습니다.";
+                fcmNotificationService.sendLikeNotification(diary.getUser().getId(), diary.getId(), body);
             }
             return LikeToggleRes.of(true);
         }

--- a/hilingual-api/src/main/java/org/sopt/controller/follow/service/FollowService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/follow/service/FollowService.java
@@ -11,6 +11,7 @@ import org.sopt.controller.follow.dto.NewFollowInfoRes;
 
 import org.sopt.controller.follow.exception.FollowApiErrorCode;
 import org.sopt.controller.follow.exception.SelfFollowNotAllowedException;
+import org.sopt.controller.notification.service.FcmNotificationService;
 
 import org.sopt.controller.follow.dto.FollowerListRes;
 import org.sopt.controller.follow.dto.FollowingListRes;
@@ -45,6 +46,7 @@ public class FollowService {
     private final FeedAlarmFacade feedAlarmFacade;
     private final AlarmPreferenceFacade alarmPreferenceFacade;
     private final S3Service s3Service;
+    private final FcmNotificationService fcmNotificationService;
 
     @Transactional
     public void follow(Long userId, Long targetUserId) {
@@ -67,6 +69,8 @@ public class FollowService {
 
         if (alarmPreferenceFacade.isEnabled(followee.getId(), AlarmType.FEED)) {
             feedAlarmFacade.createFollowAlarm(followee, follower);
+            String body = follower.getUserProfile().getNickname() + "님이 당신을 팔로우했습니다.";
+            fcmNotificationService.sendFollowNotification(followee.getId(), follower.getId(), body);
         }
     }
 

--- a/hilingual-api/src/main/java/org/sopt/controller/notification/service/FcmNotificationService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/notification/service/FcmNotificationService.java
@@ -1,0 +1,73 @@
+package org.sopt.controller.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.device.domain.Device;
+import org.sopt.device.facade.DeviceFacade;
+import org.sopt.firebase.FCMClient;
+import org.sopt.firebase.dto.FCMMessageRequest;
+import org.sopt.firebase.exception.FCMException;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FcmNotificationService {
+
+    private static final String APP_NAME = "하이링구얼";
+    private static final String DEEP_LINK_KEY = "link";
+    private static final String DIARY_DETAIL_LINK = "hilingual://app/home/diarydetail?diaryId=%d";
+    private static final String FEED_PROFILE_LINK = "hilingual://app/home/feedprofile?userId=%d";
+
+    private final DeviceFacade deviceFacade;
+    private final Optional<FCMClient> fcmClient;
+
+    public void sendLikeNotification(Long targetUserId, Long diaryId, String body) {
+        String deepLink = String.format(DIARY_DETAIL_LINK, diaryId);
+        sendToAllDevices(targetUserId, body, deepLink);
+    }
+
+    public void sendFollowNotification(Long targetUserId, Long actorUserId, String body) {
+        String deepLink = String.format(FEED_PROFILE_LINK, actorUserId);
+        sendToAllDevices(targetUserId, body, deepLink);
+    }
+
+    private void sendToAllDevices(Long userId, String body, String deepLink) {
+        if (fcmClient.isEmpty()) {
+            log.debug("FCMClient 비활성화 상태 - 푸시 알림 미발송");
+            return;
+        }
+
+        List<Device> devices = deviceFacade.findAllByUserId(userId);
+        for (Device device : devices) {
+            if (!StringUtils.hasText(device.getFcmToken())) {
+                continue;
+            }
+            send(userId, device, body, deepLink);
+        }
+    }
+
+    private void send(Long userId, Device device, String body, String deepLink) {
+        try {
+            FCMMessageRequest request = FCMMessageRequest.of(
+                    device.getFcmToken(),
+                    APP_NAME,
+                    body,
+                    Map.of(DEEP_LINK_KEY, deepLink)
+            );
+            fcmClient.get().send(request);
+        } catch (FCMException e) {
+            if (e.isInvalidToken()) {
+                deviceFacade.clearFcmToken(userId, device.getDeviceId());
+                log.warn("FCM 만료 토큰 clear: deviceId={}", device.getDeviceId());
+            } else {
+                log.error("FCM 발송 실패: deviceId={}", device.getDeviceId(), e);
+            }
+        }
+    }
+}

--- a/hilingual-api/src/test/java/org/sopt/controller/notification/service/FcmNotificationServiceTest.java
+++ b/hilingual-api/src/test/java/org/sopt/controller/notification/service/FcmNotificationServiceTest.java
@@ -1,0 +1,167 @@
+package org.sopt.controller.notification.service;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.device.domain.Device;
+import org.sopt.device.facade.DeviceFacade;
+import org.sopt.firebase.FCMClient;
+import org.sopt.firebase.dto.FCMMessageRequest;
+import org.sopt.firebase.exception.FCMErrorCode;
+import org.sopt.firebase.exception.FCMException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FcmNotificationServiceTest {
+
+    @Mock
+    private DeviceFacade deviceFacade;
+
+    @Mock
+    private FCMClient fcmClient;
+
+    private FcmNotificationService fcmNotificationService;
+
+    private static final Long TARGET_USER_ID = 1L;
+    private static final Long DIARY_ID = 100L;
+    private static final Long ACTOR_USER_ID = 2L;
+
+    @BeforeEach
+    void setUp() {
+        fcmNotificationService = new FcmNotificationService(deviceFacade, Optional.of(fcmClient));
+    }
+
+    // ─── FCMClient 비활성 ────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("FCMClient 비활성 상태이면 디바이스 조회도 하지 않고 종료된다")
+    void sendLikeNotification_whenFcmClientAbsent_doesNothing() {
+        FcmNotificationService disabledService =
+                new FcmNotificationService(deviceFacade, Optional.empty());
+
+        disabledService.sendLikeNotification(TARGET_USER_ID, DIARY_ID, "알림 내용");
+
+        verifyNoInteractions(deviceFacade);
+        verifyNoInteractions(fcmClient);
+    }
+
+    // ─── 토큰 null / blank 스킵 ──────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("FCM 토큰이 null인 디바이스는 발송 건너뜀")
+    void sendLikeNotification_whenTokenIsNull_skipsDevice() {
+        Device device = mock(Device.class);
+        when(device.getFcmToken()).thenReturn(null);
+        when(deviceFacade.findAllByUserId(TARGET_USER_ID)).thenReturn(List.of(device));
+
+        fcmNotificationService.sendLikeNotification(TARGET_USER_ID, DIARY_ID, "알림 내용");
+
+        verifyNoInteractions(fcmClient);
+    }
+
+    @Test
+    @DisplayName("FCM 토큰이 빈 문자열인 디바이스는 발송 건너뜀")
+    void sendLikeNotification_whenTokenIsBlank_skipsDevice() {
+        Device device = mock(Device.class);
+        when(device.getFcmToken()).thenReturn("   ");
+        when(deviceFacade.findAllByUserId(TARGET_USER_ID)).thenReturn(List.of(device));
+
+        fcmNotificationService.sendLikeNotification(TARGET_USER_ID, DIARY_ID, "알림 내용");
+
+        verifyNoInteractions(fcmClient);
+    }
+
+    // ─── 딥링크 포함 검증 ────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("좋아요 알림 발송 시 diaryId 딥링크가 data.link에 포함된다")
+    void sendLikeNotification_sendsWithDiaryDeepLink() {
+        Device device = mock(Device.class);
+        when(device.getFcmToken()).thenReturn("valid-token-123456");
+        when(deviceFacade.findAllByUserId(TARGET_USER_ID)).thenReturn(List.of(device));
+
+        fcmNotificationService.sendLikeNotification(TARGET_USER_ID, DIARY_ID, "OOO님이 공감했습니다.");
+
+        verify(fcmClient).send(argThat(req ->
+                "hilingual://app/home/diarydetail?diaryId=100"
+                        .equals(req.data().get("link"))
+        ));
+    }
+
+    @Test
+    @DisplayName("팔로우 알림 발송 시 actorUserId 딥링크가 data.link에 포함된다")
+    void sendFollowNotification_sendsWithFeedProfileDeepLink() {
+        Device device = mock(Device.class);
+        when(device.getFcmToken()).thenReturn("valid-token-123456");
+        when(deviceFacade.findAllByUserId(TARGET_USER_ID)).thenReturn(List.of(device));
+
+        fcmNotificationService.sendFollowNotification(TARGET_USER_ID, ACTOR_USER_ID, "OOO님이 팔로우했습니다.");
+
+        verify(fcmClient).send(argThat(req ->
+                "hilingual://app/home/feedprofile?userId=2"
+                        .equals(req.data().get("link"))
+        ));
+    }
+
+    // ─── 토큰 만료 처리 ──────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("INVALID_TOKEN 예외 발생 시 해당 디바이스 토큰을 clear한다")
+    void sendLikeNotification_whenInvalidToken_clearsToken() {
+        Device device = mock(Device.class);
+        when(device.getFcmToken()).thenReturn("expired-token-123456");
+        when(device.getDeviceId()).thenReturn(99L);
+        when(deviceFacade.findAllByUserId(TARGET_USER_ID)).thenReturn(List.of(device));
+        doThrow(new FCMException(FCMErrorCode.FCM_INVALID_TOKEN))
+                .when(fcmClient).send(any(FCMMessageRequest.class));
+
+        fcmNotificationService.sendLikeNotification(TARGET_USER_ID, DIARY_ID, "알림 내용");
+
+        verify(deviceFacade).clearFcmToken(TARGET_USER_ID, 99L);
+    }
+
+    // ─── 발송 실패 시 예외 전파 차단 ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("FCM 발송 실패(FCM_SEND_FAILED) 시 예외가 상위로 전파되지 않는다")
+    void sendLikeNotification_whenSendFailed_doesNotPropagate() {
+        Device device = mock(Device.class);
+        when(device.getFcmToken()).thenReturn("valid-token-123456");
+        when(deviceFacade.findAllByUserId(TARGET_USER_ID)).thenReturn(List.of(device));
+        doThrow(new FCMException(FCMErrorCode.FCM_SEND_FAILED))
+                .when(fcmClient).send(any(FCMMessageRequest.class));
+
+        Assertions.assertThatCode(
+                () -> fcmNotificationService.sendLikeNotification(TARGET_USER_ID, DIARY_ID, "알림 내용")
+        ).doesNotThrowAnyException();
+    }
+
+    // ─── 멀티 디바이스 ──────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("토큰이 있는 디바이스에만 발송되고, 없는 디바이스는 건너뛴다")
+    void sendLikeNotification_multipleDevices_sendsOnlyToTokenOwners() {
+        Device device1 = mock(Device.class);
+        Device device2 = mock(Device.class);
+        Device deviceNoToken = mock(Device.class);
+        when(device1.getFcmToken()).thenReturn("token-device-1-aaa");
+        when(device2.getFcmToken()).thenReturn("token-device-2-bbb");
+        when(deviceNoToken.getFcmToken()).thenReturn(null);
+        when(deviceFacade.findAllByUserId(TARGET_USER_ID))
+                .thenReturn(List.of(device1, deviceNoToken, device2));
+
+        fcmNotificationService.sendLikeNotification(TARGET_USER_ID, DIARY_ID, "알림 내용");
+
+        verify(fcmClient, times(2)).send(any(FCMMessageRequest.class));
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
  - closed #380 

  ## Work Description ✏️
  - `FcmNotificationService` 구현 (`hilingual-api`)
    - 알림 타입별 딥링크 URL 생성 및 `data.link` 필드에 포함
    - 유저의 전체 디바이스에 FCM 발송 (멀티 디바이스 대응)
    - FCM 토큰 null인 디바이스 건너뜀
    - `INVALID_TOKEN` 예외 발생 시 해당 디바이스 토큰 자동 clear
    - `firebase.enabled=false` 환경에서 graceful skip (`Optional<FCMClient>`)
  - 팔로우 알림 FCM 발송 연결 (`FollowService`)
    - 딥링크: `hilingual://app/home/feedprofile?userId={actorId}`
  - 좋아요 알림 FCM 발송 연결 (`FeedService`)
    - 딥링크: `hilingual://app/home/diarydetail?diaryId={diaryId}`
  - `FcmNotificationService` 단위 테스트 추가 (8개)

  ## Screenshot 📸
  N/A

  ## Uncompleted Tasks 😅
  N/A

  ## To Reviewers 📢
  - FCM 발송이 `@Transactional` 내부에서 실행되므로, DB 롤백 시에도 이미 발송된 푸시는 취소되지 않습니다. MVP 범위에서 허용 가능한 수준으로 판단했습니다.
  - `firebase.enabled=false`인 로컬 환경에서는 FCM 발송 없이 정상 동작합니다.