### PR TITLE
[chore] #387 Discord에 연동된 회원가입 알림을 Slack 연동으로 변경

### DIFF
--- a/hilingual-api/src/main/java/org/sopt/controller/auth/api/AuthController.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/auth/api/AuthController.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.controller.auth.dto.SocialLoginReq;
 import org.sopt.controller.auth.dto.SocialLoginRes;
 import org.sopt.controller.auth.service.AuthService;
-import org.sopt.controller.discord.service.WebhookService;
+import org.sopt.controller.slack.service.WebhookService;
 import org.sopt.jwt.annotation.UserId;
 import org.sopt.jwt.core.JwtTokenProvider;
 import org.springframework.http.ResponseEntity;
@@ -19,7 +19,6 @@ public class AuthController {
 
     private final AuthService authService;
     private final JwtTokenProvider jwtTokenProvider;
-    private final WebhookService webhookService;
 
     /*
      * 소셜 로그인(구글, 애플)

--- a/hilingual-api/src/main/java/org/sopt/controller/slack/service/WebhookService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/slack/service/WebhookService.java
@@ -1,8 +1,6 @@
-package org.sopt.controller.discord.service;
+package org.sopt.controller.slack.service;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.user.domain.User;
-import org.sopt.user.facade.UserFacade;
 import org.sopt.userprofile.domain.UserProfile;
 import org.sopt.userprofile.facade.UserProfileFacade;
 import org.springframework.beans.factory.annotation.Value;
@@ -21,8 +19,8 @@ import java.util.Map;
 @Transactional
 public class WebhookService {
 
-    @Value("${discord.webhook.url}")
-    private String discordWebhookUrl;
+    @Value("${slack.webhook.url}")
+    private String slackWebhookUrl;
 
     private final UserProfileFacade userProfileFacade;
 
@@ -30,19 +28,19 @@ public class WebhookService {
         final long totalMembers = userProfileFacade.count();
 
         String message = "✏️하이링구얼 신규 회원✏️\n🔸닉네임 : " + userProfile.getNickname() + "\n🔸현재 가입 유저 수 : " + totalMembers + "명\n🔸플랫폼 : " + userProfile.getUser().getProvider();
-        sendDiscordWebhook(message);
+        sendSlackWebhook(message);
     }
 
-    private void sendDiscordWebhook(String message) {
+    private void sendSlackWebhook(String message) {
         RestTemplate restTemplate = new RestTemplate();
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
 
         Map<String, String> body = new HashMap<>();
-        body.put("content", message);
+        body.put("text", message);
 
         HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(body, headers);
-        restTemplate.postForEntity(discordWebhookUrl, requestEntity, String.class);
+        restTemplate.postForEntity(slackWebhookUrl, requestEntity, String.class);
     }
 }

--- a/hilingual-api/src/main/java/org/sopt/controller/userprofile/service/UserProfileService.java
+++ b/hilingual-api/src/main/java/org/sopt/controller/userprofile/service/UserProfileService.java
@@ -1,13 +1,12 @@
 package org.sopt.controller.userprofile.service;
 
-import com.fasterxml.jackson.databind.ser.Serializers;
 import lombok.RequiredArgsConstructor;
 import org.sopt.alarmpreference.domain.AlarmPreference;
 import org.sopt.alarmpreference.facade.AlarmPreferenceFacade;
 import org.sopt.alarmpreference.type.AlarmType;
 import org.sopt.aws.s3.dto.Purpose;
 import org.sopt.aws.s3.service.S3Service;
-import org.sopt.controller.discord.service.WebhookService;
+import org.sopt.controller.slack.service.WebhookService;
 import org.sopt.controller.userprofile.dto.UserNicknameReq;
 import org.sopt.controller.userprofile.dto.UserNicknameRes;
 import org.sopt.controller.userprofile.dto.UserProfileImgReq;
@@ -18,7 +17,6 @@ import org.sopt.controller.userprofile.exception.UserProfileApiErrorCode;
 import org.sopt.controller.userprofile.exception.UserProfileImagePurposeMismatchException;
 import org.sopt.dto.BaseResponseDto;
 import org.sopt.exception.code.GlobalSuccessCode;
-import org.sopt.exception.code.SuccessCode;
 import org.sopt.forbiddenword.facade.ForbiddenWordFacade;
 import org.sopt.user.facade.UserFacade;
 import org.sopt.user.domain.User;

--- a/hilingual-api/src/main/resources/application.yml
+++ b/hilingual-api/src/main/resources/application.yml
@@ -129,6 +129,6 @@ spring:
 
 ---
 
-discord:
+slack:
   webhook:
     url: ${NEW_USER_WEBHOOK}


### PR DESCRIPTION
## Related issue 🛠
- closed #387 

## Work Description ✏️
- Discord에 연동된 회원가입 알림을 Slack 연동으로 변경
- Discord 코드 삭

## Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| Slack 연결 | <img width="1072" height="1212" alt="image" src="https://github.com/user-attachments/assets/65dda81c-cee6-4e44-8512-7db1bf075ff5" /> |

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
N/A