### PR TITLE
[feat] #382 닉네임 변경 API 구현

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/auth/service/AuthService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/auth/service/AuthService.java
@@ -52,14 +52,9 @@ public class AuthService {
 
     private final TokenService tokenService;
     private final UserFacade userFacade;
-    private final UserCalendarFacade userCalendarFacade;
     private final DiaryFacade diaryFacade;
     private final LikedDiaryFacade likedDiaryFacade;
-    private final FeedAlarmFacade feedAlarmFacade;
-    private final BlockFacade blockFacade;
-    private final FollowFacade followFacade;
     private final AlarmPreferenceFacade alarmPreferenceFacade;
-    private final VocaFacade vocaFacade;
     private final UserProfileFacade userProfileFacade;
     private final DeviceFacade deviceFacade;
 

--- a/hilingual-api/src/main/java/org/sopt/controller/userprofile/api/UserProfileController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/userprofile/api/UserProfileController.java
@@ -43,7 +43,7 @@ public class UserProfileController {
     /*
      * 닉네임 변경
      */
-    @PostMapping("/profile/nickname")
+    @PatchMapping("/profile/nickname")
     public BaseResponseDto<UserNicknameRes> changeUserNickname(
             @UserId Long userId,
             @RequestBody @NotNull UserNicknameReq userNicknameReq

--- a/hilingual-api/src/main/java/org/sopt/controller/userprofile/api/UserProfileController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/userprofile/api/UserProfileController.java
@@ -2,8 +2,9 @@ package org.sopt.controller.userprofile.api;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
-import org.sopt.controller.discord.service.WebhookService;
 import org.sopt.controller.user.dto.NicknameAvailableRes;
+import org.sopt.controller.userprofile.dto.UserNicknameReq;
+import org.sopt.controller.userprofile.dto.UserNicknameRes;
 import org.sopt.controller.userprofile.dto.UserProfileImgReq;
 import org.sopt.controller.userprofile.dto.UserProfileReq;
 import org.sopt.dto.BaseResponseDto;
@@ -39,6 +40,20 @@ public class UserProfileController {
         return ResponseEntity.ok(GlobalSuccessCode.OK);
     }
 
+    /*
+     * 닉네임 변경
+     */
+    @PostMapping("/profile/nickname")
+    public BaseResponseDto<UserNicknameRes> changeUserNickname(
+            @UserId Long userId,
+            @RequestBody @NotNull UserNicknameReq userNicknameReq
+    ) {
+        return userProfileService.changeUserNickname(userId, userNicknameReq);
+    }
+
+    /*
+     * 프로필 이미지 변경
+     */
     @PatchMapping("/mypage/profileImg")
     public ResponseEntity<Void> changeUserProfileImg(
             @UserId Long userId,

--- a/hilingual-api/src/main/java/org/sopt/controller/userprofile/dto/UserNicknameReq.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/userprofile/dto/UserNicknameReq.java
@@ -1,0 +1,7 @@
+package org.sopt.controller.userprofile.dto;
+
+import lombok.NonNull;
+
+public record UserNicknameReq(
+        @NonNull String nickname
+){}

--- a/hilingual-api/src/main/java/org/sopt/controller/userprofile/dto/UserNicknameRes.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/userprofile/dto/UserNicknameRes.java
@@ -1,0 +1,5 @@
+package org.sopt.controller.userprofile.dto;
+
+public record UserNicknameRes(
+        String nickname
+){ }

--- a/hilingual-api/src/main/java/org/sopt/controller/userprofile/exception/UserProfileApiErrorCode.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/userprofile/exception/UserProfileApiErrorCode.java
@@ -7,7 +7,6 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum UserProfileApiErrorCode implements ErrorCode {
     IMAGE_PURPOSE_INVALID(HttpStatus.BAD_REQUEST, 40030, "image.purpose 값이 잘못되었습니다.");
-
     public final HttpStatus httpStatus;
     private final int code;
     private final String message;

--- a/hilingual-api/src/main/java/org/sopt/controller/userprofile/exception/UserProfileImagePurposeMismatchException.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/userprofile/exception/UserProfileImagePurposeMismatchException.java
@@ -1,6 +1,5 @@
 package org.sopt.controller.userprofile.exception;
 
-import org.sopt.controller.diary.exception.DiaryApiException;
 import org.sopt.controller.user.exception.UserApiException;
 import org.sopt.exception.code.ErrorCode;
 import org.springframework.http.HttpStatus;

--- a/hilingual-api/src/main/java/org/sopt/controller/userprofile/service/UserProfileService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/userprofile/service/UserProfileService.java
@@ -1,5 +1,6 @@
 package org.sopt.controller.userprofile.service;
 
+import com.fasterxml.jackson.databind.ser.Serializers;
 import lombok.RequiredArgsConstructor;
 import org.sopt.alarmpreference.domain.AlarmPreference;
 import org.sopt.alarmpreference.facade.AlarmPreferenceFacade;
@@ -7,14 +8,17 @@ import org.sopt.alarmpreference.type.AlarmType;
 import org.sopt.aws.s3.dto.Purpose;
 import org.sopt.aws.s3.service.S3Service;
 import org.sopt.controller.discord.service.WebhookService;
+import org.sopt.controller.userprofile.dto.UserNicknameReq;
+import org.sopt.controller.userprofile.dto.UserNicknameRes;
 import org.sopt.controller.userprofile.dto.UserProfileImgReq;
-import org.sopt.aws.s3.service.S3Service;
 import org.sopt.controller.user.dto.NicknameAvailableRes;
 import org.sopt.controller.userprofile.exception.UserProfileSuccessCode;
 import org.sopt.controller.userprofile.dto.UserProfileReq;
 import org.sopt.controller.userprofile.exception.UserProfileApiErrorCode;
 import org.sopt.controller.userprofile.exception.UserProfileImagePurposeMismatchException;
 import org.sopt.dto.BaseResponseDto;
+import org.sopt.exception.code.GlobalSuccessCode;
+import org.sopt.exception.code.SuccessCode;
 import org.sopt.forbiddenword.facade.ForbiddenWordFacade;
 import org.sopt.user.facade.UserFacade;
 import org.sopt.user.domain.User;
@@ -141,5 +145,10 @@ public class UserProfileService {
         }
 
         return null;
+    }
+
+    public BaseResponseDto<UserNicknameRes> changeUserNickname(Long userId, UserNicknameReq userNicknameReq) {
+        String updatedNickname = userProfileFacade.updateUserNickname(userId, userNicknameReq.nickname());
+        return BaseResponseDto.success(GlobalSuccessCode.OK, new UserNicknameRes(updatedNickname));
     }
 }

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/domain/UserProfile.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/domain/UserProfile.java
@@ -66,6 +66,10 @@ public class UserProfile extends BaseTimeEntity {
         this.streak = streak;
     }
 
+    public void updateNickname(final String nickname) {
+        this.nickname = nickname;
+    }
+
     public void increaseFollowingCount() {
         this.followingCount = this.followingCount + 1;
     }

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/exception/InvalidSameNicknameException.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/exception/InvalidSameNicknameException.java
@@ -1,0 +1,16 @@
+package org.sopt.userprofile.exception;
+
+import org.sopt.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class InvalidSameNicknameException extends UserProfileCoreException {
+
+    public InvalidSameNicknameException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/exception/UserProfileCoreErrorCode.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/exception/UserProfileCoreErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 public enum UserProfileCoreErrorCode implements ErrorCode {
 
     USER_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, 40406, "회원 기본 정보가 존재하지 않습니다."),
-    USER_PROFILE_ALREADY_EXIST(HttpStatus.BAD_REQUEST, 40011, "이미 존재하는 프로필 정보입니다.");
+    USER_PROFILE_ALREADY_EXIST(HttpStatus.BAD_REQUEST, 40011, "이미 존재하는 프로필 정보입니다."),
+    INVALID_SAME_NICKNAME(HttpStatus.BAD_REQUEST, 40049, "이전과 같은 닉네임입니다.");
 
     private final HttpStatus httpStatus;
     private final int code;

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileFacade.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileFacade.java
@@ -96,4 +96,8 @@ public class UserProfileFacade {
     public void syncStreak(final long userId, final ZoneId userZone) {
         userProfileUpdater.syncStreak(userId, userZone);
     }
+
+    public String updateUserNickname(final long userId, final String nickname) {
+        return userProfileUpdater.updateNickname(userId, nickname);
+    }
 }

--- a/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileUpdater.java
+++ b/hilingual-domain/src/main/java/org/sopt/userprofile/facade/UserProfileUpdater.java
@@ -5,6 +5,8 @@ import org.sopt.user.domain.User;
 import org.sopt.usercalendar.domain.WriteStatus;
 import org.sopt.usercalendar.facade.UserCalendarFacade;
 import org.sopt.userprofile.domain.UserProfile;
+import org.sopt.userprofile.exception.InvalidSameNicknameException;
+import org.sopt.userprofile.exception.UserProfileCoreErrorCode;
 import org.sopt.userprofile.repository.UserProfileRepository;
 import org.springframework.cglib.core.Local;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -25,6 +27,7 @@ public class UserProfileUpdater {
     private final UserCalendarFacade userCalendarFacade;
     private final UserProfileRepository userProfileRepository;
     private final UserProfileRetriever userProfileRetriever;
+
     /**
      * 일기 작성 시 totalDiaries 증가 및 streak 재계산
      */
@@ -34,6 +37,19 @@ public class UserProfileUpdater {
         updateStreakOnWrite(profile, writtenDate, userZone); // 캘린더 상태 기준으로 streak 반영
         resyncTotal(profile);                     // WRITTEN 개수로 동기화
         userProfileRepository.save(profile);
+    }
+
+    public String updateNickname(Long userId, String nickname) {
+        UserProfile profile = userProfileRetriever.findByUserId(userId);
+
+        if (nickname.equals(profile.getNickname())) {
+            throw new InvalidSameNicknameException(UserProfileCoreErrorCode.INVALID_SAME_NICKNAME);
+        }
+
+        profile.updateNickname(nickname);
+        userProfileRepository.save(profile);
+
+        return profile.getNickname();
     }
 
     /**


### PR DESCRIPTION
## Related issue 🛠
- closed #382 

## Work Description ✏️
- 닉네임 변경 API 구현

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 닉네임 변경 API | <img width="908" height="920" alt="image" src="https://github.com/user-attachments/assets/9726582a-0f2e-4c57-8177-9dfeeb29e1a4" /> |
| 동일한 닉네임으로 변경 시도하는 경우 | <img width="868" height="827" alt="image" src="https://github.com/user-attachments/assets/e15511c7-574d-4371-9f89-21c5ede33046" /> |


## Uncompleted Tasks 😅
- [ ] 이전에 쌓인 2가지 타입의 피드 알림 속 닉네임도 변경

## To Reviewers 📢
N/A